### PR TITLE
feat(agents): support markdown agent definitions in ~/.kiro/agents

### DIFF
--- a/src/kiro_crew/docs/agents.md
+++ b/src/kiro_crew/docs/agents.md
@@ -58,6 +58,42 @@ Custom agents are JSON files in `~/.kiro/agents/`. They define their own system 
 }
 ```
 
+### Markdown definitions
+
+A custom agent can also be written as a single markdown file in the same
+directory: YAML frontmatter for the fields, and the markdown body as the system
+prompt. This is the shape the wider ecosystem (Kiro IDE, kiro-agent) uses, so an
+existing agent file can be dropped in as-is instead of hand-translated to JSON.
+
+```markdown
+---
+name: code-reviewer
+description: Reviews code changes
+model: claude-opus
+tools: [fs_read, grep, glob, "@kirocrew-core"]
+allowedTools: [fs_read, grep, glob]
+---
+You are a meticulous code reviewer. Focus on correctness, security, and
+maintainability.
+```
+
+kiro-cli itself reads only JSON, so Kiro Crew compiles each `<name>.md` into a
+`<name>.json` beside it at startup and keeps the two in step — the markdown file
+stays the source you edit. Points worth knowing:
+
+- The output filename follows the **declared** `name`, so `reviewer.md` declaring
+  `name: code-reviewer` compiles to `code-reviewer.json`.
+- The body is the prompt, so frontmatter may not also declare `prompt`.
+- A frontmatter key kiro-cli does not accept is dropped with a warning rather
+  than failing the whole file, because kiro-cli rejects a spec wholesale on an
+  unknown key.
+- Kiro Crew never overwrites a JSON spec it did not generate. If a
+  hand-written `code-reviewer.json` already exists, the markdown file is refused
+  and the reason is logged; the same applies once you edit a generated file, so
+  your edit is preserved rather than reverted.
+- Deleting the markdown file removes the JSON it generated. Compilation covers
+  `~/.kiro/agents/` only, not a project's `.kiro/agents/`.
+
 ## Managing Agents
 
 **Agent Capabilities → Agents** shows your agents; select one and open its **Template** pane to see its definition — model, system prompt, skills, tools, and MCP servers. Drop a new JSON file into `~/.kiro/agents/` and it appears automatically. `/agents` redirects to Agent Capabilities.

--- a/src/kiro_crew/md_agent_specs.py
+++ b/src/kiro_crew/md_agent_specs.py
@@ -1,0 +1,656 @@
+"""Compile markdown agent definitions into the JSON specs kiro-cli loads.
+
+WHY A COMPILER AND NOT A SECOND READER
+======================================
+The wider ecosystem writes an agent as ONE markdown file: YAML frontmatter for
+the config fields, the markdown body as the system prompt. kiro-agent (the v3
+engine) loads that shape natively. **kiro-cli does not** -- it globs
+``*.json`` and parses whatever it is handed as JSON regardless of extension, so
+a ``.md`` spec is not discoverable by it and cannot be activated by
+``--agent <name>``.
+
+Kiro Crew does not load the spec either: it hands kiro-cli a bare NAME and
+kiro-cli resolves the file itself. So teaching Crew's own discovery to read
+markdown would produce an agent that lists in the dashboard and then fails at
+``session/set_mode`` -- the exact "visible but not dispatchable" inversion that
+``agent_discovery.project_agent_files``' ``include_legacy=False`` default exists
+to prevent. Worse, Crew reads the agents directory from ~45 places, and three of
+them are not cosmetic: the MCP gateway rewriter (``mcp_gateway/rewriter.py``)
+would never rewrite a markdown spec's ``mcpServers`` into broker stubs, so its
+MCP servers would spawn DIRECT and bypass the tool gate entirely;
+``agent_discovery._dir_signature`` fingerprints only ``*.json``, so roster caches
+would not invalidate on a markdown edit; and ``connections/ownership`` would read
+a markdown sharer as absent and tear down a live connection.
+
+This module therefore treats markdown as a SOURCE FORMAT and compiles it to the
+one on-disk shape every existing consumer already understands. kiro-cli can then
+resolve it, the rewriter stubs its MCP servers, the roster lists it, the model
+resolvers see it, and doctor checks it -- with no change to any of them.
+
+TRUST BOUNDARY
+==============
+The agents DIRECTORY is the trust boundary, not the file extension. A ``.json``
+dropped in ``~/.kiro/agents`` may already declare ``mcpServers``, ``allowedTools``
+and lifecycle ``hooks`` -- shell commands the backend runs with no permission
+request. ``security/paths.py`` write-protects the whole directory against the
+agent's own file tools for exactly that reason. A ``.md`` in the same directory is
+neither more nor less trusted, so this compiler passes those fields through
+rather than inventing a second, weaker policy for the same directory. What it
+does NOT do is widen the boundary: it reads only from the user-level agents
+directory, and it writes only there.
+
+WHY THE FRONTMATTER IS PARSED AS REAL YAML
+==========================================
+``kiro_crew.frontmatter`` is deliberately NOT reused. That module's contract is a
+flat ``dict[str, str]`` -- it cannot express ``tools: [fs_read, grep]`` or a
+nested ``mcpServers`` mapping, which is most of an agent spec -- and its
+``split_frontmatter`` body is documented as "not a document body" for the column-0
+extractions (it cuts immediately after the closer token, possibly mid-line),
+while here the body IS the prompt. Its plain-scalar grammar also deliberately
+accepts text a YAML parser rejects, which is right for SKILL.md and wrong here:
+this format's grammar is defined by the ecosystem that already writes it, and
+that grammar is YAML. So the fence is located here, the block goes through
+``yaml.safe_load`` (never ``yaml.load`` -- the directory is user-writable and
+shared with other tools, so arbitrary object construction is not on the table),
+and the closer is strict: a ``---junk`` line is not a closer, and a document
+whose fence does not close is refused rather than compiled with its frontmatter
+leaking into the prompt.
+
+OWNERSHIP, AND WHY IT LIVES OUTSIDE THE SPEC
+============================================
+The compiler must clean up its own output: a renamed or deleted ``.md`` leaves a
+stale ``<name>.json`` behind, and a stale spec is an agent the user can still
+select. So cleanup has to answer "did I write this file?" -- and kiro-cli
+validates specs with ``deny_unknown_fields``, so an ownership marker cannot live
+inside the spec (an extra key makes kiro-cli reject the whole file and the user
+loses the agent). ``connections/alias_record`` hit this same wall and solved it
+with an out-of-spec, generation-bound record; this module follows that design.
+
+Shape cannot decide history, and re-derivation is not evidence: "the JSON I would
+have written" is no proof that I DID write it, and claiming a hand-written
+``code-reviewer.json`` because a ``code-reviewer.md`` now exists would delete a
+user's file. The record is the only ownership oracle, and absence proves only
+"not provably mine" -- which is the safe reading, since an unrecorded spec is
+treated as the user's and survives untouched.
+
+Two files means two writes, and no ORDERING of two writes is safe in both
+directions, so each entry is written as a two-phase transaction carrying the
+digest of the generation it describes::
+
+    PENDING(previous=<digest on disk>, target=<digest about to be written>)
+      -> spec write
+    -> COMMITTED(<digest written>)
+
+An entry authorizes overwriting or deleting ``<name>.json`` only when the file's
+CURRENT digest matches one of the digests that entry names. Every crash boundary
+is safe in both directions:
+
+===  ================================  ==============  ==========================================
+ #   interrupted at                    record          ``<name>.json`` resolves to
+===  ================================  ==============  ==========================================
+ 0   before the pending write          unchanged       previous generation -- pass retries cleanly
+ 1   pending write FAILS               unchanged       unchanged; the spec MUST NOT advance
+ 2   kill after the pending write      PENDING         previous digest matches -> ours
+ 3   spec write FAILS                  PENDING         previous digest matches -> ours
+ 4   kill after the spec write         PENDING         target digest matches -> ours
+ 5   commit write FAILS                PENDING         target digest matches -> ours
+ 6   nothing (success)                 COMMITTED       committed digest matches -> ours
+ 7   record absent / unusable / vN     --              nothing -- never ours, file survives
+ 8   spec hand-edited                  either          neither digest matches -> the user's
+===  ================================  ==============  ==========================================
+
+Row 4/5 is why the pending entry names BOTH digests: without the target digest an
+interrupted write would leave a file matching nothing, and the source would never
+compile again without manual cleanup. Row 8 is the case that protects a user who
+edited the generated JSON: the compiler refuses, says so, and leaves the edit
+alone rather than reverting it on the next pass.
+
+CONCURRENCY
+===========
+The whole pass runs under ``agent.agents_spec_lock`` -- the same cross-process
+advisory lock the dashboard's fork/publish endpoints and the agent-detail PATCH
+take. A read-modify-writer in this directory that skips it can silently revert
+another writer's spec.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from kiro_crew.agent_files import OWNED_KIRO_AGENT_FILES
+from kiro_crew.config.paths import data_home, kiro_agents_dir
+from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes
+from kiro_crew.security.paths import is_sensitive_path
+from kiro_crew.validation import _AGENT_NAME_RE
+
+logger = logging.getLogger(__name__)
+
+#: Source extension. Lowercase-only on purpose: ``glob`` is case-sensitive on
+#: POSIX and not on macOS/Windows, so accepting ``.MD`` would make the compiled
+#: set platform-dependent for the same directory.
+MD_SUFFIX = ".md"
+
+#: Record schema. Bumped when an entry's meaning changes for identical inputs;
+#: an unrecognised version is treated as row 7 (no ownership), never migrated
+#: in place, because a wrong migration authorizes deleting a user's file.
+RECORD_SCHEMA = 1
+
+_STATE_PENDING = "pending"
+_STATE_COMMITTED = "committed"
+
+# The frontmatter fence. Stricter than ``kiro_crew.frontmatter``'s column-0
+# grammar in two ways that matter for THIS format:
+#   * the closer must be a line of its own (trailing whitespace only), because a
+#     ``---junk`` line treated as a closer would silently move frontmatter into
+#     the prompt;
+#   * the match consumes the closer's line ending, so group 2 is the body a
+#     prompt can be built from rather than an arbitrary unconsumed remainder.
+# The inner group is optional so an empty block (``---\n---``) is a match with no
+# fields rather than "no fence at all".
+_FENCE_RE = re.compile(
+    r"\A---[ \t]*\r?\n(?:(.*?)\r?\n)?---[ \t]*(?:\r?\n|\Z)",
+    re.DOTALL,
+)
+
+#: Frontmatter keys carried into the compiled spec. An ALLOWLIST, because
+#: kiro-cli rejects a spec wholesale on an unknown key -- so passing an
+#: unrecognised frontmatter key through would not produce a partially-working
+#: agent, it would produce no agent at all, with the failure surfacing far from
+#: this file. An unknown key is dropped with a warning instead, which is also
+#: what kiro-agent's own schemas do (Zod strips them).
+#:
+#: ``allowedTools`` and ``toolsSettings`` are kiro-cli-only fields that
+#: kiro-agent silently strips, so the same document grants different authority on
+#: the two engines. They are carried here because this compiler's output is FOR
+#: kiro-cli; the divergence is the ecosystem's, not ours, and dropping them would
+#: silently downgrade a ported file's declared permissions.
+CARRIED_KEYS = frozenset(
+    {
+        "description",
+        "model",
+        "tools",
+        "allowedTools",
+        "toolsSettings",
+        "mcpServers",
+        "resources",
+        "hooks",
+        "includeMcpJson",
+        "useLegacyMcpJson",
+    }
+)
+
+#: Refused in frontmatter. ``name`` is handled separately (it decides the output
+#: filename). ``prompt`` is refused rather than ignored: in this format the BODY
+#: is the prompt, so a document declaring both is ambiguous, and silently picking
+#: one would leave the author with an agent running a prompt they did not choose.
+_REFUSED_KEYS = frozenset({"prompt"})
+
+
+class MdAgentSpecError(RuntimeError):
+    """A markdown agent definition could not be compiled.
+
+    Carries a stable ``code`` so callers and tests can distinguish "the author
+    must fix the document" from "another file owns this name".
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class CompiledSpec:
+    """One compiled definition: the agent name, its spec, and the exact bytes."""
+
+    name: str
+    spec: dict[str, Any]
+    payload: bytes
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.payload).hexdigest()
+
+
+@dataclass
+class CompileOutcome:
+    """What one pass did, for logging and for the dashboard's own diagnostics."""
+
+    written: list[str] = field(default_factory=list)
+    unchanged: list[str] = field(default_factory=list)
+    pruned: list[str] = field(default_factory=list)
+    refused: list[tuple[str, str, str]] = field(default_factory=list)
+
+    def refuse(self, source: str, code: str, message: str) -> None:
+        self.refused.append((source, code, message))
+
+
+def _spec_payload(spec: dict[str, Any]) -> bytes:
+    """Serialize *spec* to the EXACT bytes ``agent._atomic_json_write`` writes.
+
+    Ownership is decided by comparing a file's digest to a recorded one, so this
+    serialization and that writer's must not drift: ``json.dump(data, f,
+    indent=2)`` followed by a trailing newline. If they diverge, every compiled
+    spec reads as hand-edited on the next pass and the compiler stops touching
+    its own output -- a silent, total failure of the feature rather than a loud
+    one, which is why this lives in one function next to a test that pins it.
+    """
+    return (json.dumps(spec, indent=2) + "\n").encode("utf-8")
+
+
+def _decode(raw: bytes) -> str:
+    """Decode a markdown source to text, or raise ``MdAgentSpecError``.
+
+    Strips a UTF-8 BOM and folds CRLF/CR to LF. Both are load-bearing rather
+    than tidiness: the fence is anchored at position 0, so a BOM leaves
+    ``\\ufeff---`` and the whole block reads as absent -- the document compiles
+    to an agent with no config and its frontmatter as prose. A file exported from
+    a Windows editor is the ordinary way to get one, and this format exists to
+    accept files authored elsewhere.
+    """
+    try:
+        text = raw.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise MdAgentSpecError("not_utf8", "the file is not valid UTF-8") from exc
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def derive_spec(text: str, *, fallback_name: str) -> CompiledSpec:
+    """Compile one markdown definition into a kiro-cli spec. Pure: no I/O.
+
+    *fallback_name* is used when the frontmatter declares no ``name`` -- by
+    convention the source file's stem, mirroring how kiro-cli falls back to a
+    spec's filename.
+
+    Raises ``MdAgentSpecError`` on anything that would produce an agent the
+    author did not ask for: no closing fence, frontmatter that is not a mapping,
+    a declared ``prompt`` competing with the body, or a name that cannot identify
+    a spec. Refusal is the right outcome for all of them -- an unrunnable
+    document is recoverable, an agent quietly running the wrong prompt or the
+    wrong permissions is not.
+    """
+    match = _FENCE_RE.match(text)
+    if match is None:
+        raise MdAgentSpecError(
+            "no_frontmatter",
+            "no YAML frontmatter block: expected '---' on the first line and a "
+            "closing '---' on a line of its own",
+        )
+    block = match.group(1) or ""
+    body = text[match.end() :]
+
+    try:
+        loaded = yaml.safe_load(block) if block.strip() else {}
+    except yaml.YAMLError as exc:
+        # yaml.YAMLError is NOT a ValueError, so it would escape a caller
+        # catching ValueError. Translated here so this function's contract is
+        # "MdAgentSpecError or success" and no caller has to know it parses YAML.
+        raise MdAgentSpecError("bad_yaml", f"the frontmatter is not valid YAML: {exc}") from exc
+    if loaded is None:
+        loaded = {}
+    if not isinstance(loaded, dict):
+        raise MdAgentSpecError(
+            "frontmatter_not_mapping",
+            f"the frontmatter must be a mapping of fields, not {type(loaded).__name__}",
+        )
+
+    refused = sorted(k for k in _REFUSED_KEYS if k in loaded)
+    if refused:
+        raise MdAgentSpecError(
+            "reserved_key",
+            f"frontmatter may not declare {refused[0]!r}: in this format the "
+            "markdown body is the prompt",
+        )
+
+    declared = loaded.get("name", fallback_name)
+    if not isinstance(declared, str) or not _AGENT_NAME_RE.match(declared):
+        raise MdAgentSpecError(
+            "unsafe_name",
+            f"{declared!r} is not a usable agent name (letters, digits, '_' and "
+            "'-'; must start and end alphanumeric)",
+        )
+    if f"{declared.lower()}.json" in OWNED_KIRO_AGENT_FILES:
+        raise MdAgentSpecError(
+            "reserved_name",
+            f"{declared!r} is a Kiro Crew-managed agent name and cannot be " "defined in markdown",
+        )
+
+    spec: dict[str, Any] = {"name": declared}
+    for key in sorted(k for k in loaded if k in CARRIED_KEYS):
+        value = loaded[key]
+        if value is not None:
+            spec[key] = value
+    unknown = sorted(set(loaded) - CARRIED_KEYS - {"name"})
+    if unknown:
+        # Dropped, not refused: an unrecognised key is usually a field another
+        # engine understands (kiro-agent has several kiro-cli does not), and
+        # refusing the whole document for it would make a ported file unusable
+        # for a field that changes nothing here.
+        logger.warning(
+            "markdown agent %r: dropping frontmatter key(s) kiro-cli does not " "accept: %s",
+            declared,
+            ", ".join(unknown),
+        )
+
+    prompt = body.strip()
+    if prompt:
+        spec["prompt"] = prompt
+
+    return CompiledSpec(name=declared, spec=spec, payload=_spec_payload(spec))
+
+
+def _record_path() -> Path:
+    """Where the ownership record lives: OUTSIDE the agents directory.
+
+    Deliberately not a dotfile beside the specs. ``pathlib.glob("*.json")``
+    matches dotfiles, several sweeps in this repo enumerate that directory, and
+    the rewriter's own prune pass learned this the hard way (its fingerprint file
+    carries no ``.json`` suffix precisely so a prune cannot eat it). Keeping the
+    record under the data home means no agents-directory consumer can see it at
+    all.
+    """
+    return data_home() / "md-agents" / "compiled.json"
+
+
+def _load_record() -> dict[str, dict[str, Any]]:
+    """Read the ownership record; ``{}`` for anything that is not a usable one.
+
+    Absent, unreadable, malformed, or written by a schema this version does not
+    recognise all collapse to "no ownership claimed" (row 7). That degrades to
+    leaving files alone, which is the safe direction: the cost is a stale spec
+    the user removes by hand, and the alternative is authorizing a delete from a
+    record we cannot read.
+    """
+    path = _record_path()
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return {}
+    try:
+        doc = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        logger.warning("markdown agent record at %s is unreadable; claiming nothing", path)
+        return {}
+    if not isinstance(doc, dict) or doc.get("schema") != RECORD_SCHEMA:
+        return {}
+    entries = doc.get("entries")
+    if not isinstance(entries, dict):
+        return {}
+    return {k: v for k, v in entries.items() if isinstance(k, str) and isinstance(v, dict)}
+
+
+def _store_record(entries: dict[str, dict[str, Any]]) -> None:
+    """Write the record atomically. Raises on failure -- the caller must stop.
+
+    A pending entry that fails to land must abort the spec write it was meant to
+    describe (row 1): advancing the spec anyway is what leaves a generation no
+    record can recognise.
+    """
+    path = _record_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({"schema": RECORD_SCHEMA, "entries": entries}, indent=2) + "\n"
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _owned(entry: dict[str, Any] | None, digest: str | None) -> bool:
+    """Does *entry* authorize writing over a file whose current digest is *digest*?
+
+    A committed entry names one generation; a pending one names two (the
+    generation it was replacing and the one it was writing), because an
+    interrupted transaction may have left either on disk.
+
+    ``None`` means the file EXISTS but could not be read (oversized, sensitive
+    resolved target, permission), and that is never owned. Absence is not
+    expressed here at all -- callers decide that from ``exists`` before asking --
+    because conflating "no bytes to compare" with "nothing is there" would
+    authorize overwriting, and pruning, a file this compiler could not inspect.
+    """
+    if digest is None:
+        return False
+    if not entry:
+        return False
+    if entry.get("state") == _STATE_COMMITTED:
+        return digest == entry.get("output_sha256")
+    if entry.get("state") == _STATE_PENDING:
+        return digest in (entry.get("target_sha256"), entry.get("previous_sha256"))
+    return False
+
+
+def _read_existing(path: Path) -> tuple[bool, str | None]:
+    """Return ``(exists, digest)`` for a compiled spec already on disk.
+
+    Reads through the same hardened gate ``agent_discovery._read_agent_spec``
+    uses -- resolved-symlink sensitivity check, size cap -- because this
+    directory is user-writable and shared: a ``foo.json`` symlinked at
+    ``~/.aws/credentials`` must not be read here just because a ``foo.md``
+    appeared next to it.
+
+    A file that exists but cannot be read returns ``(True, None)``, which no
+    entry can own, so the compiler refuses rather than overwriting bytes it could
+    not inspect.
+    """
+    try:
+        real = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return (path.exists() or path.is_symlink(), None)
+    if is_sensitive_path(str(real)):
+        logger.warning("refusing to inspect a sensitive compiled-spec target: %s", path)
+        return (True, None)
+    try:
+        raw = safe_read_file_bytes(str(real))
+    except FileTooLargeError:
+        return (True, None)
+    if raw is None:
+        return (True, None)
+    return (True, hashlib.sha256(raw).hexdigest())
+
+
+def _sources(agents_dir: Path) -> list[Path]:
+    """Markdown definitions in *agents_dir*, AppleDouble sidecars excluded."""
+    if not agents_dir.is_dir():
+        return []
+    return sorted(p for p in agents_dir.glob(f"*{MD_SUFFIX}") if not p.name.startswith("._"))
+
+
+def compile_markdown_agents(agents_dir: Path | None = None) -> CompileOutcome:
+    """Compile every ``*.md`` in the user-level agents directory to a JSON spec.
+
+    Idempotent: a source whose compiled output already matches byte-for-byte is
+    left alone, so repeated passes do not churn mtimes (which would invalidate
+    every roster cache keyed on this directory's signature).
+
+    Never raises for a bad document -- a single unparseable definition must not
+    stop the others from compiling, and must not fail gateway startup. Per-source
+    refusals are collected in the returned outcome and logged. An unwritable
+    record IS fatal to the pass, because continuing would write specs no record
+    describes.
+    """
+    from kiro_crew.agent import _atomic_json_write, agents_spec_lock
+
+    target_dir = agents_dir or kiro_agents_dir()
+    outcome = CompileOutcome()
+    sources = _sources(target_dir)
+    entries = _load_record()
+    if not sources and not entries:
+        return outcome
+    if not target_dir.is_dir():
+        # No directory means no sources and no outputs, but the record may still
+        # claim specs from before it was removed. Retire those claims without
+        # taking the spec lock -- its sidecar lockfile lives in the directory that
+        # is not there, so acquiring it would fail and strand the record instead.
+        for name in [n for n in entries if not (target_dir / f"{n}.json").exists()]:
+            del entries[name]
+        try:
+            _store_record(entries)
+        except OSError:
+            logger.exception("markdown agent record write failed for a missing agents dir")
+        return outcome
+
+    with agents_spec_lock(target_dir):
+        seen: dict[str, str] = {}
+        for source in sources:
+            try:
+                raw = source.read_bytes()
+            except OSError as exc:
+                outcome.refuse(source.name, "unreadable", str(exc))
+                continue
+            try:
+                compiled = derive_spec(_decode(raw), fallback_name=source.stem)
+            except MdAgentSpecError as exc:
+                outcome.refuse(source.name, exc.code, str(exc))
+                logger.warning("markdown agent %s: %s", source.name, exc)
+                continue
+
+            if compiled.name in seen:
+                # Two documents claiming one name would race for one output file,
+                # and which won would depend on directory order. Refuse the
+                # second and name the first, rather than compile whichever sorted
+                # later.
+                outcome.refuse(
+                    source.name,
+                    "duplicate_name",
+                    f"agent name {compiled.name!r} is already declared by {seen[compiled.name]}",
+                )
+                continue
+            seen[compiled.name] = source.name
+
+            target = target_dir / f"{compiled.name}.json"
+            exists, current = _read_existing(target)
+            entry = entries.get(compiled.name)
+            if exists and not _owned(entry, current):
+                if current is None:
+                    code = "unreadable_output"
+                elif entry:
+                    code = "derived_modified"
+                else:
+                    code = "name_taken"
+                outcome.refuse(
+                    source.name,
+                    code,
+                    f"{target.name} was not written by this compiler (or has been "
+                    f"edited since); leaving it untouched",
+                )
+                logger.warning(
+                    "markdown agent %s: refusing to overwrite %s (%s)",
+                    source.name,
+                    target.name,
+                    code,
+                )
+                continue
+            if exists and current == compiled.digest:
+                outcome.unchanged.append(compiled.name)
+                entries[compiled.name] = {
+                    "source": source.name,
+                    "state": _STATE_COMMITTED,
+                    "output_sha256": compiled.digest,
+                }
+                continue
+
+            entries[compiled.name] = {
+                "source": source.name,
+                "state": _STATE_PENDING,
+                "previous_sha256": current,
+                "target_sha256": compiled.digest,
+            }
+            try:
+                _store_record(entries)
+            except OSError:
+                logger.exception("markdown agent record write failed; not advancing any spec")
+                return outcome
+            try:
+                _atomic_json_write(target, compiled.spec)
+            except OSError as exc:
+                outcome.refuse(source.name, "write_failed", str(exc))
+                logger.warning("markdown agent %s: spec write failed: %s", source.name, exc)
+                continue
+            entries[compiled.name] = {
+                "source": source.name,
+                "state": _STATE_COMMITTED,
+                "output_sha256": compiled.digest,
+            }
+            try:
+                _store_record(entries)
+            except OSError:
+                # Row 5: the spec is durable and the pending entry still names its
+                # digest, so the next pass recognises it. Nothing is stranded.
+                logger.exception("markdown agent record commit failed for %s", compiled.name)
+            outcome.written.append(compiled.name)
+
+        _prune(target_dir, entries, seen, outcome)
+    return outcome
+
+
+def _prune(
+    agents_dir: Path,
+    entries: dict[str, dict[str, Any]],
+    live: dict[str, str],
+    outcome: CompileOutcome,
+) -> None:
+    """Remove compiled specs whose markdown source is gone.
+
+    Only ever unlinks a file the record still owns. A spec the user has since
+    edited is left on disk and merely stops being claimed -- deleting it would
+    destroy an edit, and continuing to claim it would authorize that delete on
+    some later pass.
+    """
+    stale = [name for name in entries if name not in live]
+    if not stale:
+        return
+    for name in stale:
+        entry = entries[name]
+        target = agents_dir / f"{name}.json"
+        exists, current = _read_existing(target)
+        if not exists:
+            del entries[name]
+            continue
+        if current is None:
+            # Existing but unreadable: a TRANSIENT condition (oversized, a
+            # permission blip, a symlink that currently resolves somewhere
+            # refused), not evidence the user took the file over. Keep the claim
+            # so a later pass can still prune it -- dropping it here would
+            # abandon our own output permanently the first time one read failed.
+            logger.warning(
+                "markdown agent %s: source is gone but %s could not be read; "
+                "keeping the claim and retrying next pass",
+                name,
+                target.name,
+            )
+            continue
+        if not _owned(entry, current):
+            logger.warning(
+                "markdown agent %s: source is gone but %s has been edited; leaving it in place",
+                name,
+                target.name,
+            )
+            del entries[name]
+            continue
+        try:
+            target.unlink()
+        except OSError as exc:
+            outcome.refuse(f"{name}{MD_SUFFIX}", "prune_failed", str(exc))
+            continue
+        del entries[name]
+        outcome.pruned.append(name)
+    try:
+        _store_record(entries)
+    except OSError:
+        logger.exception("markdown agent record write failed after prune")

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -216,6 +216,7 @@ from kiro_crew.mcp_gateway.rewriter import (
     rewrite_agents,
 )
 from kiro_crew.mcp_hot_reload import parse_kiro_cli_version
+from kiro_crew.md_agent_specs import compile_markdown_agents
 from kiro_crew.memory import MemoryStore
 from kiro_crew.messaging import APPROVAL_INTERACTIVE, TurnDriver, inbound_spool, registry
 from kiro_crew.messaging.dispatch import build_directive_consumer, build_tool_gate
@@ -9536,6 +9537,42 @@ class GatewayOrchestrator:
     # MCP Gateway
     # ------------------------------------------------------------------
 
+    async def _compile_markdown_agents(self) -> None:
+        """Compile ``~/.kiro/agents/*.md`` into the JSON specs kiro-cli loads.
+
+        kiro-cli globs ``*.json`` and parses whatever it is handed as JSON, so a
+        markdown definition is invisible to it; Crew hands it a bare NAME and
+        kiro-cli resolves the file itself. Compiling to JSON is therefore what
+        makes a markdown agent runnable at all, and it also lets every existing
+        consumer -- the roster, the model resolvers, doctor, and above all the MCP
+        gateway rewriter -- keep working unchanged.
+
+        Fail-open and offloaded. The pass globs a directory, parses each document
+        and writes files, which is blocking filesystem work that must not run on
+        the event loop during boot; and a malformed definition is the author's
+        problem, never a reason for the gateway not to start. Skipped in
+        ``test_mode`` for the same reason the agents-dir janitor is: the offline
+        E2E gate must not write into a developer's real agents directory.
+        """
+        if self._test_mode:
+            return
+        try:
+            outcome = await asyncio.to_thread(compile_markdown_agents)
+        except Exception:
+            logger.warning("markdown agent compilation failed at boot", exc_info=True)
+            return
+        if outcome.written or outcome.pruned:
+            logger.info(
+                "markdown agents: %d compiled, %d removed",
+                len(outcome.written),
+                len(outcome.pruned),
+            )
+        for source, code, message in outcome.refused:
+            # WARNING, not debug: the author's agent is silently absent from
+            # every picker until they fix the document, so the reason has to be
+            # visible without turning on debug logging.
+            logger.warning("markdown agent %s refused (%s): %s", source, code, message)
+
     async def _init_mcp_gateway(self, stub_servers: frozenset[str] | None = None) -> None:
         """Start the MCP gateway sidecar and populate the agent-JSON overlay.
 
@@ -11559,6 +11596,14 @@ class GatewayOrchestrator:
         await self._start_embeddings()
 
         # Auto-migration starts only after deferred restore and memory init.
+
+        # Compile markdown agent definitions (``~/.kiro/agents/*.md``) into the
+        # JSON specs kiro-cli actually loads. Ordering is load-bearing and this
+        # step MUST stay ahead of the MCP gateway below: the rewriter is what
+        # turns a spec's ``mcpServers`` into broker stubs, so a spec compiled
+        # after it would have its MCP servers spawn DIRECT and bypass the tool
+        # gate for the rest of the process's life.
+        await self._compile_markdown_agents()
 
         # Start MCP gateway sidecar before any ACP session can spawn.  The
         # rewriter writes the agent-JSON overlay first so kiro-cli picks up

--- a/test/test_md_agent_specs.py
+++ b/test/test_md_agent_specs.py
@@ -1,0 +1,428 @@
+"""Tests for ``kiro_crew.md_agent_specs`` -- markdown agent definitions.
+
+Two halves, and the second is the one that protects a user's files: the pure
+derivation (what a document compiles to, and what it refuses), and the ownership
+transaction (what the compiler is allowed to overwrite or delete). Every
+ownership test asserts on the FILE, not just the returned outcome -- the whole
+point of the record is that a refusal leaves bytes untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import md_agent_specs as mas
+
+FULL_DOC = """---
+name: code-reviewer
+description: Reviews code changes
+model: claude-opus
+tools: [fs_read, grep, glob, "@kirocrew-core"]
+allowedTools: [fs_read, grep]
+mcpServers:
+  fetch:
+    command: uvx
+    args: [mcp-server-fetch]
+---
+You are a meticulous code reviewer.
+
+Focus on correctness.
+"""
+
+
+@pytest.fixture
+def agents_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "agents"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _isolated_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the ownership record at a tmp data home, never the real one."""
+    monkeypatch.setattr(mas, "data_home", lambda: tmp_path / "data")
+
+
+def _write(agents_dir: Path, name: str, text: str) -> Path:
+    path = agents_dir / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ── derivation ────────────────────────────────────────────────────────────────
+
+
+def test_full_document_compiles_every_carried_field() -> None:
+    compiled = mas.derive_spec(FULL_DOC, fallback_name="ignored")
+    assert compiled.name == "code-reviewer"
+    assert compiled.spec["model"] == "claude-opus"
+    # Typed structures survive: a flat string-only frontmatter reader could not
+    # express either of these, which is why this format parses real YAML.
+    assert compiled.spec["tools"] == ["fs_read", "grep", "glob", "@kirocrew-core"]
+    assert compiled.spec["mcpServers"]["fetch"]["args"] == ["mcp-server-fetch"]
+    assert compiled.spec["prompt"] == (
+        "You are a meticulous code reviewer.\n\nFocus on correctness."
+    )
+
+
+def test_name_falls_back_to_the_file_stem() -> None:
+    compiled = mas.derive_spec("---\ndescription: d\n---\nbody\n", fallback_name="from-stem")
+    assert compiled.name == "from-stem"
+
+
+def test_unknown_frontmatter_key_is_dropped_not_refused() -> None:
+    # kiro-cli rejects a spec wholesale on an unknown key, so carrying one
+    # through would yield no agent at all. Dropping keeps a ported file usable.
+    compiled = mas.derive_spec("---\nname: a\nexcludedTools: [x]\n---\nb\n", fallback_name="a")
+    assert "excludedTools" not in compiled.spec
+    assert compiled.name == "a"
+
+
+def test_bom_and_crlf_document_compiles() -> None:
+    raw = "\ufeff---\r\nname: winagent\r\ndescription: d\r\n---\r\nBody here.\r\n".encode("utf-8")
+    compiled = mas.derive_spec(mas._decode(raw), fallback_name="x")
+    assert compiled.name == "winagent"
+    assert compiled.spec["prompt"] == "Body here."
+
+
+def test_empty_frontmatter_block_is_a_fence_not_a_miss() -> None:
+    compiled = mas.derive_spec("---\n---\nOnly a prompt.\n", fallback_name="stem")
+    assert compiled.name == "stem"
+    assert compiled.spec["prompt"] == "Only a prompt."
+
+
+def test_body_only_whitespace_emits_no_prompt_key() -> None:
+    compiled = mas.derive_spec("---\nname: a\n---\n\n  \n", fallback_name="a")
+    assert "prompt" not in compiled.spec
+
+
+@pytest.mark.parametrize(
+    ("code", "doc"),
+    [
+        ("no_frontmatter", "just prose\n"),
+        # A '---junk' line is NOT a closer: treating it as one would move the
+        # remaining frontmatter into the prompt silently.
+        ("no_frontmatter", "---\nname: a\n---junk\nbody\n"),
+        ("no_frontmatter", "---\nname: a\nnever closed\n"),
+        ("frontmatter_not_mapping", "---\n- a\n- b\n---\nbody\n"),
+        ("reserved_key", "---\nname: a\nprompt: hi\n---\nbody\n"),
+        ("unsafe_name", "---\nname: 'bad name!'\n---\nbody\n"),
+        ("unsafe_name", "---\nname: 42\n---\nbody\n"),
+        ("reserved_name", "---\nname: kirocrew\n---\nbody\n"),
+        ("bad_yaml", "---\nname: [unclosed\n---\nbody\n"),
+    ],
+)
+def test_refusals(code: str, doc: str) -> None:
+    with pytest.raises(mas.MdAgentSpecError) as excinfo:
+        mas.derive_spec(doc, fallback_name="fallback")
+    assert excinfo.value.code == code
+
+
+def test_payload_matches_the_atomic_writer_byte_for_byte() -> None:
+    """Ownership compares digests, so these two serializations must not drift.
+
+    If ``_spec_payload`` and ``agent._atomic_json_write`` ever disagree, every
+    compiled spec reads as hand-edited on the next pass and the compiler stops
+    touching its own output -- a silent total failure. This pins them together.
+    """
+    from kiro_crew.agent import _atomic_json_write
+
+    compiled = mas.derive_spec(FULL_DOC, fallback_name="x")
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "out.json"
+        _atomic_json_write(target, compiled.spec)
+        assert target.read_bytes() == compiled.payload
+
+
+# ── compile / ownership ───────────────────────────────────────────────────────
+
+
+def test_compile_writes_the_spec_and_is_idempotent(agents_dir: Path) -> None:
+    _write(agents_dir, "code-reviewer.md", FULL_DOC)
+
+    first = mas.compile_markdown_agents(agents_dir)
+    target = agents_dir / "code-reviewer.json"
+    assert first.written == ["code-reviewer"]
+    assert json.loads(target.read_text())["name"] == "code-reviewer"
+
+    stamp = target.stat().st_mtime_ns
+    second = mas.compile_markdown_agents(agents_dir)
+    assert second.written == []
+    assert second.unchanged == ["code-reviewer"]
+    # Not merely "same content": an unnecessary rewrite bumps the directory
+    # signature every roster cache is keyed on.
+    assert target.stat().st_mtime_ns == stamp
+
+
+def test_the_record_never_lands_in_the_agents_directory(agents_dir: Path) -> None:
+    _write(agents_dir, "a.md", "---\nname: a\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    # Several sweeps enumerate this directory and glob('*.json') matches
+    # dotfiles, so a record kept here would be prunable by another pass. The
+    # only extra file tolerated is agents_spec_lock's own sidecar, which this
+    # module does not create and every other spec writer also leaves behind.
+    produced = {p.name for p in agents_dir.iterdir() if not p.name.startswith(".")}
+    assert produced == {"a.md", "a.json"}
+    assert mas._record_path().is_file()
+    assert mas._record_path().parent != agents_dir
+
+
+def test_a_hand_written_spec_of_the_same_name_is_never_overwritten(agents_dir: Path) -> None:
+    mine = {"name": "code-reviewer", "description": "hand written"}
+    (agents_dir / "code-reviewer.json").write_text(json.dumps(mine), encoding="utf-8")
+    _write(agents_dir, "code-reviewer.md", FULL_DOC)
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert [c for _, c, _ in outcome.refused] == ["name_taken"]
+    assert outcome.written == []
+    assert json.loads((agents_dir / "code-reviewer.json").read_text()) == mine
+
+
+def test_an_edited_generated_spec_is_preserved_not_reverted(agents_dir: Path) -> None:
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: original\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    target = agents_dir / "a.json"
+
+    edited = {"name": "a", "description": "the user edited this"}
+    target.write_text(json.dumps(edited), encoding="utf-8")
+    # Change the source too, so the compiler genuinely wants to rewrite.
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: changed\n---\nbody\n")
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert [c for _, c, _ in outcome.refused] == ["derived_modified"]
+    assert json.loads(target.read_text()) == edited
+
+
+def test_a_removed_source_prunes_its_generated_spec(agents_dir: Path) -> None:
+    source = _write(agents_dir, "a.md", "---\nname: a\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    assert (agents_dir / "a.json").is_file()
+
+    source.unlink()
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert outcome.pruned == ["a"]
+    assert not (agents_dir / "a.json").exists()
+    assert mas._load_record() == {}
+
+
+def test_a_removed_source_does_not_delete_an_edited_spec(agents_dir: Path) -> None:
+    source = _write(agents_dir, "a.md", "---\nname: a\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    target = agents_dir / "a.json"
+
+    edited = {"name": "a", "description": "mine now"}
+    target.write_text(json.dumps(edited), encoding="utf-8")
+    source.unlink()
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert outcome.pruned == []
+    assert json.loads(target.read_text()) == edited
+    # The claim is retired, so a later pass treats the file as the user's.
+    assert "a" not in mas._load_record()
+
+
+def test_an_unreadable_existing_output_is_never_overwritten(
+    agents_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file we cannot read is not a file we may replace.
+
+    "No bytes to compare" must not collapse into "nothing is there": the digest
+    is the only ownership evidence, so an unreadable output has none and the
+    compiler has to refuse. Without this the absent-file and unreadable-file
+    cases share a code path and the compiler overwrites bytes it never inspected.
+    """
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: v1\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    target = agents_dir / "a.json"
+    before = target.read_bytes()
+
+    monkeypatch.setattr(mas, "safe_read_file_bytes", lambda _p: None)
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: v2\n---\nbody\n")
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert [c for _, c, _ in outcome.refused] == ["unreadable_output"]
+    assert target.read_bytes() == before
+
+
+def test_an_unreadable_output_is_not_pruned_and_keeps_its_claim(
+    agents_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient read failure must not abandon our own output permanently."""
+    source = _write(agents_dir, "a.md", "---\nname: a\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    target = agents_dir / "a.json"
+    source.unlink()
+
+    monkeypatch.setattr(mas, "safe_read_file_bytes", lambda _p: None)
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert outcome.pruned == []
+    assert target.is_file()
+    # Still claimed, so a later pass with a readable file can finish the prune.
+    assert "a" in mas._load_record()
+
+
+def test_two_sources_claiming_one_name_refuse_the_second(agents_dir: Path) -> None:
+    _write(agents_dir, "aaa.md", "---\nname: dup\ndescription: first\n---\nb\n")
+    _write(agents_dir, "zzz.md", "---\nname: dup\ndescription: second\n---\nb\n")
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert outcome.written == ["dup"]
+    assert [(s, c) for s, c, _ in outcome.refused] == [("zzz.md", "duplicate_name")]
+    assert json.loads((agents_dir / "dup.json").read_text())["description"] == "first"
+
+
+def test_one_bad_document_does_not_stop_the_others(agents_dir: Path) -> None:
+    _write(agents_dir, "good.md", "---\nname: good\n---\nbody\n")
+    _write(agents_dir, "bad.md", "no frontmatter at all\n")
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert outcome.written == ["good"]
+    assert [(s, c) for s, c, _ in outcome.refused] == [("bad.md", "no_frontmatter")]
+
+
+def test_applediouble_sidecars_are_not_sources(agents_dir: Path) -> None:
+    _write(agents_dir, "._a.md", FULL_DOC)
+    outcome = mas.compile_markdown_agents(agents_dir)
+    assert outcome.written == []
+    assert not (agents_dir / "code-reviewer.json").exists()
+
+
+# ── crash boundaries (the rows in the module docstring) ───────────────────────
+
+
+def test_row_4_an_interrupted_write_is_still_recognised_as_ours(agents_dir: Path) -> None:
+    """Killed after the spec write, before the commit: the pass must recover.
+
+    Without the target digest in the pending entry the file would match nothing,
+    the compiler would read its own output as hand-written, and the source could
+    never compile again without manual cleanup.
+    """
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: v1\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    target = agents_dir / "a.json"
+
+    # Simulate the interrupted transaction: the spec on disk is generation 2,
+    # the record is still PENDING and names both generations.
+    doc_v2 = "---\nname: a\ndescription: v2\n---\nbody\n"
+    v2 = mas.derive_spec(doc_v2, fallback_name="a")
+    previous = mas._load_record()["a"]["output_sha256"]
+    target.write_bytes(v2.payload)
+    mas._store_record(
+        {
+            "a": {
+                "source": "a.md",
+                "state": "pending",
+                "previous_sha256": previous,
+                "target_sha256": v2.digest,
+            }
+        }
+    )
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: v3\n---\nbody\n")
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert outcome.refused == []
+    assert outcome.written == ["a"]
+    assert json.loads(target.read_text())["description"] == "v3"
+    assert mas._load_record()["a"]["state"] == "committed"
+
+
+def test_row_3_a_pending_entry_over_the_previous_generation_is_ours(agents_dir: Path) -> None:
+    """Killed after the pending write but before the spec write."""
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: v1\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    target = agents_dir / "a.json"
+    on_disk = mas._load_record()["a"]["output_sha256"]
+
+    mas._store_record(
+        {
+            "a": {
+                "source": "a.md",
+                "state": "pending",
+                "previous_sha256": on_disk,
+                "target_sha256": "0" * 64,
+            }
+        }
+    )
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: v2\n---\nbody\n")
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    assert outcome.refused == []
+    assert json.loads(target.read_text())["description"] == "v2"
+
+
+def test_row_7_an_unusable_record_claims_nothing(agents_dir: Path) -> None:
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: v1\n---\nbody\n")
+    mas.compile_markdown_agents(agents_dir)
+    target = agents_dir / "a.json"
+    before = target.read_bytes()
+
+    record = mas._record_path()
+    record.write_text("{ not json", encoding="utf-8")
+    _write(agents_dir, "a.md", "---\nname: a\ndescription: v2\n---\nbody\n")
+
+    outcome = mas.compile_markdown_agents(agents_dir)
+
+    # Losing the record must degrade to leaving files alone, never to a delete
+    # or an overwrite authorized by a record we could not read.
+    assert [c for _, c, _ in outcome.refused] == ["name_taken"]
+    assert target.read_bytes() == before
+
+
+def test_an_unrecognised_record_schema_is_not_migrated(agents_dir: Path) -> None:
+    mas._record_path().parent.mkdir(parents=True, exist_ok=True)
+    mas._record_path().write_text(
+        json.dumps({"schema": mas.RECORD_SCHEMA + 1, "entries": {"a": {"state": "committed"}}}),
+        encoding="utf-8",
+    )
+    assert mas._load_record() == {}
+
+
+def test_a_missing_agents_directory_retires_stale_claims(tmp_path: Path) -> None:
+    gone = tmp_path / "not-there"
+    mas._store_record({"a": {"source": "a.md", "state": "committed", "output_sha256": "x"}})
+
+    outcome = mas.compile_markdown_agents(gone)
+
+    assert outcome.refused == []
+    assert mas._load_record() == {}
+
+
+# ── boot ordering ─────────────────────────────────────────────────────────────
+
+
+def test_compilation_is_wired_ahead_of_the_mcp_gateway() -> None:
+    """The compile step MUST precede ``_init_mcp_gateway`` in the boot sequence.
+
+    ``mcp_gateway/rewriter.rewrite_agents`` is what rewrites a spec's
+    ``mcpServers`` into broker stubs, and it scans the agents directory once. A
+    spec compiled AFTER it therefore keeps its raw server entries, so those
+    servers spawn direct and bypass the tool gate for the life of the process.
+    That makes the ordering a security property rather than a style choice, and a
+    comment cannot enforce it -- an unrelated edit that moves either call would
+    silently reopen the hole, so it is pinned here.
+    """
+    import inspect
+
+    from kiro_crew.slack import gateway as gw
+
+    source = inspect.getsource(gw)
+    compiled_at = source.find("await self._compile_markdown_agents()")
+    gateway_at = source.find("await self._init_mcp_gateway()")
+    assert compiled_at != -1, "the boot sequence no longer compiles markdown agents"
+    assert gateway_at != -1, "the MCP gateway boot call moved or was renamed"
+    assert compiled_at < gateway_at


### PR DESCRIPTION
## Problem / Motivation

A custom agent can only be defined as JSON in `~/.kiro/agents/`, with the system prompt referenced out via `"prompt": "file:///path/to/prompt.md"`. The wider ecosystem — Kiro IDE, kiro-agent, and similar tools — defines an agent as ONE markdown file: YAML frontmatter for the fields, the markdown body as the system prompt. A user with existing agent files has to hand-translate every one of them to JSON, escaping their prompt into a JSON string or splitting it into a second file.

## Why it matters

Hand-translation is the kind of work that silently loses fidelity: a prompt escaped into a JSON string field is unreviewable in a diff, and the two-file split puts the prompt somewhere the spec merely points at. Accepting the ecosystem's format means a team can drop their agent files in, keep them in version control as readable markdown, and review a prompt change as prose.

It is also not merely a convenience gap. **kiro-agent (the v3 engine) already loads this format natively** — `profile-loader.ts` globs both `.md` and `.json`, and `custom-agents/custom-agent-parser.ts` parses the frontmatter and uses the body as the prompt. Its loader carries the comment *"CLI agents are JSON-only."* So the same file behaves differently depending on which engine a user is on, and this PR closes that for the v2 default.

## What changed (motivation → approach → change)

**Measured constraint first.** kiro-cli 2.21.1 cannot load the format: a `.md` spec is not discovered by `agent list` at all, and handed to `agent validate --path` it is parsed as JSON regardless of extension (`invalid number at line 1 column 2` — serde on the `---` fence). Crew does not load the spec either; it hands kiro-cli a bare NAME and kiro-cli resolves the file itself.

**Approach considered and rejected: teach Crew's discovery to read `.md`.** That is the obvious change and it is the wrong one. Roughly 45 call sites hard-code `*.json` against the agents directory, and after widening all of them kiro-cli still could not run the agent — the result lists in the dashboard and then fails at `session/set_mode`, the same "visible but not dispatchable" inversion `project_agent_files`' `include_legacy=False` default exists to prevent. Three of those sites are not cosmetic:

- `mcp_gateway/rewriter.py` would never rewrite a markdown spec's `mcpServers` into broker stubs, so **its MCP servers would spawn direct and bypass the tool gate**;
- `agent_discovery._dir_signature` fingerprints only `*.json`, so roster caches would not invalidate on a markdown edit — a stale-roster bug outliving the glob fix;
- `connections/ownership` would read a markdown sharer as absent and tear down a live connection.

**Approach taken: compile, don't re-read.** Markdown is a source format; `<name>.md` compiles to `<name>.json` in the same directory. Every existing consumer then works unchanged — the roster, the model resolvers, doctor, and above all the MCP gateway rewriter, so a compiled spec's MCP servers are stubbed exactly like a hand-written one's. Scope collapses from 45 edits across security-sensitive paths to one new module plus one wiring line.

**Ordering is a security property.** The compile step runs at boot ahead of `_init_mcp_gateway`, because the rewriter scans the agents directory once: a spec compiled after it keeps its raw server entries for the life of the process. `test_compilation_is_wired_ahead_of_the_mcp_gateway` pins the order — a comment cannot enforce it against an unrelated edit that moves either call.

**Ownership, and why it lives outside the spec.** The compiler has to clean up its own output (a renamed or deleted `.md` otherwise leaves a selectable stale agent), so it must answer "did I write this file?". kiro-cli validates specs with `deny_unknown_fields`, so an in-spec marker is impossible — an extra key makes it reject the whole file and the user loses the agent. `connections/alias_record` hit the same wall; this follows its design: an out-of-spec, generation-bound record under the data home, written as a two-phase transaction (`PENDING(previous, target)` → spec write → `COMMITTED`) so every crash boundary resolves safely in both directions. The state table is in the module docstring.

Consequences that matter to a user: a hand-written `code-reviewer.json` is **never** overwritten because a `code-reviewer.md` appeared next to it; an edited generated spec is preserved rather than reverted on the next pass; a lost or unreadable record degrades to leaving files alone, never to a delete authorized by a record we could not read; and an existing output the compiler cannot READ has no digest and therefore no ownership evidence, so it is refused rather than replaced.

**Frontmatter is parsed as real YAML** (`yaml.safe_load`, never `yaml.load` — the directory is user-writable and shared with other tools). `kiro_crew.frontmatter` is deliberately not reused: its contract is a flat `dict[str, str]`, which cannot express `tools: [a, b]` or a nested `mcpServers` map — most of an agent spec — and its `split_frontmatter` body is documented as *not* a document body for the column-0 extractions, while here the body IS the prompt. Its plain-scalar grammar also intentionally accepts text YAML rejects, which is right for SKILL.md and wrong for a format whose grammar is defined by the ecosystem already writing it. No existing dialect is touched, so the `SkillForm.tsx` mirror is unaffected.

Two parsing details are load-bearing rather than tidiness: the closer must be a line of its own, so a `---junk` line is not a closer and frontmatter cannot silently leak into the prompt; and a UTF-8 BOM is stripped, because the fence is anchored at position 0 and a BOM would make the whole block read as absent — compiling a document whose config became prose. A file exported from a Windows editor is the ordinary way to get one, and this format exists to accept files authored elsewhere.

**Unknown frontmatter keys are dropped with a warning, not refused.** kiro-cli rejects a spec wholesale on an unknown key, so carrying one through would produce no agent at all, failing far from the file that caused it. `allowedTools` and `toolsSettings` are carried even though kiro-agent's schemas silently strip them: this output is for kiro-cli, and dropping them would quietly downgrade a ported file's declared permissions.

**Trust boundary unchanged.** The agents DIRECTORY is the boundary, not the extension — a `.json` there may already declare `mcpServers`, `allowedTools` and lifecycle `hooks`, which is why `security/paths.py` write-protects the whole directory against the agent's own file tools. A `.md` in the same directory is neither more nor less trusted, so those fields pass through rather than getting a second, weaker policy for the same directory. Nothing widens: the compiler reads only the user-level agents directory and writes only there.

**Scope: user-level `~/.kiro/agents` only.** A project's `.kiro/agents` cannot compile in place (Crew never writes into a user's checkout), and compiling into the user-level directory needs a source digest to keep two checkouts apart — which changes the agent's name and breaks `--agent <name>` fidelity. That belongs with the project work in #7181 rather than being smuggled in here.

## Tests

33 tests in `test/test_md_agent_specs.py`, split between what a document compiles to and what the compiler is allowed to touch. Every ownership test asserts on the FILE, not just the returned outcome — the point of the record is that a refusal leaves bytes untouched.

- Derivation: full document carries typed structures (`tools` list, nested `mcpServers`) that a flat string reader could not express; name falls back to the file stem; BOM+CRLF document compiles; empty fence is a fence, not a miss; whitespace-only body emits no `prompt` key; unknown key dropped rather than refused.
- Refusals (9 parametrized): no fence, `---junk` closer, unclosed fence, non-mapping frontmatter, a `prompt` key competing with the body, unsafe and non-string names, a Crew-managed reserved name, invalid YAML.
- `test_payload_matches_the_atomic_writer_byte_for_byte` pins `_spec_payload` against `agent._atomic_json_write`. Ownership compares digests, so if those two serializations ever drift, every compiled spec reads as hand-edited and the compiler silently stops touching its own output.
- Ownership: idempotent second pass does not rewrite (asserted on `st_mtime_ns` — an unnecessary rewrite bumps the directory signature every roster cache keys on); hand-written spec of the same name never overwritten; edited generated spec preserved; removed source pruned; removed source with an edited output NOT deleted; unreadable output neither overwritten nor pruned, and its claim retained as transient; duplicate name across two documents refuses the second deterministically; one bad document does not stop the others; AppleDouble sidecars are not sources; record never lands in the agents directory.
- Crash boundaries: rows 3, 4 and 7 from the module's state table, plus an unrecognised record schema not being migrated in place, plus a missing agents directory retiring stale claims without taking a lock whose sidecar lives in the absent directory.
- Boot ordering: compile precedes `_init_mcp_gateway`.

**Four guards revert-verified** — each breaks a named test when removed, so none of them is passing for free: unreadable-output ownership (`digest is None` → not owned), the pending entry's target digest (the interrupted-write row), the strict closer, and BOM stripping. The module was restored byte-for-byte afterwards and the suite re-run.

Also green, as the suites most likely to be tripped by a new spec reader or a new file format: `test_agent_spec_hardened_reads` (the AST call-site ratchet — untripped, since this uses `safe_read_file_bytes` directly rather than any of the four tracked helpers), `test_agent_discovery`, `test_security_posture`, `test_error_code_contract`, `test_docs_lint_fact_checks`, `test_mcp_stub_apply`, `test_slack_gateway_coverage`, `test_mcp_gateway_cluster_fixes`, `test_migrate_agent_specs`, `test_parsed_agents_cache` — 188 + 97 + 161 passed. black, flake8, isort, mypy clean.

## Manual verification

The format was verified against the real binary before any code was written, which is where the JSON-only constraint came from: in a scratch workspace, `kiro-cli agent list` did not list a `.md` spec at all, and `kiro-cli agent validate --path <spec>.md` reported `Json supplied at ... is invalid: invalid number at line 1 column 2`. The same directory's `.json` spec listed and validated cleanly.

Still required before merge: an end-to-end run on a live gateway — drop a `.md` into `~/.kiro/agents`, restart, confirm the agent appears in the roster and that a session started on it actually runs (`--agent <name>` resolving the compiled spec). Unit coverage pins the compilation and ownership contracts but cannot prove kiro-cli activates the result.

## Screenshots / video

N/A — no UI change. The compiled agent appears in the existing roster through the existing endpoint; no panel, component or layout is touched.

## Related Issues

Closes #10214

Project-scope `.kiro/agents` is deliberately out of scope and belongs with #7181 (portable project bundles); see the scope note above for why compiling a project spec into the user-level directory breaks `--agent <name>` fidelity.
