### PR TITLE
Explain caller_record_missing instead of a bare "Forbidden"

### DIFF
--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -1596,6 +1596,30 @@ def _http_error_body(exc: urllib.error.HTTPError) -> dict:
             "the instance you meant) and retry; the gateway's security event log "
             "records both credential fingerprints for the mismatch."
         )
+    elif code == "caller_record_missing":
+        # The sibling case, and the one that reads most misleadingly of all: the
+        # credential was fine and the caller WAS identified, but the identity it
+        # presented names a record the gateway can no longer find. Session keys in
+        # the ``cron:<id>`` and ``subagent:<id>`` namespaces are checked against
+        # their registries by ``token_auth._internal_caller_record_missing``, which
+        # fails CLOSED -- so a deleted cron job, a reaped subagent run, an id-less
+        # key, or a registry that merely could not be read all deny here. Left
+        # unmapped, every one of those surfaced as a bare "Forbidden", which reads
+        # as a permission decision about the tool's subject and hides the fact that
+        # the SESSION is orphaned. Mapped in the same decoder and keyed on the CODE
+        # for the same reasons as the branch above.
+        message = (
+            "this session is no longer backed by a record the gateway can find. "
+            "Its session key names a cron job or subagent run that is not in the "
+            "registry -- most often because the cron job was deleted (or renamed) "
+            "or the subagent run was reaped while a session linked to it stayed "
+            "open, and the check fails closed, so an unreadable registry denies "
+            "the same way. The credential and the caller identity are both fine; "
+            "nothing the tool was asked to do was refused on its merits. Continue "
+            "in a session that is not linked to the removed record -- a new "
+            "dashboard tab or thread -- since this one cannot be revived by "
+            "retrying. The gateway's security event log records the denial."
+        )
     out: dict = {"error": message}
     if counted:
         out["counted"] = True

--- a/test/test_instance_credential_pairing.py
+++ b/test/test_instance_credential_pairing.py
@@ -351,6 +351,50 @@ class TestEveryToolGetsTheExplanation:
         assert "wrong Kiro Crew instance" in out
         assert out.strip() != "Error: Forbidden"
 
+    def test_caller_record_missing_is_rewritten_for_every_caller(self) -> None:
+        # An orphaned session -- its cron job deleted, or its subagent run reaped
+        # -- denies with this code while the credential and the caller identity
+        # are both intact. Unmapped it read as a bare "Forbidden", which points at
+        # a permission problem the caller does not have.
+        out = self._body(b'{"error": "Forbidden", "code": "caller_record_missing"}')
+        assert "no longer backed by a record" in out["error"]
+        assert out["error"] != "Forbidden"
+
+    def test_caller_record_missing_is_not_confused_with_the_desync(self) -> None:
+        # The two 403 codes share a body and must not borrow each other's cause:
+        # one is a credential problem, the other is a missing registry record.
+        orphan = self._body(b'{"error": "Forbidden", "code": "caller_record_missing"}')
+        desync = self._body(b'{"error": "Forbidden", "code": "internal_auth_mismatch"}')
+        assert "wrong Kiro Crew instance" not in orphan["error"]
+        assert "no longer backed by a record" not in desync["error"]
+
+    def test_a_plain_forbidden_is_not_given_the_orphan_explanation(self) -> None:
+        out = self._body(b'{"error": "Forbidden"}')
+        assert "no longer backed by a record" not in out["error"]
+        assert out["error"] == "Forbidden"
+
+    def test_caller_record_missing_keeps_its_machine_readable_code(self) -> None:
+        # Callers dispatch on the code, so rewriting the prose must not drop it.
+        out = self._body(b'{"error": "Forbidden", "code": "caller_record_missing"}')
+        assert out["code"] == "caller_record_missing"
+
+    def test_learn_add_surfaces_the_orphan_explanation(self) -> None:
+        from kiro_crew.mcp_tools import learn
+
+        rewritten = self._body(
+            b'{"error": "Forbidden", "code": "caller_record_missing"}'
+        )
+        with mock.patch.object(
+            learn.mcp_core, "_post", return_value=rewritten
+        ), mock.patch.object(
+            learn.mcp_core, "_vet_memory_writes_governance", return_value=""
+        ), mock.patch.object(
+            learn.mcp_core, "_resolve_session_key", return_value="cron:47311b25"
+        ):
+            out = learn.learn_add("learn_add", {"rule": "always check the port"})
+        assert "no longer backed by a record" in out
+        assert out.strip() != "Error: Forbidden"
+
 
 class TestTheSharedHelperOwnsThePairing:
     """The invariant lives at one chokepoint, and the dial target is never inferred.


### PR DESCRIPTION
TLDR: an orphaned session denies every `kirocrew-core` tool with `Error: Forbidden` and no cause. `token_auth` emits two distinct 403 codes and the shared decoder maps only one of them.

```
_deny(request, "Forbidden", "internal_auth_mismatch")  -> explained (mcp_core.py:1581)
_deny(request, "Forbidden", "caller_record_missing")   -> bare "Forbidden"
```

`caller_record_missing` fires from `token_auth._internal_caller_record_missing` when a `cron:<id>` or `subagent:<id>` session key names a record that is not in the registry. It fails closed, so a deleted cron job, a reaped subagent run, an id-less key, and a registry that merely could not be read all deny here. In every one of those the credential is valid and the caller *is* identified, so `Forbidden` reads as a permission decision about the tool own subject and points the reader at a bug they do not have.

## How I hit it

I deleted a cron job while a session linked to it was still open, then called `learn_add`. It answered `Error: Forbidden`. So did `learn_list`, which is what suggested the whole server was refusing rather than the session being orphaned. I went looking at credential desync (`dashboard/server.py:1933`) and at `mcp_gateway.stub_servers` routing before finding the real cause. The gateway had already sent the reason in the response `code` and the client discarded it.

Repro: create a cron job, open its linked session, delete the job, call any `kirocrew-core` tool from that session.

## The change

One `elif` in `_http_error_body`, alongside its sibling and keyed on the code for the same reason given there: a genuine permission denial produces the same body and must keep the plain message. Mapping it in the shared decoder means no tool needs its own branch.

Before: `Error: Forbidden`

After: `Error: this session is no longer backed by a record the gateway can find. Its session key names a cron job or subagent run that is not in the registry ... Continue in a session that is not linked to the removed record.`

The machine-readable `code` is preserved, so callers that dispatch on it are unaffected.

## Note on the ratchet

The error-code ratchet does not catch this class. It enforces that a response *carries* a code, not that a client *maps* one, so any future `_deny` code added to `token_auth` can regress the same way. Happy to add a ratchet test asserting every code `token_auth` emits has a branch in the decoder if you want that in scope, though it would need a decision about which codes are legitimately allowed to stay unmapped.

## Testing

Six tests added to `TestEveryToolGetsTheExplanation` in `test/test_instance_credential_pairing.py`, following the sibling code tests: the rewrite fires, the two 403 codes do not borrow each other cause, a plain `Forbidden` is untouched, the `code` survives, and `learn_add` surfaces the explanation end to end. All pass, as does the existing sibling coverage.