### PR TITLE
feat(gui-user-test): new-user friction channel beside the verdict

### DIFF
--- a/.github/workflows/gui-user-test.yml
+++ b/.github/workflows/gui-user-test.yml
@@ -59,7 +59,8 @@ on:
 
 permissions:
   contents: read
-  issues: write # nightly failure report
+  issues: write # nightly failure report + new-user friction issues
+  actions: read # download the previous run's friction ledger artifact
   id-token: write # AWS OIDC (configure-aws-credentials)
 
 concurrency:
@@ -260,6 +261,89 @@ jobs:
           python test/gui_user/report.py --format features --run-url "$RUN_URL" "${summary_args[@]}" \
             > "$GUI_OUT/results/features.md"
 
+      # New-user friction: what confused the tester persona, carried across
+      # nights. `merge` writes this run's friction.json (ledger-aware rows:
+      # counts, last seen, issue numbers) and the updated ledger. Every run
+      # READS the ledger so its report shows counts; only the scheduled run on
+      # the default branch WRITES it back (upload + issues below), so two runs
+      # on different refs -- a dispatch beside the nightly, two dispatches --
+      # can never race each other's entries and issue numbers into the
+      # canonical ledger. The per-ref concurrency group already serializes runs
+      # on one ref. `merge` also refuses to read a malformed ledger
+      # (friction.load_ledger), and this step's failure leaves the canonical
+      # artifact untouched either way.
+      #
+      # PROVENANCE. The ledger later drives issue writes with the repository
+      # token, so it is never looked up by artifact NAME across the repository:
+      # a fork pull request can upload an artifact called anything. `pick-ledger`
+      # (friction.py) lists the completed scheduled runs of THIS workflow file
+      # on the default branch, keeps only those whose head and base repository
+      # are this repository, and takes the ledger artifact from the newest such
+      # run that still holds one -- checking the artifact's own workflow_run
+      # block against that run and branch before it is downloaded. A RE-RUN of
+      # a scheduled night reads its own earlier attempt's ledger first (that
+      # attempt already filed issues; last night's ledger would file them
+      # again), which is also why the ledger upload below overwrites.
+      - name: Merge new-user friction into the ledger
+        id: friction
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # github.event.repository is absent on schedule payloads; ref_name is the
+          # default branch on both automatic triggers (same fallback as pr-readiness.yml).
+          LEDGER_BRANCH: ${{ github.event.repository.default_branch || github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          # -e as well: every command here either resolves, downloads, merges or
+          # re-renders the ledger, and a failure in any of them (the ledger write
+          # after friction.json, say) must fail the step so nothing downstream
+          # uploads or files against a night that was not persisted.
+          set -euo pipefail
+          mkdir -p "$GUI_OUT/results" "$RUNNER_TEMP/friction-prev"
+          summary="$GUI_OUT/results/summary.json"
+          date="$(date -u +%F)"
+          echo "date=$date" >> "$GITHUB_OUTPUT"
+          # A retrieval ERROR (API 5xx, download failure) is not a first night: it
+          # fails this step, so the scheduled run uploads nothing and the canonical
+          # ledger keeps its counts and issue numbers. Only a complete API answer
+          # with NO eligible scheduled run holding a ledger starts a fresh one.
+          [ -n "$LEDGER_BRANCH" ] || { echo "::error::default branch unknown; refusing to pick a ledger"; exit 1; }
+          if ! python test/gui_user/friction.py pick-ledger --repo "$REPO" \
+                 --branch "$LEDGER_BRANCH" --self-run "$RUN_ID" --out "$RUNNER_TEMP/friction-pick.json"; then
+            echo "::error::could not resolve the previous friction ledger; refusing to start a fresh one"
+            exit 1
+          fi
+          prev_run="$(jq -r '.run_id // empty' "$RUNNER_TEMP/friction-pick.json")"
+          ledger_args=()
+          if [ -n "$prev_run" ]; then
+            if ! gh run download "$prev_run" --repo "$REPO" -n gui-user-test-friction-ledger \
+                 -D "$RUNNER_TEMP/friction-prev"; then
+              echo "::error::could not download the friction ledger from run $prev_run"
+              exit 1
+            fi
+            [ -f "$RUNNER_TEMP/friction-prev/friction_ledger.json" ] || {
+              echo "::error::ledger artifact from run $prev_run holds no friction_ledger.json"; exit 1; }
+            ledger_args=(--ledger "$RUNNER_TEMP/friction-prev/friction_ledger.json")
+            echo "previous ledger from scheduled run $prev_run on $LEDGER_BRANCH"
+          else
+            echo "no scheduled run on $LEDGER_BRANCH holds a ledger artifact; starting one"
+          fi
+          if [ -f "$summary" ]; then
+            python test/gui_user/friction.py merge --summary "$summary" "${ledger_args[@]}" \
+              --out "$GUI_OUT/results/friction.json" --out-ledger "$GUI_OUT/results/friction_ledger.json" \
+              --date "$date" --run-url "$RUN_URL" --head-sha "$SHA"
+            # The harness wrote verdict.md before the ledger existed; re-render it
+            # with the ledger-aware rows so the uploaded verdict carries the
+            # recurrence counts (issue numbers are a nightly-only, later step).
+            python test/gui_user/report.py --summary "$summary" --run-url "$RUN_URL" \
+              --friction "$GUI_OUT/results/friction.json" > "$GUI_OUT/results/verdict.md"
+          elif [ -n "${ledger_args[1]:-}" ]; then
+            cp "${ledger_args[1]}" "$GUI_OUT/results/friction_ledger.json"
+          fi
+
       - name: Upload screenshots, steps and verdict
         id: artifact
         if: always()
@@ -273,6 +357,41 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      # Nightly only: one `ux(<feature>)` issue per non-cosmetic friction row
+      # without one (at most five a night; the rest wait in the summary), one
+      # "again on <date>" comment per recurrence that already has an issue.
+      # Cosmetic rows never leave the summary. Runs BEFORE the summary and the
+      # nightly report so both can show the numbers it opened; the artifact
+      # URL is stamped on tonight's rows first so the issue's screenshot link
+      # resolves. A night the harness did not run (no summary.json, so the
+      # merge step carried the ledger forward and wrote no friction.json) has
+      # nothing to file: nothing was tested, so no row is "tonight's", and the
+      # held-over rows wait for a night that produced evidence.
+      - name: File new-user friction issues
+        if: always() && github.event_name == 'schedule' && steps.friction.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DATE: ${{ steps.friction.outputs.date }}
+          ARTIFACT_URL: ${{ steps.artifact.outputs.artifact-url }}
+        run: |
+          set -uo pipefail
+          ledger="$GUI_OUT/results/friction_ledger.json"
+          [ -f "$ledger" ] || { echo "no ledger tonight"; exit 0; }
+          [ -f "$GUI_OUT/results/friction.json" ] || {
+            echo "the harness did not run tonight (no friction.json); nothing to file"; exit 0; }
+          rc=0
+          python test/gui_user/friction.py issues --ledger "$ledger" --repo "$REPO" --date "$DATE" \
+            --artifact-url "$ARTIFACT_URL" --friction "$GUI_OUT/results/friction.json" || rc=$?
+          # friction.json was written before filing; rebuild it so the reports below
+          # carry the issue numbers (the artifact keeps the pre-filing snapshot).
+          # The ledger already holds every number that WAS filed, so the snapshot
+          # runs even after a partial failure -- and the step then reports that
+          # failure instead of letting the snapshot's exit code paint it green.
+          python test/gui_user/friction.py snapshot --ledger "$ledger" \
+            --out "$GUI_OUT/results/friction.json" --date "$DATE"
+          exit "$rc"
+
       - name: Summarize
         id: summary
         if: always()
@@ -282,12 +401,14 @@ jobs:
         run: |
           set -uo pipefail
           summary="$GUI_OUT/results/summary.json"
+          friction_args=()
+          [ -f "$GUI_OUT/results/friction.json" ] && friction_args=(--friction "$GUI_OUT/results/friction.json")
           if [ -f "$summary" ]; then
             verdict="$(python test/gui_user/report.py --summary "$summary" --format verdict)"
             {
               echo "## GUI user test — $verdict"
               echo
-              python test/gui_user/report.py --summary "$summary" --run-url "$RUN_URL" --artifact-url "$ARTIFACT_URL"
+              python test/gui_user/report.py --summary "$summary" --run-url "$RUN_URL" --artifact-url "$ARTIFACT_URL" "${friction_args[@]}"
             } >> "$GITHUB_STEP_SUMMARY"
           else
             verdict="ERROR"
@@ -321,10 +442,12 @@ jobs:
           summary="$GUI_OUT/results/summary.json"
           title_file="${RUNNER_TEMP}/gui-issue-title.txt"
           body_file="${RUNNER_TEMP}/gui-issue-body.md"
+          friction_args=()
+          [ -f "$GUI_OUT/results/friction.json" ] && friction_args=(--friction "$GUI_OUT/results/friction.json")
           if [ -f "$summary" ]; then
             python test/gui_user/report.py --summary "$summary" --format issue-title --head-sha "$SHA" > "$title_file"
             python test/gui_user/report.py --summary "$summary" --format issue-body --head-sha "$SHA" \
-              --run-url "$RUN_URL" --artifact-url "$ARTIFACT_URL" > "$body_file"
+              --run-url "$RUN_URL" --artifact-url "$ARTIFACT_URL" "${friction_args[@]}" > "$body_file"
           else
             echo "Nightly GUI user test ERROR: target did not boot" > "$title_file"
             printf 'The nightly agentic GUI user test produced no summary at `%s`: the target did not boot or the harness crashed.\n\nSee the [workflow run](%s).\n\nLane: `.github/workflows/gui-user-test.yml` · tracking: #9578\n' "$SHA" "$RUN_URL" > "$body_file"
@@ -339,6 +462,20 @@ jobs:
             gh issue create --repo "$REPO" --title "$(cat "$title_file")" --body-file "$body_file" \
               --label gui-test-report --label "area: tests" && echo "Opened a new report issue"
           fi
+
+      # Only the nightly on main is the ledger's writer (see the merge step).
+      - name: Upload the friction ledger
+        if: always() && github.event_name == 'schedule' && steps.friction.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gui-user-test-friction-ledger
+          path: ${{ env.GUI_OUT }}/results/friction_ledger.json
+          if-no-files-found: ignore
+          retention-days: 90
+          # A re-run of the same scheduled run already holds attempt 1's ledger
+          # under this name; without this the upload fails and the night's
+          # issue numbers are never persisted.
+          overwrite: true
 
       # The job's status IS the verdict: a dispatch or nightly run that did not
       # PASS is red, so a red means red and the nightly issue carries the why.

--- a/docs/build/gui-user-test.md
+++ b/docs/build/gui-user-test.md
@@ -30,6 +30,7 @@ while the code holding credentials is not. `pr-readiness.yml` does not read this
 | `test/gui_user/scenarios.py` + `scenarios/*.yaml` | The scenario DSL (including the `FEATURES` registry) and the shipped scenarios. |
 | `test/gui_user/report.py` | Renders `summary.json` into `verdict.md`, the PR comment and the nightly issue, all grouped by feature; renders `features.md` from the scenario directory. |
 | [`test/gui_user/FEATURES.md`](../../test/gui_user/FEATURES.md) + `features.json` | The scenario backlog: every user-visible feature as one record (feature slug, user story, start URL, seed, runnable tier, priority). `features.json` is the source of truth; `FEATURES.md` is rendered from it by `features_catalog.py` (`--write` / `--check`), which also validates every record and refuses cross-slug duplicates. |
+| `test/gui_user/friction.py` | The new-user friction channel: the `report_friction` tool schema, entry validation, the cross-night ledger, the "New-user friction" section and the nightly `ux(<feature>)` issues. |
 
 The unit tests under `test/gui_user/` run in the ordinary Backend Tests shards; they
 need no display and never call Bedrock.
@@ -107,6 +108,7 @@ expectations:
   - The page background colour is clearly different from the first screenshot.
 max_steps: 12               # actions before the scenario FAILS (ceiling 40)
 max_seconds: 300            # wall clock before the scenario FAILS (ceiling 900)
+persona: new-user           # optional; who the tester is (scenarios.PERSONAS), see below
 ```
 
 Write `steps` as you would brief a human tester -- what to look for, not where to
@@ -163,6 +165,91 @@ on demand (below) before merging.
 `boot.sh` seeds one home per run from `GUI_SEED` (default `rich`) with `GUI_MEMBERS`
 (default `nova-sky`); a scenario's `preconditions.seed` / `members` document what it
 needs and must agree with that boot, because the target is booted once per run.
+
+### New-user friction: what confused the tester, beside the verdict
+
+A scenario tells you whether a flow works. It does not tell you whether a person who
+has never seen the product could find it. The friction channel does, and it is
+deliberately independent of PASS/FAIL: a scenario can pass with five confusions
+logged, or fail with none.
+
+- **Persona.** The tester runs as `scenarios.PERSONAS["new-user"]` unless the YAML sets
+  `persona: none` (the bare tester, no friction tool -- for a scenario about the expert
+  path, or to measure the channel's own cost). The persona text is spliced into the
+  harness system prompt: first time using Kiro Crew, no documentation, used ordinary
+  chat apps and an editor before; and a standing instruction to call `report_friction`
+  the moment it pauses for more than a glance, cannot find a control, clicks the wrong
+  thing, does not understand a label / icon / message, does not know what is
+  happening, or finds the layout hides the main action -- then carry on.
+- **Entries.** `report_friction` takes `surface`, `element`, `what_confused` (first
+  person, one sentence), `expected`, `actual` and `severity` (`blocker` = could not
+  continue without guessing; `slows-down` = got there but lost time; `cosmetic` =
+  looked wrong, did not slow me down). `friction.validate_entry` is the only way in:
+  every field typed, trimmed and capped at 240 characters, unknown fields refused,
+  and the harness stamps `feature` (from the scenario), `scenario`, the last
+  screenshot's artifact path and the step number. Twelve entries per attempt; a
+  duplicate or a malformed call gets a one-line answer and never fails the task. The
+  entries ride in `summary.json` under each attempt as `friction[]`.
+- **Identity across nights.** `friction.entry_key(feature, element, what_confused)`
+  after case / whitespace / punctuation normalization. The workflow fetches the
+  previous `gui-user-test-friction-ledger` artifact, folds
+  tonight's entries in (`friction.py merge`: a recurrence bumps `count` and
+  `last_seen`, takes the newest sighting's wording and screenshot and keeps the worst
+  severity; a second run on the same day -- a dispatch after the nightly -- refreshes
+  the evidence under its own artifact without counting the day twice, and a re-run of
+  the same run is never a new night, even across midnight UTC), writes `results/friction.json` (tonight's
+  rows with counts and issue numbers) and -- on the scheduled run only -- re-uploads
+  the ledger with 90-day retention. A dispatch reads the ledger for its report but
+  never writes it, so runs on different refs cannot race each other's entries into
+  the canonical ledger.
+- **Where the ledger may come from.** The ledger feeds a step that writes issues
+  with the repository token, so it is never looked up by artifact name across the
+  repository -- a fork pull request can upload an artifact called anything.
+  `friction.py pick-ledger` first looks at the current run itself -- a **re-run**
+  of a scheduled night reads its own earlier attempt's ledger, which already
+  records the issues that attempt filed (the ledger upload overwrites for the same
+  reason) -- then lists the completed **scheduled** runs of this workflow file on
+  the **default branch**, keeps only those whose head and base repository are this
+  repository (walking the listing page by page, so a long streak of ledgerless
+  nights cannot hide an older ledger still inside its retention window), and takes
+  the ledger from the newest such run that still holds one
+  (a red, cancelled or timed-out nightly counts: its ledger was written and
+  uploaded before the job ended; a night whose merge step failed uploaded nothing
+  and is skipped). The
+  artifact's own `workflow_run` block is checked against that run and branch
+  before download. A complete answer with no eligible run means "first night"; a
+  listing or download ERROR fails the merge step instead, so a transient outage
+  can never replace the canonical ledger with an empty one. A night the harness
+  did not run carries the ledger forward and files nothing. `verdict.md` is
+  re-rendered after the merge so the uploaded verdict carries the counts.
+- **Where it shows.** `verdict.md`, the run summary and the nightly failure issue all
+  end with a "New-user friction" section: one table per feature in registry order,
+  worst severity first, each row with where / expected → actual / how many nights /
+  the screenshot in the artifact. The section is capped at 30k characters (issue
+  bodies and comments stop at 64k): rows past the budget are counted in one
+  trailer line and stay in the artifact's `friction.json`. Model text is rendered
+  inert (no fences, links, HTML or mentions survive).
+- **Issues.** Nightly only: each non-cosmetic row without an issue gets one
+  (unless an OPEN issue already carries the row's marker -- a number the ledger
+  lost to a cancelled run is adopted, never duplicated; a failed lookup skips the
+  row for the night) --
+  title `ux(<feature>): <what confused me>`, labels `ux`, `channel: gui-user-test`
+  and an `area:` label mapped from the feature (`friction.AREA_LABELS`, keyed only by
+  registry slugs, default `area: dashboard`), body carrying
+  `<!-- gui-user-friction <key> -->` -- at most
+  five a night, the rest wait in the summary for the next night. A recurrence whose
+  row already has an issue gets one "again on <date>" comment per date (a same-day
+  rerun posts nothing twice; the ledger is written -- atomically, temp file then
+  rename, so a disk-full or killed runner never leaves a truncated ledger under the
+  canonical name -- after every successful `gh` call
+  so a rerun after a partial failure files only what is missing). Cosmetic rows never
+  leave the summary. Closing an issue is a human call; the lane never reopens one.
+- **Cost.** The persona adds about 450 input tokens to every model call and each
+  `report_friction` call is one extra round trip (~7k input, ~150 output tokens);
+  two to four per scenario in practice. Roughly +$0.10 per scenario, about +$1 a
+  night on the twelve-scenario tier, inside the $10 ceiling. If the ceiling is ever
+  the problem, set `persona: none` on the low-priority scenarios first rather than
+  dropping the channel.
 
 ## Running it
 

--- a/test/gui_user/friction.py
+++ b/test/gui_user/friction.py
@@ -1,0 +1,1090 @@
+"""New-user friction: what confused the tester, reported beside (not inside) the verdict.
+
+The harness gives the model one extra tool, ``report_friction``. Whenever the
+persona (``scenarios.PERSONAS``) stalls -- cannot find a control, clicks the
+wrong thing, does not understand a label or an icon, does not know what just
+happened -- it files one structured entry and carries on with the task. A
+scenario can PASS with a dozen friction entries and FAIL with none: the two
+channels never touch each other.
+
+This module owns everything about those entries once the model has spoken:
+
+* :data:`FRICTION_TOOL` -- the tool schema the harness advertises;
+* :func:`validate_entry` -- the only way an entry gets into ``summary.json``
+  (every field typed, bounded and stripped; the model cannot smuggle Markdown,
+  fences or mentions into a bot-authored comment);
+* :func:`entry_key` -- the cross-night identity ``(feature, element,
+  what_confused)`` after normalization, so the same confusion seen on
+  consecutive nights is one row with a count, not a new row each night;
+* :func:`merge_ledger` -- folds a run into the ledger the workflow carries
+  from night to night as an artifact;
+* :func:`render_section` -- the "New-user friction" block for ``verdict.md``,
+  the run summary and the nightly issue, grouped by feature, ordered by
+  severity;
+* :func:`plan_issues` / :func:`file_issues` -- the GitHub issues: at most
+  ``ISSUE_CAP`` new ones per night for non-cosmetic rows that have no issue yet
+  (new tonight, or held over by an earlier night's cap),
+  one "again on <date>" comment for a recurrence that already has an issue;
+* :func:`ledger_source_runs` / :func:`ledger_artifact_id` / :func:`pick_ledger`
+  -- WHERE the previous ledger may come from. The ledger feeds a job that writes
+  issues with the repository token, so it is never looked up by artifact name
+  across the repository (a fork pull request can upload an artifact of any
+  name): the source is this run's own earlier attempt when there is one, else
+  the newest completed scheduled run of THIS workflow on the default branch,
+  and the artifact is taken from that run alone.
+
+CLI (what the workflow calls)::
+
+    python test/gui_user/friction.py pick-ledger --repo owner/name --branch main \
+        --self-run $GITHUB_RUN_ID --out prev/pick.json   # {"run_id": ..., "artifact_id": ...} or nulls
+    python test/gui_user/friction.py merge  --summary results/summary.json \
+        --ledger prev/friction_ledger.json --out results/friction.json \
+        --out-ledger results/friction_ledger.json --date YYYY-MM-DD \
+        --run-url ... --artifact-url ... --head-sha ...
+    python test/gui_user/friction.py issues --ledger results/friction_ledger.json \
+        --repo owner/name --date YYYY-MM-DD [--dry-run]
+    python test/gui_user/friction.py snapshot --ledger results/friction_ledger.json \
+        --out results/friction.json --date YYYY-MM-DD     # after issues: rows now carry numbers
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+
+if __package__ in (None, ""):  # ``python test/gui_user/friction.py``
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gui_user.scenarios import FEATURES  # noqa: E402
+
+SEVERITIES: tuple[str, ...] = ("blocker", "slows-down", "cosmetic")
+#: Longest text the model may put in one field; longer is cut, never rejected,
+#: so a verbose tester does not lose the entry.
+FIELD_MAX = 240
+#: Entries one attempt may file; past this the tool answers "log full" and the
+#: task continues. Bounds the cost of a tester who narrates every pixel.
+ATTEMPT_CAP = 12
+#: New issues one night may open; the rest stay in the run summary.
+ISSUE_CAP = 5
+LEDGER_VERSION = 1
+LEDGER_FILE = "friction_ledger.json"
+LEDGER_ARTIFACT = "gui-user-test-friction-ledger"
+WORKFLOW_PATH = ".github/workflows/gui-user-test.yml"
+LEDGER_EVENT = "schedule"
+# Which finished runs may supply the ledger. A FAIL verdict, a cancellation or a
+# timeout all come AFTER the ledger was written and uploaded (the upload step runs
+# whenever the merge step succeeded, and an artifact either finalized or does not
+# exist), so a ledger found on any of them is a whole night; rejecting a cancelled
+# run would drop the issue numbers it filed and re-file them. Only conclusions
+# under which the job never ran are out (skipped, action_required, stale, ...).
+LEDGER_CONCLUSIONS: frozenset[str] = frozenset({"success", "failure", "cancelled", "timed_out"})
+# Bound on the rendered "New-user friction" section: it rides inside an issue
+# body / comment whose ceiling is 65,536 characters alongside the scenario table,
+# and a run can produce many maximum-length rows. Rows past the budget are
+# counted, not shown; every row is in the artifact's friction.json.
+SECTION_MAX_CHARS = 30_000
+# Pages of completed nightlies the ledger lookup will walk (100 runs each) before
+# concluding no ledger exists: ~500 nights, far past the 90-day artifact retention.
+MAX_RUN_PAGES = 5
+FRICTION_FILE = "friction.json"
+ISSUE_MARKER = "<!-- gui-user-friction "
+LABEL_UX = "ux"
+LABEL_CHANNEL = "channel: gui-user-test"
+#: ``feature`` slug -> the repo's ``area:`` label, for the slugs whose surface is
+#: not the dashboard shell. Every key must be a ``FEATURES`` slug (a unit test
+#: holds it); anything unlisted is the dashboard.
+AREA_LABELS: dict[str, str] = {
+    "apps": "area: apps",
+    "schedule": "area: cron",
+}
+DEFAULT_AREA_LABEL = "area: dashboard"
+
+FRICTION_TOOL: dict[str, Any] = {
+    "name": "report_friction",
+    "description": (
+        "Record ONE moment where the app confused you as a first-time user: you paused for more "
+        "than a glance to find something, could not find a control, clicked the wrong thing, did "
+        "not understand a label, icon or message, did not know what was happening, or the layout "
+        "hid the main action. Call it the moment it happens, then continue the task. Say it in "
+        "your own words. This never changes the task or its verdict."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "surface": {
+                "type": "string",
+                "maxLength": FIELD_MAX,
+                "description": "Page or panel you were on (as a user would name it).",
+            },
+            "element": {
+                "type": "string",
+                "maxLength": FIELD_MAX,
+                "description": "The control, text or area involved, described so someone else could find it.",
+            },
+            "what_confused": {
+                "type": "string",
+                "maxLength": FIELD_MAX,
+                "description": "One sentence, first person: what confused you.",
+            },
+            "expected": {
+                "type": "string",
+                "maxLength": FIELD_MAX,
+                "description": "What you expected to see or happen.",
+            },
+            "actual": {
+                "type": "string",
+                "maxLength": FIELD_MAX,
+                "description": "What actually was there or happened.",
+            },
+            "severity": {
+                "type": "string",
+                "enum": list(SEVERITIES),
+                "description": (
+                    "blocker = you could not continue without guessing; slows-down = you got there "
+                    "but lost time; cosmetic = it looked wrong but did not slow you down."
+                ),
+            },
+        },
+        "required": ["surface", "element", "what_confused", "expected", "actual", "severity"],
+        "additionalProperties": False,
+    },
+}
+
+_WS = re.compile(r"\s+")
+_PUNCT = re.compile(r"[^a-z0-9 ]+")
+
+
+class FrictionError(ValueError):
+    """A friction entry or ledger is malformed."""
+
+
+# --------------------------------------------------------------------------
+# Entries
+# --------------------------------------------------------------------------
+
+
+def _clean(value: Any, what: str) -> str:
+    if not isinstance(value, str):
+        raise FrictionError(f"{what} must be a string")
+    kept = "".join(ch for ch in value if ch.isprintable() or ch in "\n\t")
+    text = _WS.sub(" ", kept).strip()
+    if not text:
+        raise FrictionError(f"{what} must not be empty")
+    return text if len(text) <= FIELD_MAX else text[: FIELD_MAX - 1] + "…"
+
+
+def normalize(text: str) -> str:
+    """Case-, whitespace- and punctuation-insensitive form used for the key."""
+    return _WS.sub(" ", _PUNCT.sub(" ", text.lower())).strip()
+
+
+def entry_key(feature: str, element: str, what_confused: str) -> str:
+    raw = "\n".join([feature, normalize(element), normalize(what_confused)])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def validate_entry(
+    raw: Any, *, feature: str, scenario: str, screenshot: str, step: int
+) -> dict[str, Any]:
+    """Turn a ``report_friction`` tool input into a stored entry, or raise."""
+    if not isinstance(raw, dict):
+        raise FrictionError("friction input must be a mapping")
+    unknown = set(raw) - set(FRICTION_TOOL["input_schema"]["properties"])
+    if unknown:
+        raise FrictionError(f"unknown friction fields {sorted(unknown)}")
+    severity = raw.get("severity")
+    if severity not in SEVERITIES:
+        raise FrictionError(f"severity must be one of {SEVERITIES}")
+    if feature not in FEATURES:
+        raise FrictionError(f"feature {feature!r} is not a registry slug")
+    entry = {
+        "feature": feature,
+        "scenario": scenario,
+        "surface": _clean(raw.get("surface"), "surface"),
+        "element": _clean(raw.get("element"), "element"),
+        "what_confused": _clean(raw.get("what_confused"), "what_confused"),
+        "expected": _clean(raw.get("expected"), "expected"),
+        "actual": _clean(raw.get("actual"), "actual"),
+        "severity": severity,
+        "screenshot": str(screenshot),
+        "step": int(step),
+    }
+    entry["key"] = entry_key(feature, entry["element"], entry["what_confused"])
+    return entry
+
+
+def collect(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every entry of a run, one per key, in first-sighting order.
+
+    A key seen twice in one run -- the retry of a scenario reporting the same
+    confusion, two scenarios stumbling on the same control -- is folded the way
+    :func:`merge_ledger` folds nights: the newest sighting's evidence (surface,
+    wording, screenshot) with the WORST severity either sighting gave it. A
+    first attempt that called something cosmetic must not hide the retry that
+    found it a blocker: cosmetic rows never reach :func:`plan_issues`.
+    """
+    by_key: dict[str, dict[str, Any]] = {}
+    for sc in summary.get("scenarios") or []:
+        if not isinstance(sc, dict):
+            continue
+        for att in sc.get("attempts") or []:
+            if not isinstance(att, dict):
+                continue
+            for e in att.get("friction") or []:
+                if not isinstance(e, dict) or e.get("severity") not in SEVERITIES:
+                    continue
+                key = str(e.get("key") or "")
+                if not key:
+                    continue
+                prior = by_key.get(key)
+                merged = dict(e)
+                if prior is not None and severity_rank(prior["severity"]) < severity_rank(
+                    merged["severity"]
+                ):
+                    merged["severity"] = prior["severity"]
+                by_key[key] = merged
+    return list(by_key.values())
+
+
+def severity_rank(severity: str) -> int:
+    return SEVERITIES.index(severity) if severity in SEVERITIES else len(SEVERITIES)
+
+
+def sort_entries(entries: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    slugs = list(FEATURES)
+
+    def rank(e: dict[str, Any]) -> tuple[int, int, str]:
+        f = str(e.get("feature", ""))
+        return (
+            slugs.index(f) if f in slugs else len(slugs),
+            severity_rank(e["severity"]),
+            e["key"],
+        )
+
+    return sorted(entries, key=rank)
+
+
+# --------------------------------------------------------------------------
+# Ledger
+# --------------------------------------------------------------------------
+
+
+def empty_ledger() -> dict[str, Any]:
+    return {"version": LEDGER_VERSION, "entries": {}}
+
+
+def load_ledger(path: Optional[Path]) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return empty_ledger()
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise FrictionError(f"ledger {path}: {exc}") from exc
+    if (
+        not isinstance(doc, dict)
+        or doc.get("version") != LEDGER_VERSION
+        or not isinstance(doc.get("entries"), dict)
+    ):
+        raise FrictionError(f"ledger {path}: unexpected shape")
+    for key, row in doc["entries"].items():
+        if not isinstance(row, dict) or row.get("severity") not in SEVERITIES:
+            raise FrictionError(f"ledger {path}: entry {key} is malformed")
+    return doc
+
+
+def merge_ledger(
+    ledger: dict[str, Any],
+    entries: Iterable[dict[str, Any]],
+    *,
+    date: str,
+    run_url: str = "",
+    artifact_url: str = "",
+    head_sha: str = "",
+) -> tuple[dict[str, Any], list[str]]:
+    """Fold one run into the ledger; return ``(ledger, keys that are new tonight)``.
+
+    A recurrence bumps ``count`` and ``last_seen`` and takes the newest sighting
+    whole (surface, wording, expected/actual, screenshot) plus the worst severity
+    of old and new, so a blocker never downgrades to cosmetic because one
+    night's tester shrugged. Runs are told apart by ``run_url``: the same run
+    merged twice is a no-op, a different run on the same day refreshes the
+    evidence but does not count the day twice.
+    """
+    rows: dict[str, Any] = ledger["entries"]
+    new_keys: list[str] = []
+    for e in entries:
+        key = e["key"]
+        row = rows.get(key)
+        if row is None:
+            rows[key] = {
+                "feature": e["feature"],
+                "scenario": e["scenario"],
+                "surface": e["surface"],
+                "element": e["element"],
+                "what_confused": e["what_confused"],
+                "expected": e["expected"],
+                "actual": e["actual"],
+                "severity": e["severity"],
+                "screenshot": e["screenshot"],
+                "first_seen": date,
+                "last_seen": date,
+                "count": 1,
+                "issue": None,
+                "run_url": run_url,
+                "artifact_url": artifact_url,
+                "head_sha": head_sha,
+            }
+            new_keys.append(key)
+            continue
+        if row.get("run_url") == run_url:
+            # The same run merged twice -- a re-run of the night, even one that
+            # crossed midnight UTC and so carries a later ``date``: attempt 1
+            # already counted it, filed it and uploaded its evidence. Not a new
+            # night, not a recurrence, nothing to refresh.
+            continue
+        same_day = row.get("last_seen") == date
+        if not same_day:
+            # A night counts once, however many runs saw the row that day.
+            row["count"] = int(row.get("count", 1)) + 1
+            row["last_seen"] = date
+        # Take the newest sighting whole -- surface, wording and evidence together --
+        # so a row never pairs an old location with a new screenshot, and a
+        # same-day run other than the one recorded (a dispatch after the nightly)
+        # reports ITS evidence under ITS artifact, not the earlier run's. The key
+        # is normalized, so ``element`` / ``what_confused`` may differ in spelling.
+        for field in ("scenario", "surface", "element", "what_confused", "expected", "actual"):
+            row[field] = e[field]
+        row["screenshot"] = e["screenshot"]
+        row["run_url"] = run_url
+        row["artifact_url"] = artifact_url
+        row["head_sha"] = head_sha
+        if severity_rank(e["severity"]) < severity_rank(row["severity"]):
+            row["severity"] = e["severity"]
+    return ledger, new_keys
+
+
+def tonight(ledger: dict[str, Any], date: str) -> list[dict[str, Any]]:
+    """Ledger rows seen on ``date``, as entries carrying their key, count and issue."""
+    out = []
+    for key, row in ledger["entries"].items():
+        if row.get("last_seen") == date:
+            out.append({**row, "key": key})
+    return sort_entries(out)
+
+
+def rows_for(ledger: dict[str, Any], keys: Iterable[str]) -> list[dict[str, Any]]:
+    """Ledger rows for exactly these keys (one run's own sightings), in catalog order.
+
+    ``friction.json`` is scoped this way rather than by date: a dispatch on the
+    same day as the nightly must report its own rows, not the nightly's, or its
+    screenshot links would point into the wrong artifact.
+    """
+    wanted = set(keys)
+    return sort_entries(
+        [{**row, "key": key} for key, row in ledger["entries"].items() if key in wanted]
+    )
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+_SCHEME = re.compile(r"(?i)\b([a-z][a-z0-9+.-]*):(//)")
+_WWW = re.compile(r"(?i)\bwww\.")
+
+
+def _cell(text: Any, *, max_chars: int = FIELD_MAX) -> str:
+    """Model-authored text rendered inert in a Markdown table cell / issue body.
+
+    Pipes, backticks, angle and square brackets lose their Markdown meaning, an
+    ``@`` cannot mention, and a URL is defanged (zero-width space after the
+    scheme colon and inside ``www.``) so GitHub never autolinks a URL the tester
+    merely read off the screen -- an injected page must not become a live link
+    in a bot-authored issue.
+    """
+    s = str(text or "")
+    kept = "".join(ch for ch in s if ch.isprintable())
+    kept = kept.replace("|", "/").replace("`", "'").replace("@", "@\u200b")
+    # "#123" / "owner/repo#123" would autolink and notify that issue's thread.
+    kept = re.sub(r"#(?=\d)", "#\u200b", kept)
+    kept = kept.replace("<", "‹").replace(">", "›").replace("[", "(").replace("]", ")")
+    kept = _SCHEME.sub("\\1:\u200b\\2", kept)
+    kept = _WWW.sub("www\u200b.", kept)
+    kept = _WS.sub(" ", kept).strip()
+    return kept if len(kept) <= max_chars else kept[: max_chars - 1] + "…"
+
+
+def _shot_link(entry: dict[str, Any], artifact_url: Optional[str]) -> str:
+    shot = _cell(entry.get("screenshot"), max_chars=120)
+    if not shot:
+        return "—"
+    url = artifact_url or entry.get("artifact_url") or ""
+    return f"[`{shot}`]({url})" if url else f"`{shot}`"
+
+
+def render_section(
+    entries: Iterable[dict[str, Any]],
+    *,
+    artifact_url: Optional[str] = None,
+    max_chars: int = SECTION_MAX_CHARS,
+) -> str:
+    """The "New-user friction" block: one table per feature, worst severity first.
+
+    Never longer than ``max_chars``: once the budget is spent the remaining rows
+    (already sorted, so the worst are the ones shown) are summarised in one
+    line, because the block is embedded in issue bodies and comments GitHub caps
+    at 65,536 characters.
+    """
+    rows = sort_entries(entries)
+    lines = ["## New-user friction", ""]
+    if not rows:
+        lines.append("_The tester reported nothing confusing in this run._")
+        return "\n".join(lines) + "\n"
+    counts = {s: sum(1 for r in rows if r["severity"] == s) for s in SEVERITIES}
+    lines.append(
+        f"_{len(rows)} moment(s) where a first-time user stalled: "
+        + " · ".join(f"{counts[s]} {s}" for s in SEVERITIES)
+        + ". Reported by the tester persona beside the verdict; a scenario can PASS and still list friction._"
+    )
+    current = None
+    used = sum(len(line) + 1 for line in lines)
+    shown = 0
+    for r in rows:
+        chunk: list[str] = []
+        if r["feature"] != current:
+            chunk += [
+                "",
+                f"### {FEATURES.get(r['feature'], r['feature'])} (`{r['feature']}`)",
+                "",
+                "| Severity | What confused me | Where | Expected → actual | Seen | Screenshot |",
+                "|---|---|---|---|---|---|",
+            ]
+        seen = f"{int(r.get('count', 1))}× · last {r.get('last_seen', '')}".strip(" ·")
+        if int(r.get("count", 1)) == 1:
+            seen = "new"
+        issue = r.get("issue")
+        if issue:
+            seen += f" · #{int(issue)}"
+        chunk.append(
+            f"| {r['severity']} | {_cell(r['what_confused'])} | {_cell(r['surface'])} → {_cell(r['element'])} "
+            f"| {_cell(r['expected'])} → {_cell(r['actual'])} | {seen} | {_shot_link(r, artifact_url)} |"
+        )
+        cost = sum(len(line) + 1 for line in chunk)
+        if used + cost > max_chars - 160:  # keep room for the closing line
+            break
+        lines += chunk
+        used += cost
+        shown += 1
+        current = r["feature"]
+    if shown < len(rows):
+        lines += [
+            "",
+            f"_… {len(rows) - shown} more row(s) not shown to keep this report within GitHub's "
+            "size limit; every row is in the run artifact's `friction.json`._",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------
+# Issues
+# --------------------------------------------------------------------------
+
+
+def issue_title(row: dict[str, Any]) -> str:
+    text = _cell(row["what_confused"], max_chars=90)
+    return f"ux({row['feature']}): {text}"
+
+
+def issue_body(key: str, row: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            f"{ISSUE_MARKER}{key} -->",
+            f"A first-time user drove `{row.get('scenario', '')}` (feature `{row['feature']}`) in the nightly "
+            f"GUI user test and stalled here. Severity **{row['severity']}**. Opened by the lane; the wording "
+            "below is the tester's, in the first person.",
+            "",
+            f"- **Where:** {_cell(row['surface'])} → {_cell(row['element'])}",
+            f"- **What confused me:** {_cell(row['what_confused'])}",
+            f"- **Expected:** {_cell(row['expected'])}",
+            f"- **Actual:** {_cell(row['actual'])}",
+            f"- **First seen:** {row.get('first_seen', '')} · **seen** {int(row.get('count', 1))}×"
+            + (
+                " · earlier issue(s): " + ", ".join(f"#{int(n)}" for n in row["closed_issues"])
+                if row.get("closed_issues")
+                else ""
+            ),
+            f"- **Screenshot:** {_shot_link(row, None)} · [run]({row.get('run_url', '')}) · `{row.get('head_sha', '')}`",
+            "",
+            "Recurrences are appended as comments by the lane; close when the confusion is gone (the lane "
+            "reopens nothing -- a sighting after the close opens a new issue that links back here).",
+            "",
+            "Lane: `.github/workflows/gui-user-test.yml` · docs: `docs/build/gui-user-test.md` · tracking: #9578",
+        ]
+    )
+
+
+def plan_issues(ledger: dict[str, Any], *, date: str, cap: int = ISSUE_CAP) -> dict[str, list[str]]:
+    """Which ledger keys get a new issue tonight, which get a recurrence comment.
+
+    Cosmetic rows never leave the summary. Every non-cosmetic row in the ledger
+    that has no issue yet is a candidate -- tonight's sightings first, then rows
+    an earlier night's cap held over, each group in registry-then-severity
+    order -- and the first ``cap`` are opened. A row seen tonight that already
+    has an issue and a count above one gets an "again on <date>" comment, once
+    per date (``last_commented`` makes a same-day rerun idempotent).
+    """
+    seen_tonight = {r["key"] for r in tonight(ledger, date)}
+    unissued = [
+        {**row, "key": key}
+        for key, row in ledger["entries"].items()
+        if row["severity"] != "cosmetic" and not row.get("issue")
+    ]
+    ordered = sort_entries([r for r in unissued if r["key"] in seen_tonight]) + sort_entries(
+        [r for r in unissued if r["key"] not in seen_tonight]
+    )
+    create = [r["key"] for r in ordered[:cap]]
+    comment = [
+        r["key"]
+        for r in tonight(ledger, date)
+        if r["severity"] != "cosmetic"
+        and r.get("issue")
+        and int(r.get("count", 1)) > 1
+        and r.get("last_commented") != date  # a same-day rerun must not post the comment twice
+    ]
+    return {"create": create, "comment": comment}
+
+
+Runner = Callable[[list[str]], str]
+
+
+def _full_name(repo_block: Any) -> Optional[str]:
+    """``owner/name`` from an API repository block, None when it is missing or malformed."""
+    if not isinstance(repo_block, dict):
+        return None
+    name = repo_block.get("full_name")
+    return name if isinstance(name, str) else None
+
+
+def ledger_source_run(
+    run: Any,
+    *,
+    repo: str,
+    branch: str,
+    workflow_path: str = WORKFLOW_PATH,
+    event: str = LEDGER_EVENT,
+    require_completed: bool = True,
+) -> Optional[int]:
+    """The run's id if every provenance field says it may supply the ledger, else None.
+
+    ``run`` is one Actions API run object. It qualifies only when it is a run OF
+    this workflow file, fired BY the trusted event, ON the trusted branch, whose
+    head and base repository are both this repository (never a fork), and --
+    unless ``require_completed`` is off, which only the current run's own prior
+    attempt earns -- that completed with a conclusion in
+    :data:`LEDGER_CONCLUSIONS`. Anything malformed is None, never guessed at.
+    """
+    if not isinstance(run, dict):
+        return None
+    run_id = run.get("id")
+    if not isinstance(run_id, int) or isinstance(run_id, bool):
+        return None
+    if run.get("path") != workflow_path or run.get("event") != event:
+        return None
+    if run.get("head_branch") != branch:
+        return None
+    if require_completed and (
+        run.get("status") != "completed" or run.get("conclusion") not in LEDGER_CONCLUSIONS
+    ):
+        return None
+    if _full_name(run.get("repository")) != repo or _full_name(run.get("head_repository")) != repo:
+        return None
+    return run_id
+
+
+def ledger_source_runs(
+    runs: Iterable[Any],
+    *,
+    repo: str,
+    branch: str,
+    workflow_path: str = WORKFLOW_PATH,
+    event: str = LEDGER_EVENT,
+    exclude_run_id: Optional[int] = None,
+) -> list[int]:
+    """Ids of the completed runs that may supply the previous ledger, newest first.
+
+    ``runs`` is the ``workflow_runs`` list of the Actions API; each is judged by
+    :func:`ledger_source_run`. ``exclude_run_id`` (the current run) is left out
+    here because :func:`pick_ledger` consults it separately, and first.
+    """
+    picked: list[tuple[str, int]] = []
+    for run in runs:
+        run_id = ledger_source_run(
+            run, repo=repo, branch=branch, workflow_path=workflow_path, event=event
+        )
+        if run_id is None or run_id == exclude_run_id:
+            continue
+        picked.append((str(run.get("created_at") or ""), run_id))
+    picked.sort(reverse=True)
+    return [run_id for _, run_id in picked]
+
+
+def ledger_artifact_id(
+    artifacts: Iterable[Any], *, run_id: int, branch: str, name: str = LEDGER_ARTIFACT
+) -> Optional[int]:
+    """The id of the live ledger artifact that ``run_id`` itself produced, else None.
+
+    ``artifacts`` is the ``artifacts`` list of ``GET /actions/runs/{id}/artifacts``.
+    The artifact's own ``workflow_run`` block must name the trusted run and
+    branch -- the listing was scoped to the run, but the check is repeated here
+    so a wrong listing (or a wrong caller) cannot slip a foreign artifact in.
+    """
+    for art in artifacts:
+        if not isinstance(art, dict) or art.get("name") != name or art.get("expired"):
+            continue
+        wf = art.get("workflow_run")
+        if not isinstance(wf, dict) or wf.get("id") != run_id or wf.get("head_branch") != branch:
+            continue
+        art_id = art.get("id")
+        if isinstance(art_id, int) and not isinstance(art_id, bool):
+            return art_id
+    return None
+
+
+def _ledger_of_run(
+    run_id: int, *, branch: str, fetch: Callable[[str], Any]
+) -> Optional[dict[str, Optional[int]]]:
+    arts = fetch(f"actions/runs/{run_id}/artifacts?name={LEDGER_ARTIFACT}")
+    items = arts.get("artifacts") if isinstance(arts, dict) else None
+    if not isinstance(items, list):
+        raise FrictionError(f"artifact listing for run {run_id} has no artifacts list")
+    art_id = ledger_artifact_id(items, run_id=run_id, branch=branch)
+    return None if art_id is None else {"run_id": run_id, "artifact_id": art_id}
+
+
+def pick_ledger(
+    *,
+    repo: str,
+    branch: str,
+    self_run_id: Optional[int],
+    fetch: Callable[[str], Any],
+    per_page: int = 100,
+) -> dict[str, Optional[int]]:
+    """Resolve the previous ledger's (run id, artifact id) through ``fetch``.
+
+    ``fetch(path)`` returns the decoded JSON of ``GET /repos/{repo}/{path}`` and
+    raises on any API failure -- a failure propagates, because a retrieval error
+    is not a first night (the caller must refuse to start a fresh ledger). Only a
+    complete answer with NO eligible run or artifact yields ``{"run_id": None,
+    "artifact_id": None}``.
+
+    The current run (``self_run_id``) is consulted FIRST, by fetching its own
+    run object and judging it like any other except that it may still be in
+    progress: on a re-run of a scheduled night the earlier attempt already
+    filed issues and uploaded the ledger that records them, and reading last
+    night's ledger instead would file them all again. A ledger is uploaded only
+    after the merge step succeeded, so a prior attempt's artifact is a whole
+    night, never a half-written one. A current run that is not itself a trusted
+    scheduled run (a dispatch, a pull request) never wrote a ledger and is
+    skipped. Then the completed candidates are walked newest first and the
+    first run that still holds a live ledger artifact wins, so a night whose
+    merge step failed (and uploaded nothing) is skipped rather than treated as
+    a reset.
+    """
+    if self_run_id is not None:
+        me = fetch(f"actions/runs/{self_run_id}")
+        if ledger_source_run(me, repo=repo, branch=branch, require_completed=False) == self_run_id:
+            mine = _ledger_of_run(self_run_id, branch=branch, fetch=fetch)
+            if mine is not None:
+                return mine
+    # Walk the completed nightlies page by page, newest first, until one holds a
+    # ledger or the listing runs dry. A single page would turn a long streak of
+    # merge-step failures into a false "first night" while an older ledger still
+    # sits inside its retention window; MAX_RUN_PAGES bounds the walk well past
+    # that window (nightly cadence, 90-day artifact retention).
+    for page in range(1, MAX_RUN_PAGES + 1):
+        listing = fetch(
+            f"actions/workflows/{Path(WORKFLOW_PATH).name}/runs"
+            f"?event={LEDGER_EVENT}&branch={branch}&status=completed"
+            f"&per_page={per_page}&page={page}"
+        )
+        runs = listing.get("workflow_runs") if isinstance(listing, dict) else None
+        if not isinstance(runs, list):
+            raise FrictionError("workflow runs listing has no workflow_runs list")
+        for run_id in ledger_source_runs(
+            runs, repo=repo, branch=branch, exclude_run_id=self_run_id
+        ):
+            found = _ledger_of_run(run_id, branch=branch, fetch=fetch)
+            if found is not None:
+                return found
+        if len(runs) < per_page:
+            break
+    return {"run_id": None, "artifact_id": None}
+
+
+def _gh(args: list[str]) -> str:
+    proc = subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    )
+    return proc.stdout
+
+
+Persist = Callable[[dict[str, Any]], None]
+
+
+def _existing_issue(run: Runner, *, repo: str, key: str) -> Optional[int]:
+    """The number of an OPEN issue whose body carries ``key``'s marker, else None.
+
+    Searches by the key (a hex digest, so the search is exact enough) and then
+    checks the literal marker in each body, so a stray mention of the digest in
+    prose cannot be adopted. Raises on a ``gh`` failure or an unreadable answer.
+    """
+    out = run(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            LABEL_UX,
+            "--search",
+            f"{key} in:body",
+            "--json",
+            "number,body",
+            "--limit",
+            "20",
+        ]
+    )
+    marker = f"{ISSUE_MARKER}{key} -->"
+    for item in json.loads(out):
+        if not isinstance(item, dict) or marker not in str(item.get("body") or ""):
+            continue
+        number = item.get("number")
+        if isinstance(number, int) and not isinstance(number, bool):
+            return number
+    return None
+
+
+def file_issues(
+    ledger: dict[str, Any],
+    *,
+    repo: str,
+    date: str,
+    run: Runner = _gh,
+    cap: int = ISSUE_CAP,
+    persist: Optional[Persist] = None,
+) -> dict[str, Any]:
+    """Open / comment the planned issues via ``gh``; record issue numbers in the ledger.
+
+    ``persist`` (the ledger writer) is called after EVERY successful ``gh``
+    mutation, so a failure partway through a batch never loses the numbers of
+    the issues already opened -- a rerun would otherwise open them twice. A
+    failed create or comment is recorded under ``failed`` and the batch goes on.
+    """
+    rows = ledger["entries"]
+    failed: list[dict[str, str]] = []
+
+    def save() -> None:
+        if persist is not None:
+            persist(ledger)
+
+    # A recurrence whose issue a human has since CLOSED is a new sighting, not a
+    # comment on a closed thread: forget the mapping (kept under ``closed_issues``)
+    # so the plan below opens a fresh issue. Unknown state (gh error) keeps the
+    # mapping and the comment path -- never lose a number on a transient failure.
+    for row in tonight(ledger, date):
+        issue = row.get("issue")
+        if not issue:
+            continue
+        try:
+            state = json.loads(
+                run(["issue", "view", str(issue), "--repo", repo, "--json", "state"])
+            ).get("state")
+        except (subprocess.CalledProcessError, ValueError):
+            continue
+        if state == "CLOSED":
+            live = rows[row["key"]]
+            live.setdefault("closed_issues", []).append(int(issue))
+            live["issue"] = None
+            live.pop("last_commented", None)
+            save()
+
+    plan = plan_issues(ledger, date=date, cap=cap)
+
+    for label, color, desc in (
+        (LABEL_UX, "D4C5F9", "New-user confusion reported by the GUI user-test persona"),
+        (LABEL_CHANNEL, "0E8A16", "Filed by the nightly GUI user-test lane"),
+    ):
+        try:
+            run(
+                [
+                    "label",
+                    "create",
+                    label,
+                    "--repo",
+                    repo,
+                    "--color",
+                    color,
+                    "--description",
+                    desc,
+                    "--force",
+                ]
+            )
+        except subprocess.CalledProcessError:
+            pass  # the label exists or labels are not ours to make; create still works
+    opened: list[int] = []
+    adopted: list[int] = []
+    for key in plan["create"]:
+        row = rows[key]
+        # The ledger may have lost this key's number (the run that opened the
+        # issue was cancelled before it uploaded): an OPEN issue already carrying
+        # the key's marker is adopted, never duplicated. A failed lookup skips
+        # the key for tonight -- a duplicate is worse than a night's delay.
+        try:
+            existing = _existing_issue(run, repo=repo, key=key)
+        except (subprocess.CalledProcessError, ValueError) as exc:
+            failed.append({"key": key, "op": "reconcile", "error": str(exc)})
+            continue
+        if existing is not None:
+            row["issue"] = existing
+            adopted.append(existing)
+            save()
+            continue
+        try:
+            out = run(
+                [
+                    "issue",
+                    "create",
+                    "--repo",
+                    repo,
+                    "--title",
+                    issue_title(row),
+                    "--body",
+                    issue_body(key, row),
+                    "--label",
+                    LABEL_UX,
+                    "--label",
+                    LABEL_CHANNEL,
+                    "--label",
+                    AREA_LABELS.get(row["feature"], DEFAULT_AREA_LABEL),
+                ]
+            )
+        except subprocess.CalledProcessError as exc:
+            failed.append({"key": key, "op": "create", "error": str(exc)})
+            continue
+        m = re.search(r"/issues/(\d+)", out)
+        if not m:
+            failed.append({"key": key, "op": "create", "error": "no issue URL in gh output"})
+            continue
+        row["issue"] = int(m.group(1))
+        opened.append(row["issue"])
+        save()
+    commented: list[int] = []
+    for key in plan["comment"]:
+        row = rows[key]
+        body = (
+            f"Again on {date} ({int(row.get('count', 1))}× so far, severity {row['severity']}): "
+            f"{_cell(row['what_confused'])} — {_shot_link(row, None)} · [run]({row.get('run_url', '')})"
+        )
+        try:
+            run(["issue", "comment", str(row["issue"]), "--repo", repo, "--body", body])
+        except subprocess.CalledProcessError as exc:
+            failed.append({"key": key, "op": "comment", "error": str(exc)})
+            continue
+        row["last_commented"] = date
+        commented.append(int(row["issue"]))
+        save()
+    return {"opened": opened, "adopted": adopted, "commented": commented, "failed": failed}
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _write(path: Path, doc: Any) -> None:
+    """Write ``doc`` as JSON, atomically.
+
+    The ledger is written after every ``gh`` mutation and then uploaded by a
+    step that only checks the file exists, so a write cut short (disk full, a
+    killed runner) must never leave a truncated file under the canonical name:
+    the next night would fail to load it, upload nothing, and keep failing until
+    someone deleted the artifact by hand. The document goes to a sibling
+    temporary file first and is renamed over the target only once it is fully
+    on disk; ``os.replace`` is atomic on every platform the lane runs on.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(description="new-user friction: merge, render, file issues")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    m = sub.add_parser("merge", help="fold summary.json into the ledger; write friction.json")
+    m.add_argument("--summary", type=Path, required=True)
+    m.add_argument("--ledger", type=Path, help="previous night's ledger (optional)")
+    m.add_argument("--out", type=Path, required=True, help="friction.json for this run")
+    m.add_argument("--out-ledger", type=Path, required=True)
+    m.add_argument("--date", required=True, help="YYYY-MM-DD of this run")
+    m.add_argument("--run-url", default="")
+    m.add_argument("--artifact-url", default="")
+    m.add_argument("--head-sha", default="")
+
+    r = sub.add_parser(
+        "snapshot", help="rewrite friction.json (tonight's rows) from the ledger, e.g. after issues"
+    )
+    r.add_argument("--ledger", type=Path, required=True)
+    r.add_argument("--out", type=Path, required=True, help="the friction.json `merge` wrote")
+    r.add_argument("--date", required=True)
+
+    i = sub.add_parser("issues", help="open / comment GitHub issues for tonight's ledger rows")
+    i.add_argument("--ledger", type=Path, required=True)
+    i.add_argument("--repo", required=True)
+    i.add_argument("--date", required=True)
+    i.add_argument(
+        "--artifact-url",
+        default="",
+        help="this run's artifact URL, stamped on tonight's rows so issue screenshot links resolve",
+    )
+    i.add_argument(
+        "--friction",
+        type=Path,
+        help="this run's friction.json: only ITS rows (run_keys) get --artifact-url stamped",
+    )
+    i.add_argument("--dry-run", action="store_true")
+
+    k = sub.add_parser(
+        "pick-ledger",
+        help="resolve the previous ledger: newest scheduled run of this workflow on the trusted branch",
+    )
+    k.add_argument("--repo", required=True)
+    k.add_argument("--branch", required=True, help="the trusted branch (the default branch)")
+    k.add_argument(
+        "--self-run",
+        type=int,
+        default=None,
+        help="this run's id: a prior attempt's ledger is preferred, the run is otherwise skipped",
+    )
+    k.add_argument(
+        "--out", type=Path, required=True, help='where to write {"run_id": ..., "artifact_id": ...}'
+    )
+
+    args = p.parse_args(argv)
+    try:
+        if args.cmd == "merge":
+            summary = json.loads(args.summary.read_text(encoding="utf-8"))
+            ledger = load_ledger(args.ledger)
+            entries = collect(summary)
+            ledger, new_keys = merge_ledger(
+                ledger,
+                entries,
+                date=args.date,
+                run_url=args.run_url,
+                artifact_url=args.artifact_url,
+                head_sha=args.head_sha,
+            )
+            run_keys = [e["key"] for e in entries]
+            rows = rows_for(ledger, run_keys)
+            _write(
+                args.out,
+                {
+                    "date": args.date,
+                    "head_sha": args.head_sha,
+                    "run_url": args.run_url,
+                    "artifact_url": args.artifact_url,
+                    "run_keys": run_keys,
+                    "new_keys": new_keys,
+                    "entries": rows,
+                },
+            )
+            _write(args.out_ledger, ledger)
+            print(
+                f"{len(rows)} friction entr{'y' if len(rows) == 1 else 'ies'}, {len(new_keys)} new"
+            )
+        elif args.cmd == "snapshot":
+            ledger = load_ledger(args.ledger)
+            if not args.out.exists():
+                raise FrictionError(f"{args.out}: snapshot needs the friction.json `merge` wrote")
+            prior = json.loads(args.out.read_text(encoding="utf-8"))
+            run_keys = [str(k) for k in prior.get("run_keys") or []]
+            rows = rows_for(ledger, run_keys)
+            _write(
+                args.out,
+                {
+                    "date": args.date,
+                    "head_sha": prior.get("head_sha", ""),
+                    "run_url": prior.get("run_url", ""),
+                    "artifact_url": prior.get("artifact_url", ""),
+                    "run_keys": run_keys,
+                    "new_keys": prior.get("new_keys", []),
+                    "entries": rows,
+                },
+            )
+            print(f"{len(rows)} friction entr{'y' if len(rows) == 1 else 'ies'} snapshotted")
+        elif args.cmd == "pick-ledger":
+            picked = pick_ledger(
+                repo=args.repo,
+                branch=args.branch,
+                self_run_id=args.self_run,
+                fetch=lambda path: json.loads(_gh(["api", f"repos/{args.repo}/{path}"])),
+            )
+            # To a file, not stdout: the workflow reads it with jq, and nothing
+            # that came back from the API is echoed into the job log.
+            _write(args.out, picked)
+            print("no previous ledger" if picked["run_id"] is None else "previous ledger found")
+        else:
+            ledger = load_ledger(args.ledger)
+            if args.artifact_url:
+                # Only the rows THIS run observed: a re-run that did not see an
+                # earlier attempt's row must not point that row's screenshot at
+                # an artifact which does not hold it. Without the run's
+                # friction.json nothing is stamped.
+                if args.friction is None:
+                    raise FrictionError("--artifact-url needs --friction (the run's own keys)")
+                own = json.loads(args.friction.read_text(encoding="utf-8"))
+                for key in own.get("run_keys") or []:
+                    row = ledger["entries"].get(str(key))
+                    if row is not None:
+                        row["artifact_url"] = args.artifact_url
+            if args.dry_run:
+                print(json.dumps(plan_issues(ledger, date=args.date), indent=2))
+                return 0
+            _write(args.ledger, ledger)  # the artifact-url stamp, before any gh call
+            result = file_issues(
+                ledger,
+                repo=args.repo,
+                date=args.date,
+                persist=lambda led: _write(args.ledger, led),
+            )
+            print(json.dumps(result))
+            if result["failed"]:
+                print(f"friction: {len(result['failed'])} gh call(s) failed", file=sys.stderr)
+                return 2
+    except (OSError, ValueError, KeyError, subprocess.CalledProcessError) as exc:
+        print(f"friction: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/gui_user/harness.py
+++ b/test/gui_user/harness.py
@@ -5,7 +5,11 @@ One process runs a list of scenarios (``scenarios.py``) against a dashboard that
 
     screenshot -> Bedrock Messages API -> action -> xdotool (x11.py) -> screenshot ...
 
-until the model answers with a ``VERDICT`` block or a gate trips. Gates, in
+until the model answers with a ``VERDICT`` block or a gate trips. Beside the
+verdict runs a second, independent channel: the tester persona
+(``scenarios.PERSONAS``) files ``report_friction`` entries whenever the app
+confused it (``friction.py``); they land in ``summary.json`` per attempt and
+never touch PASS/FAIL. Gates, in
 order of what they protect: ``max_steps`` / ``max_seconds`` per scenario (a
 looping model), ``--budget-usd`` per run (the bill), one retry per failed
 scenario (a flaky click). Everything the run did lands under ``--out``:
@@ -39,7 +43,7 @@ from typing import Any, Optional
 if __package__ in (None, ""):  # ``python test/gui_user/harness.py`` -- make ``gui_user`` importable
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from gui_user import report, x11  # noqa: E402
+from gui_user import friction, report, x11  # noqa: E402
 from gui_user.scenarios import Scenario, ScenarioError, load_all, select  # noqa: E402
 
 BEDROCK_ANTHROPIC_VERSION = "bedrock-2023-05-31"
@@ -73,6 +77,14 @@ EXPECTATIONS:
 - <expectation text, shortened> : MET or NOT MET -- one line of evidence from the last screenshot
 UI-ISSUES: none, or one line per visual defect you noticed on the way (overlap, clipped or unreadable text, misaligned elements, unexpected scrollbars, poor contrast, a stuck spinner)
 """
+
+
+def system_prompt(scenario: Scenario) -> str:
+    """The base prompt plus the scenario's persona block (none for ``persona: none``)."""
+    persona = scenario.persona_prompt
+    if not persona:
+        return SYSTEM_PROMPT
+    return SYSTEM_PROMPT.replace("\nHOW TO WORK:", f"\n{persona}\n\nHOW TO WORK:", 1)
 
 
 # --------------------------------------------------------------------------
@@ -328,6 +340,8 @@ class AttemptResult:
     final_text: str
     error: str = ""
     shots_dir: str = ""
+    #: ``friction.validate_entry`` records, in the order the tester filed them.
+    friction: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -400,14 +414,17 @@ class Runner:
     def spent(self) -> float:
         return self.usage.usd(self.price_in, self.price_out)
 
-    def _tools(self) -> list[dict[str, Any]]:
-        return native_tools(self.display.geo) if self.tool_mode == "native" else custom_tools()
+    def _tools(self, scenario: Scenario) -> list[dict[str, Any]]:
+        tools = native_tools(self.display.geo) if self.tool_mode == "native" else custom_tools()
+        if scenario.reports_friction:
+            tools = [*tools, friction.FRICTION_TOOL]
+        return tools
 
-    def _body(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
+    def _body(self, scenario: Scenario, messages: list[dict[str, Any]]) -> dict[str, Any]:
         body: dict[str, Any] = {
             "max_tokens": MAX_TOKENS,
-            "system": SYSTEM_PROMPT,
-            "tools": self._tools(),
+            "system": system_prompt(scenario),
+            "tools": self._tools(scenario),
             "messages": messages,
         }
         if self.tool_mode == "native":
@@ -435,10 +452,14 @@ class Runner:
         final_text = ""
         status = "NO_VERDICT"
         error = ""
+        entries: list[dict[str, Any]] = []
+        rel_shots = str(shots.relative_to(self.out))
+        last_shot = ""
 
         try:
             self.navigate(scenario.start_url, log)
             png, path = self.display.screenshot("start")
+            last_shot = f"{rel_shots}/{path.name}"
             log.write("screenshot", label="start", file=path.name)
             messages: list[dict[str, Any]] = [
                 {
@@ -462,7 +483,7 @@ class Runner:
                     raise BudgetExceeded(f"run budget ${self.budget_usd:.2f} reached mid-scenario")
 
                 try:
-                    result = self.client.messages(self._body(messages))
+                    result = self.client.messages(self._body(scenario, messages))
                 except ComputerUseUnavailable as exc:
                     if self.tool_mode != "native":
                         raise
@@ -487,13 +508,37 @@ class Runner:
                     break
 
                 results: list[dict[str, Any]] = []
+                # Every tool_use in one response was decided from the SAME screen --
+                # the last screenshot the model was shown -- so a friction entry in
+                # a batch cites that screen and step, not the state after an
+                # action that happens to precede it in the batch.
+                seen_shot, seen_step = last_shot, steps
                 for tu in tool_uses:
                     action, params = decode_tool_use(tu)
+                    if action == friction.FRICTION_TOOL["name"]:
+                        # The friction channel: no screen action, no step counted,
+                        # never an error the model has to recover from.
+                        results.append(
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": tu.get("id"),
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": self._record_friction(
+                                            scenario, params, entries, seen_shot, seen_step, log
+                                        ),
+                                    }
+                                ],
+                            }
+                        )
+                        continue
                     steps += 1
                     try:
                         summary = self.display.perform(action, params)
                         self.display.settle()
                         png, path = self.display.screenshot(action)
+                        last_shot = f"{rel_shots}/{path.name}"
                         log.write(
                             "action", action=action, params=params, result=summary, file=path.name
                         )
@@ -540,8 +585,41 @@ class Runner:
             usd=round((delta_in * self.price_in + delta_out * self.price_out) / 1_000_000, 4),
             final_text=final_text,
             error=error,
-            shots_dir=str(shots.relative_to(self.out)),
+            shots_dir=rel_shots,
+            friction=entries,
         )
+
+    def _record_friction(
+        self,
+        scenario: Scenario,
+        params: dict[str, Any],
+        entries: list[dict[str, Any]],
+        screenshot: str,
+        step: int,
+        log: StepLog,
+    ) -> str:
+        """Validate and store one ``report_friction`` call; the returned text goes back to the model."""
+        if len(entries) >= friction.ATTEMPT_CAP:
+            log.write("friction_dropped", reason="attempt cap", params=params)
+            return "Friction log is full for this task; continue with the steps."
+        try:
+            entry = friction.validate_entry(
+                params,
+                feature=scenario.feature,
+                scenario=scenario.name,
+                screenshot=screenshot,
+                step=step,
+            )
+        except friction.FrictionError as exc:
+            log.write("friction_rejected", error=str(exc), params=params)
+            return f"Not recorded ({exc}). Continue with the steps."
+        if any(e["key"] == entry["key"] for e in entries):
+            log.write("friction_duplicate", key=entry["key"])
+            return "Already noted. Continue with the steps."
+        entries.append(entry)
+        log.write("friction", **entry)
+        print(f"[{scenario.name}] friction ({entry['severity']}): {entry['what_confused'][:80]}")
+        return "Noted. Continue with the steps."
 
     def run(self, scenarios: list[Scenario], *, retries: int) -> list[ScenarioResult]:
         results: list[ScenarioResult] = []
@@ -575,6 +653,16 @@ class Runner:
 
 class BudgetExceeded(RuntimeError):
     pass
+
+
+def friction_channel_ran(scenarios: list[Scenario], *, dry_run: bool) -> bool:
+    """Whether ``summary.json`` should carry ``friction_count``.
+
+    Only a real run of at least one friction-reporting persona counts: a dry run
+    or a ``persona: none`` selection never asked the tester, so its report must
+    not read "nothing confusing".
+    """
+    return not dry_run and any(sc.reports_friction for sc in scenarios)
 
 
 # --------------------------------------------------------------------------
@@ -693,6 +781,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         "budget_usd": args.budget_usd,
         "scenarios": [asdict(r) for r in results],
     }
+    if friction_channel_ran(scenarios, dry_run=args.dry_run):
+        summary["friction_count"] = len(friction.collect(summary))
     (args.out / "summary.json").write_text(
         json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
     )

--- a/test/gui_user/report.py
+++ b/test/gui_user/report.py
@@ -9,6 +9,11 @@ DSL (``scenarios.py``, pure YAML) for the feature titles and for the
 Every table is grouped by ``feature``: the nightly report reads as "which
 product areas are healthy", and each row carries the scenario's ``user_story``
 so a reader who has never opened the YAML knows what the user was trying to do.
+
+Below the verdict tables sits the "New-user friction" section (``friction.py``):
+what confused the tester persona, grouped the same way. It is rendered whenever
+the run carried the channel (``summary["friction_count"]`` is present), so a
+night with nothing confusing says so instead of going silent.
 """
 
 from __future__ import annotations
@@ -22,6 +27,7 @@ from typing import Any, Iterable, Optional
 if __package__ in (None, ""):  # ``python test/gui_user/report.py`` -- make ``gui_user`` importable
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from gui_user import friction  # noqa: E402
 from gui_user.scenarios import (  # noqa: E402
     FEATURES,
     Scenario,
@@ -191,9 +197,17 @@ def _final_text_blocks(summary: dict[str, Any]) -> list[str]:
 
 
 def render_markdown(
-    summary: dict[str, Any], *, artifact_url: Optional[str] = None, run_url: Optional[str] = None
+    summary: dict[str, Any],
+    *,
+    artifact_url: Optional[str] = None,
+    run_url: Optional[str] = None,
+    friction_entries: Optional[list[dict[str, Any]]] = None,
 ) -> str:
-    """``verdict.md`` body (no marker, no header badge line): one table per feature."""
+    """``verdict.md`` body (no marker, no header badge line): one table per feature.
+
+    ``friction_entries`` overrides the run's own entries with the ledger-aware
+    rows of ``friction.json`` (counts, last-seen dates, issue numbers).
+    """
     lines: list[str] = []
     for slug, group in group_by_feature(summary.get("scenarios", [])).items():
         if lines:
@@ -222,6 +236,9 @@ def render_markdown(
     blocks = _final_text_blocks(summary)
     if blocks:
         lines += [""] + blocks
+    if friction_entries is not None or "friction_count" in summary:
+        entries = friction_entries if friction_entries is not None else friction.collect(summary)
+        lines += ["", friction.render_section(entries, artifact_url=artifact_url).rstrip()]
     return "\n".join(lines) + "\n"
 
 
@@ -235,6 +252,17 @@ def render_console(summary: dict[str, Any]) -> str:
                 f"    {sc.get('status', ''):7} {sc.get('name'):28} steps={last.get('steps', 0)} "
                 f"t={last.get('seconds', 0)}s attempts={len(sc.get('attempts') or [])}"
             )
+    if "friction_count" in summary:
+        entries = friction.collect(summary)
+        by_sev = {s: sum(1 for e in entries if e["severity"] == s) for s in friction.SEVERITIES}
+        rows.append(
+            "  new-user friction: "
+            + (
+                " · ".join(f"{n} {s}" for s, n in by_sev.items() if n)
+                if entries
+                else "none reported"
+            )
+        )
     return "\n".join(
         [
             f"GUI user test: {overall(summary)}  (${float(summary.get('usd', 0)):.2f}, mode {summary.get('tool_mode')})"
@@ -293,7 +321,12 @@ def render_features(
 
 
 def render_comment(
-    summary: dict[str, Any], *, head_sha: str, artifact_url: Optional[str], run_url: Optional[str]
+    summary: dict[str, Any],
+    *,
+    head_sha: str,
+    artifact_url: Optional[str],
+    run_url: Optional[str],
+    friction_entries: Optional[list[dict[str, Any]]] = None,
 ) -> str:
     """Upserted PR comment. Advisory: the badge is information, not a gate."""
     verdict = overall(summary)
@@ -306,7 +339,12 @@ def render_comment(
                 f"_A model drove a real browser on Xvfb through the `{summary.get('tier')}` scenarios against a seeded "
                 f"gateway built from `{head_sha}`. Advisory — does not block merge. Updated in place on each run._",
                 "",
-                render_markdown(summary, artifact_url=artifact_url, run_url=run_url).rstrip(),
+                render_markdown(
+                    summary,
+                    artifact_url=artifact_url,
+                    run_url=run_url,
+                    friction_entries=friction_entries,
+                ).rstrip(),
                 "",
                 f"{REVIEWED_MARKER} {head_sha}",
             ]
@@ -316,7 +354,12 @@ def render_comment(
 
 
 def render_issue(
-    summary: dict[str, Any], *, sha: str, run_url: Optional[str], artifact_url: Optional[str]
+    summary: dict[str, Any],
+    *,
+    sha: str,
+    run_url: Optional[str],
+    artifact_url: Optional[str],
+    friction_entries: Optional[list[dict[str, Any]]] = None,
 ) -> tuple[str, str]:
     """(title, body) for the nightly failure issue."""
     verdict = overall(summary)
@@ -326,7 +369,12 @@ def render_issue(
         [
             f"The nightly agentic GUI user test finished **{verdict}** on `main` at `{sha}`.",
             "",
-            render_markdown(summary, artifact_url=artifact_url, run_url=run_url).rstrip(),
+            render_markdown(
+                summary,
+                artifact_url=artifact_url,
+                run_url=run_url,
+                friction_entries=friction_entries,
+            ).rstrip(),
             "",
             "Open the artifact for per-step screenshots and `steps.jsonl`; a scenario that fails two nights in a row "
             "with the same final report is a real regression, one that flips is a flake to file against the scenario.",
@@ -348,7 +396,25 @@ def main(argv: Optional[list[str]] = None) -> int:
     p.add_argument("--head-sha", default="")
     p.add_argument("--run-url", default="")
     p.add_argument("--artifact-url", default="")
+    p.add_argument(
+        "--friction",
+        type=Path,
+        help="friction.json from `friction.py merge` (ledger-aware rows replace the run's own)",
+    )
     args = p.parse_args(argv)
+
+    friction_entries: Optional[list[dict[str, Any]]] = None
+    if args.friction is not None:
+        try:
+            fdoc = json.loads(args.friction.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"could not read {args.friction}: {exc}", file=sys.stderr)
+            return 2
+        rows = fdoc.get("entries") if isinstance(fdoc, dict) else None
+        if not isinstance(rows, list):
+            print(f"{args.friction}: expected an object with an 'entries' list", file=sys.stderr)
+            return 2
+        friction_entries = [r for r in rows if isinstance(r, dict)]
 
     summary: Optional[dict[str, Any]] = None
     if args.summary is not None:
@@ -379,6 +445,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 head_sha=args.head_sha,
                 artifact_url=args.artifact_url or None,
                 run_url=args.run_url or None,
+                friction_entries=friction_entries,
             ),
             end="",
         )
@@ -388,6 +455,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             sha=args.head_sha,
             run_url=args.run_url or None,
             artifact_url=args.artifact_url or None,
+            friction_entries=friction_entries,
         )
         print(
             title if args.format == "issue-title" else body,
@@ -396,7 +464,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     else:
         print(
             render_markdown(
-                summary, artifact_url=args.artifact_url or None, run_url=args.run_url or None
+                summary,
+                artifact_url=args.artifact_url or None,
+                run_url=args.run_url or None,
+                friction_entries=friction_entries,
             ),
             end="",
         )

--- a/test/gui_user/scenarios.py
+++ b/test/gui_user/scenarios.py
@@ -106,6 +106,31 @@ _DOCS_URL_RE = re.compile(
 MAX_STEPS_CEILING = 40
 MAX_SECONDS_CEILING = 900
 
+#: Who the tester is while it drives a scenario. The text is appended to the
+#: harness system prompt; the ``new-user`` persona also arms the
+#: ``report_friction`` tool (``friction.py``), so confusion is reported beside
+#: the verdict instead of being swallowed by a PASS. ``none`` is the bare
+#: tester with no friction channel -- for a scenario whose subject is the
+#: expert path, or to measure the channel's own cost.
+PERSONAS: dict[str, str] = {
+    "new-user": (
+        "WHO YOU ARE: this is your first time using Kiro Crew. You have not read its documentation "
+        "and nobody has shown it to you. You have used ordinary chat apps and a code editor before, "
+        "so you know what a sidebar, a settings page and a message box are, but every name, icon "
+        "and layout in THIS app is new to you. You are patient and honest about what you do not "
+        "understand.\n"
+        "WHILE YOU WORK: every time you (a) pause for more than a glance to find something, (b) "
+        "cannot find a control, (c) click the wrong thing, (d) do not understand a label, icon or "
+        "message, (e) do not know what is happening right now, or (f) find that the layout hides the "
+        "main action -- call `report_friction` at that moment, once per moment, in your own words, "
+        "and THEN continue the task. Report the confusion even when you got there in the end; the "
+        "point is what slowed you down, not whether you finished. Do not report the same moment "
+        "twice. Filing friction never changes the task, its steps or the verdict."
+    ),
+    "none": "",
+}
+DEFAULT_PERSONA = "new-user"
+
 
 class ScenarioError(ValueError):
     """A scenario file is malformed."""
@@ -126,7 +151,17 @@ class Scenario:
     seed: str = "rich"
     members: tuple[str, ...] = ()
     start_url: str = "/"
+    persona: str = DEFAULT_PERSONA
     path: Path | None = field(default=None, compare=False)
+
+    @property
+    def persona_prompt(self) -> str:
+        """System-prompt text for the persona ('' for ``none``)."""
+        return PERSONAS[self.persona]
+
+    @property
+    def reports_friction(self) -> bool:
+        return bool(self.persona_prompt)
 
     def task_prompt(self) -> str:
         """The user-turn text handed to the model, built only from the YAML."""
@@ -182,6 +217,7 @@ def parse_scenario(doc: Any, path: Path) -> Scenario:
         "expectations",
         "max_steps",
         "max_seconds",
+        "persona",
     }
     if unknown:
         raise ScenarioError(f"{path}: unknown keys {sorted(unknown)}")
@@ -224,6 +260,10 @@ def parse_scenario(doc: Any, path: Path) -> Scenario:
     if not isinstance(summary, str) or not summary.strip() or len(summary) > 200:
         raise ScenarioError(f"{path}: 'summary' must be a short non-empty string")
 
+    persona = doc.get("persona", DEFAULT_PERSONA)
+    if not isinstance(persona, str) or persona not in PERSONAS:
+        raise ScenarioError(f"{path}: 'persona' must be one of {sorted(PERSONAS)}")
+
     pre = doc.get("preconditions") or {}
     if not isinstance(pre, dict):
         raise ScenarioError(f"{path}: 'preconditions' must be a mapping")
@@ -263,6 +303,7 @@ def parse_scenario(doc: Any, path: Path) -> Scenario:
         seed=seed,
         members=tuple(members),
         start_url=start_url,
+        persona=persona,
         path=path,
     )
 

--- a/test/gui_user/test_friction.py
+++ b/test/gui_user/test_friction.py
@@ -1,0 +1,1273 @@
+"""New-user friction channel: entries, ledger, rendering, issue plan, harness routing -- all offline."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from gui_user import friction, harness, report, scenarios
+
+SCENARIOS_DIR = Path(__file__).parent / "scenarios"
+
+
+def _raw(**over) -> dict:
+    base = {
+        "surface": "Settings page",
+        "element": "Developer section header",
+        "what_confused": "I did not expect feature previews to live under Developer.",
+        "expected": "A section named Previews near the top",
+        "actual": "It was the last item, under Developer",
+        "severity": "slows-down",
+    }
+    base.update(over)
+    return base
+
+
+def _entry(**over) -> dict:
+    feature = over.pop("feature", "members")
+    return friction.validate_entry(
+        _raw(**over),
+        feature=feature,
+        scenario="members-dm-hello",
+        screenshot="members-dm-hello/attempt-1/02-left_click.png",
+        step=2,
+    )
+
+
+# --------------------------------------------------------------------------
+# Persona on the scenario
+# --------------------------------------------------------------------------
+
+
+class TestPersona:
+    def test_default_is_new_user_and_arms_the_channel(self) -> None:
+        for sc in scenarios.load_all(SCENARIOS_DIR):
+            assert sc.persona == scenarios.DEFAULT_PERSONA == "new-user"
+            assert sc.reports_friction
+            assert "report_friction" in sc.persona_prompt
+
+    def test_none_persona_disarms_the_channel(self) -> None:
+        sc = dataclasses.replace(scenarios.load_all(SCENARIOS_DIR)[0], persona="none")
+        assert not sc.reports_friction and sc.persona_prompt == ""
+
+    def test_unknown_persona_is_rejected(self, tmp_path: Path) -> None:
+        import yaml
+
+        doc = {
+            "name": "demo",
+            "feature": "settings",
+            "user_story": "As a user, I want a thing, so that it is done.",
+            "summary": "do a thing",
+            "steps": ["click"],
+            "expectations": ["clicked"],
+            "persona": "power-user",
+        }
+        p = tmp_path / "demo.yaml"
+        p.write_text(yaml.safe_dump(doc), encoding="utf-8")
+        with pytest.raises(scenarios.ScenarioError, match="'persona' must be one of"):
+            scenarios.load_scenario(p)
+
+    def test_system_prompt_splices_the_persona_before_how_to_work(self) -> None:
+        sc = scenarios.load_all(SCENARIOS_DIR)[0]
+        prompt = harness.system_prompt(sc)
+        assert prompt.startswith(harness.SYSTEM_PROMPT.split("\n", 1)[0])
+        assert prompt.index("WHO YOU ARE") < prompt.index("HOW TO WORK:")
+        assert prompt.index("RULES (non-negotiable") < prompt.index("WHO YOU ARE")
+        bare = dataclasses.replace(sc, persona="none")
+        assert harness.system_prompt(bare) == harness.SYSTEM_PROMPT
+
+    def test_tools_carry_report_friction_only_for_a_reporting_persona(self) -> None:
+        from gui_user import x11
+
+        sc = scenarios.load_all(SCENARIOS_DIR)[0]
+        runner = harness.Runner.__new__(harness.Runner)
+        runner.tool_mode = "custom"
+        runner.display = type("D", (), {"geo": x11.Geometry(1600, 1000, 1280)})()
+        names = [t["name"] for t in runner._tools(sc)]
+        assert names[-1] == "report_friction" and names.count("report_friction") == 1
+        assert "report_friction" not in [
+            t["name"] for t in runner._tools(dataclasses.replace(sc, persona="none"))
+        ]
+        runner.tool_mode = "native"
+        assert [t["name"] for t in runner._tools(sc)] == ["computer", "report_friction"]
+
+    def test_custom_action_vocabulary_is_untouched(self) -> None:
+        from gui_user import x11
+
+        assert {t["name"] for t in harness.custom_tools()} <= x11.ACTIONS
+        assert friction.FRICTION_TOOL["name"] not in x11.ACTIONS
+
+
+# --------------------------------------------------------------------------
+# Entries
+# --------------------------------------------------------------------------
+
+
+class TestEntries:
+    def test_valid_entry_carries_scenario_context_and_a_key(self) -> None:
+        e = _entry()
+        assert e["feature"] == "members" and e["scenario"] == "members-dm-hello"
+        assert e["screenshot"].endswith("02-left_click.png") and e["step"] == 2
+        assert e["key"] == friction.entry_key("members", e["element"], e["what_confused"])
+        assert set(e) == {
+            "feature",
+            "scenario",
+            "surface",
+            "element",
+            "what_confused",
+            "expected",
+            "actual",
+            "severity",
+            "screenshot",
+            "step",
+            "key",
+        }
+
+    def test_key_ignores_case_whitespace_and_punctuation(self) -> None:
+        a = friction.entry_key("chat", "The  Send button!", "I could not find it.")
+        b = friction.entry_key("chat", "the send button", "i could NOT find   it")
+        assert a == b
+        assert friction.entry_key("sidebar", "the send button", "i could not find it") != a
+
+    def test_fields_are_trimmed_and_capped_not_rejected(self) -> None:
+        e = _entry(what_confused="  x " * 200)
+        assert len(e["what_confused"]) == friction.FIELD_MAX and e["what_confused"].endswith("…")
+        assert "\n" not in _entry(surface="line one\nline two")["surface"]
+
+    @pytest.mark.parametrize(
+        "over,match",
+        [
+            ({"severity": "huge"}, "severity"),
+            ({"surface": ""}, "must not be empty"),
+            ({"element": 7}, "must be a string"),
+            ({"bonus": "x"}, "unknown friction fields"),
+        ],
+    )
+    def test_rejects_malformed_input(self, over, match) -> None:
+        with pytest.raises(friction.FrictionError, match=match):
+            friction.validate_entry(
+                _raw(**over), feature="members", scenario="s", screenshot="", step=0
+            )
+
+    def test_rejects_non_mapping_and_unknown_feature(self) -> None:
+        with pytest.raises(friction.FrictionError, match="mapping"):
+            friction.validate_entry("nope", feature="members", scenario="s", screenshot="", step=0)
+        with pytest.raises(friction.FrictionError, match="registry slug"):
+            friction.validate_entry(
+                _raw(), feature="teleporter", scenario="s", screenshot="", step=0
+            )
+
+    def test_collect_dedupes_by_key_and_skips_garbage(self) -> None:
+        e = _entry()
+        summary = {
+            "scenarios": [
+                {"attempts": [{"friction": [e, e, {"severity": "blocker"}, "junk"]}]},
+                {"attempts": [{"friction": [{**e, "key": "other"}]}]},
+                "junk",
+            ]
+        }
+        got = friction.collect(summary)
+        assert [g["key"] for g in got] == [e["key"], "other"]
+
+    def test_collect_folds_a_repeated_key_to_worst_severity_and_newest_evidence(self) -> None:
+        # Attempt 1 called it cosmetic; the retry hit the same confusion and called
+        # it a blocker with a fresher screenshot. Cosmetic never files an issue, so
+        # first-sighting-wins would have hidden the blocker for a night.
+        first = {**_entry(), "severity": "cosmetic", "screenshot": "a1/step-2.png"}
+        retry = {**_entry(), "severity": "blocker", "screenshot": "a2/step-1.png"}
+        summary = {"scenarios": [{"attempts": [{"friction": [first]}, {"friction": [retry]}]}]}
+        (got,) = friction.collect(summary)
+        assert got["severity"] == "blocker" and got["screenshot"] == "a2/step-1.png"
+        # The other way round the retry is milder: the worst severity is kept, the
+        # newest evidence still wins.
+        summary = {"scenarios": [{"attempts": [{"friction": [retry]}, {"friction": [first]}]}]}
+        (got,) = friction.collect(summary)
+        assert got["severity"] == "blocker" and got["screenshot"] == "a1/step-2.png"
+
+
+# --------------------------------------------------------------------------
+# Harness routing
+# --------------------------------------------------------------------------
+
+
+class _Log:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, dict]] = []
+
+    def write(self, kind: str, **fields) -> int:
+        self.records.append((kind, fields))
+        return len(self.records)
+
+
+class TestFrictionCountIsOnlyClaimedWhenTheChannelRan:
+    def test_dry_run_or_persona_none_never_claims_the_channel(self) -> None:
+        cat = scenarios.load_all(SCENARIOS_DIR)
+        assert harness.friction_channel_ran(cat, dry_run=False)
+        assert not harness.friction_channel_ran(cat, dry_run=True)
+        bare = [dataclasses.replace(sc, persona="none") for sc in cat]
+        assert not harness.friction_channel_ran(bare, dry_run=False)
+        assert harness.friction_channel_ran([*bare, cat[0]], dry_run=False)
+        assert not harness.friction_channel_ran([], dry_run=False)
+
+
+class TestHarnessRecordsFriction:
+    def _runner(self) -> harness.Runner:
+        return harness.Runner.__new__(harness.Runner)
+
+    def test_valid_call_is_stored_with_the_last_screenshot(self) -> None:
+        sc = scenarios.load_all(SCENARIOS_DIR)[0]
+        entries: list[dict] = []
+        log = _Log()
+        text = self._runner()._record_friction(sc, _raw(), entries, "s/attempt-1/03-x.png", 3, log)
+        assert text.startswith("Noted")
+        assert len(entries) == 1 and entries[0]["screenshot"] == "s/attempt-1/03-x.png"
+        assert entries[0]["feature"] == sc.feature and entries[0]["step"] == 3
+        assert log.records[0][0] == "friction"
+
+    def test_duplicate_rejected_and_capped_calls_do_not_fail_the_model(self) -> None:
+        sc = scenarios.load_all(SCENARIOS_DIR)[0]
+        entries: list[dict] = []
+        log = _Log()
+        r = self._runner()
+        r._record_friction(sc, _raw(), entries, "", 1, log)
+        assert r._record_friction(sc, _raw(), entries, "", 2, log).startswith("Already noted")
+        assert r._record_friction(sc, _raw(severity="huge"), entries, "", 2, log).startswith(
+            "Not recorded"
+        )
+        for i in range(friction.ATTEMPT_CAP + 2):
+            r._record_friction(sc, _raw(what_confused=f"confusion {i}"), entries, "", 3, log)
+        assert len(entries) == friction.ATTEMPT_CAP
+        assert any(k == "friction_dropped" for k, _ in log.records)
+
+    def test_attempt_result_carries_friction_into_summary(self) -> None:
+        att = harness.AttemptResult(
+            "PASS", 3, 10.0, 1, 1, 0.01, "VERDICT: PASS", friction=[_entry()]
+        )
+        doc = json.loads(json.dumps(dataclasses.asdict(att)))
+        assert doc["friction"][0]["severity"] == "slows-down"
+        assert harness.AttemptResult("ERROR", 0, 0.0, 0, 0, 0.0, "").friction == []
+
+
+class _FakeDisplay:
+    """Enough of ``x11.Display`` for ``Runner.attempt``: actions succeed, screenshots are numbered."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.shots_dir = root
+        self.n = 0
+        self.actions: list[str] = []
+
+    def reset(self, shots_dir: Path) -> None:
+        self.shots_dir = shots_dir
+        shots_dir.mkdir(parents=True, exist_ok=True)
+        self.n = 0
+
+    def perform(self, action: str, params: dict) -> str:
+        self.actions.append(action)
+        return f"did {action}"
+
+    def settle(self) -> None:
+        pass
+
+    def screenshot(self, label: str = "shot"):
+        self.n += 1
+        path = self.shots_dir / f"{self.n:02d}-{label}.png"
+        path.write_bytes(b"png")
+        return b"png", path
+
+
+class _ScriptedClient:
+    def __init__(self, responses: list[dict]) -> None:
+        self.responses = list(responses)
+        self.bodies: list[dict] = []
+
+    def messages(self, body: dict) -> dict:
+        self.bodies.append(body)
+        return self.responses.pop(0)
+
+
+def _tool_use(tid: str, name: str, inp: dict) -> dict:
+    return {"type": "tool_use", "id": tid, "name": name, "input": inp}
+
+
+class TestBatchedFrictionCitesTheScreenTheModelSaw:
+    def test_action_then_friction_in_one_response(self, tmp_path: Path) -> None:
+        sc = scenarios.load_all(SCENARIOS_DIR)[0]
+        client = _ScriptedClient(
+            [
+                {
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [
+                        _tool_use("a", "left_click", {"coordinate": [1, 2]}),
+                        _tool_use("b", "report_friction", _raw()),
+                    ],
+                },
+                {
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [
+                        {"type": "text", "text": "VERDICT: PASS\nEXPECTATIONS:\n- x : MET"}
+                    ],
+                },
+            ]
+        )
+        display = _FakeDisplay(tmp_path)
+        runner = harness.Runner(
+            client,  # type: ignore[arg-type]
+            display,  # type: ignore[arg-type]
+            base_url="http://t",
+            tool_mode="custom",
+            price_in=1.0,
+            price_out=1.0,
+            budget_usd=5.0,
+            out=tmp_path,
+        )
+        att = runner.attempt(sc, 1)
+        assert att.status == "PASS" and att.steps == 1
+        assert len(att.friction) == 1
+        # The batch was decided from the start screenshot (01-start.png) at step 0; the
+        # left_click that precedes the friction call in the batch must not move either.
+        assert att.friction[0]["screenshot"].endswith("/01-start.png")
+        assert att.friction[0]["step"] == 0
+        assert display.actions.count("left_click") == 1
+        # The tool result handed back for the friction call is text only (no image).
+        # (the harness appends to the same message list, so search rather than index)
+        friction_result = next(
+            block
+            for msg in client.bodies[1]["messages"]
+            for block in msg["content"]
+            if block.get("type") == "tool_result" and block.get("tool_use_id") == "b"
+        )
+        assert friction_result["content"] == [
+            {"type": "text", "text": "Noted. Continue with the steps."}
+        ]
+        assert client.bodies[0]["tools"][-1]["name"] == "report_friction"
+        assert "WHO YOU ARE" in client.bodies[0]["system"]
+
+
+# --------------------------------------------------------------------------
+# Ledger and issues
+# --------------------------------------------------------------------------
+
+
+def _ledger_two_nights():
+    e1 = _entry()
+    e2 = _entry(
+        feature="chat",
+        surface="Chat page",
+        element="plus icon",
+        what_confused="The plus icon has no label.",
+        severity="cosmetic",
+    )
+    e3 = _entry(
+        feature="settings",
+        surface="Display",
+        element="Theme dropdown",
+        what_confused="Nothing changed for a second.",
+        severity="blocker",
+    )
+    led, new1 = friction.merge_ledger(
+        friction.empty_ledger(), [e1, e2], date="2026-09-12", run_url="r1", head_sha="aaa"
+    )
+    led, new2 = friction.merge_ledger(
+        led, [e1, e3], date="2026-09-13", run_url="r2", head_sha="bbb"
+    )
+    return led, (e1, e2, e3), (new1, new2)
+
+
+class TestLedger:
+    def test_merge_counts_recurrences_and_keeps_the_worst_severity(self) -> None:
+        led, (e1, e2, e3), (new1, new2) = _ledger_two_nights()
+        assert set(new1) == {e1["key"], e2["key"]} and new2 == [e3["key"]]
+        row = led["entries"][e1["key"]]
+        assert row["count"] == 2 and row["first_seen"] == "2026-09-12"
+        assert (
+            row["last_seen"] == "2026-09-13" and row["run_url"] == "r2" and row["head_sha"] == "bbb"
+        )
+        led, _ = friction.merge_ledger(
+            led, [{**e1, "severity": "blocker"}], date="2026-09-14", run_url="r3"
+        )
+        assert led["entries"][e1["key"]]["severity"] == "blocker"
+        led, _ = friction.merge_ledger(
+            led, [{**e1, "severity": "cosmetic"}], date="2026-09-15", run_url="r4"
+        )
+        assert led["entries"][e1["key"]]["severity"] == "blocker"
+        # A recurrence is taken whole: a renamed surface or re-spelt wording (same key)
+        # never sits beside the previous night's screenshot.
+        moved = {
+            **e1,
+            "surface": "Settings › Developer",
+            "element": "DEVELOPER section header",
+            "what_confused": "I did not expect feature previews to live under Developer!",
+            "screenshot": "x/attempt-1/09-scroll.png",
+        }
+        assert moved["key"] == e1["key"]
+        led, _ = friction.merge_ledger(led, [moved], date="2026-09-16")
+        row = led["entries"][e1["key"]]
+        assert (
+            row["surface"] == "Settings › Developer"
+            and row["element"] == "DEVELOPER section header"
+        )
+        assert (
+            row["what_confused"].endswith("!") and row["screenshot"] == "x/attempt-1/09-scroll.png"
+        )
+
+    def test_same_run_merged_twice_is_idempotent(self) -> None:
+        e = _entry()
+        led, _ = friction.merge_ledger(
+            friction.empty_ledger(), [e], date="2026-09-12", run_url="r1"
+        )
+        led, new = friction.merge_ledger(led, [e], date="2026-09-12", run_url="r1")
+        assert new == [] and led["entries"][e["key"]]["count"] == 1
+
+    def test_another_run_on_the_same_day_refreshes_evidence_without_recounting(self) -> None:
+        # Nightly first, then a dispatch the same day that re-hits the key: the row must
+        # carry the dispatch's screenshot / artifact / head (what its report links to),
+        # but the day is still counted once.
+        e = _entry()
+        led, _ = friction.merge_ledger(
+            friction.empty_ledger(),
+            [e],
+            date="2026-09-12",
+            run_url="r-night",
+            artifact_url="a-night",
+            head_sha="aaa",
+        )
+        again = {**e, "screenshot": "s/attempt-1/07-left_click.png", "actual": "seen again"}
+        led, new = friction.merge_ledger(
+            led,
+            [again],
+            date="2026-09-12",
+            run_url="r-dispatch",
+            artifact_url="a-dispatch",
+            head_sha="bbb",
+        )
+        row = led["entries"][e["key"]]
+        assert new == [] and row["count"] == 1 and row["last_seen"] == "2026-09-12"
+        assert (
+            row["screenshot"] == "s/attempt-1/07-left_click.png" and row["actual"] == "seen again"
+        )
+        assert row["run_url"] == "r-dispatch" and row["artifact_url"] == "a-dispatch"
+        assert row["head_sha"] == "bbb"
+
+    def test_tonight_lists_only_rows_seen_on_that_date_in_registry_then_severity_order(
+        self,
+    ) -> None:
+        led, (e1, e2, e3), _ = _ledger_two_nights()
+        rows = friction.tonight(led, "2026-09-13")
+        assert [r["key"] for r in rows] == [e1["key"], e3["key"]]  # members before settings
+        assert friction.tonight(led, "2026-09-12")[-1]["key"] == e2["key"]
+
+    def test_rows_for_scopes_to_one_runs_keys_not_the_date(self) -> None:
+        led, (e1, e2, e3), _ = _ledger_two_nights()
+        # Same date as e1/e3 (the nightly), but this run only saw e3.
+        assert [r["key"] for r in friction.rows_for(led, [e3["key"]])] == [e3["key"]]
+        assert friction.rows_for(led, []) == []
+        # Catalog order (chat before members), whatever order the keys were given in.
+        assert [r["key"] for r in friction.rows_for(led, [e1["key"], e2["key"]])] == [
+            e2["key"],
+            e1["key"],
+        ]
+
+    def test_load_ledger_shapes(self, tmp_path: Path) -> None:
+        assert friction.load_ledger(None) == friction.empty_ledger()
+        assert friction.load_ledger(tmp_path / "missing.json") == friction.empty_ledger()
+        bad = tmp_path / "bad.json"
+        bad.write_text("[]", encoding="utf-8")
+        with pytest.raises(friction.FrictionError, match="unexpected shape"):
+            friction.load_ledger(bad)
+        bad.write_text(json.dumps({"version": 1, "entries": {"k": {"severity": "huge"}}}))
+        with pytest.raises(friction.FrictionError, match="malformed"):
+            friction.load_ledger(bad)
+        bad.write_text("{not json")
+        with pytest.raises(friction.FrictionError):
+            friction.load_ledger(bad)
+
+
+class TestIssues:
+    def test_plan_skips_cosmetic_caps_new_and_comments_recurrences(self) -> None:
+        led, (e1, e2, e3), _ = _ledger_two_nights()
+        # Every un-issued non-cosmetic row is a candidate whatever night it was last seen
+        # (a row an earlier cap held over is not lost); cosmetic e2 never leaves the summary.
+        assert friction.plan_issues(led, date="2026-09-12") == {
+            "create": [e1["key"], e3["key"]],
+            "comment": [],
+        }
+        # Tonight's sightings come first, each group in registry-then-severity order.
+        plan = friction.plan_issues(led, date="2026-09-13")
+        assert plan == {"create": [e1["key"], e3["key"]], "comment": []}
+        led["entries"][e3["key"]]["last_seen"] = "2026-09-10"  # held over, not seen tonight
+        assert friction.plan_issues(led, date="2026-09-13")["create"] == [e1["key"], e3["key"]]
+        led["entries"][e3["key"]]["last_seen"] = "2026-09-13"
+        assert friction.plan_issues(led, date="2026-09-13", cap=1)["create"] == [e1["key"]]
+        led["entries"][e1["key"]]["issue"] = 42
+        plan = friction.plan_issues(led, date="2026-09-13")
+        assert plan == {"create": [e3["key"]], "comment": [e1["key"]]}
+        # A same-day rerun after the comment was posted must not post it again.
+        led["entries"][e1["key"]]["last_commented"] = "2026-09-13"
+        assert friction.plan_issues(led, date="2026-09-13")["comment"] == []
+        led["entries"][e1["key"]]["last_commented"] = "2026-09-12"
+        assert friction.plan_issues(led, date="2026-09-13")["comment"] == [e1["key"]]
+
+    def test_file_issues_uses_gh_and_records_numbers(self) -> None:
+        led, (e1, e2, e3), _ = _ledger_two_nights()
+        led["entries"][e1["key"]]["issue"] = 42
+        calls: list[list[str]] = []
+
+        def fake(args: list[str]) -> str:
+            calls.append(args)
+            if args[:2] == ["issue", "view"]:
+                return '{"state": "OPEN"}'
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            if args[:2] == ["issue", "create"]:
+                return "https://github.com/o/r/issues/91\n"
+            return ""
+
+        saved: list[int] = []
+        out = friction.file_issues(
+            led, repo="o/r", date="2026-09-13", run=fake, persist=lambda led: saved.append(1)
+        )
+        assert out == {"opened": [91], "adopted": [], "commented": [42], "failed": []}
+        assert len(saved) == 2  # once per successful gh mutation
+        assert led["entries"][e1["key"]]["last_commented"] == "2026-09-13"
+        assert led["entries"][e3["key"]]["issue"] == 91
+        create = next(c for c in calls if c[:2] == ["issue", "create"])
+        assert (
+            "--label" in create and friction.LABEL_UX in create and friction.LABEL_CHANNEL in create
+        )
+        assert "area: dashboard" in create  # settings -> default area
+        assert create[create.index("--title") + 1].startswith("ux(settings): Nothing changed")
+        body = create[create.index("--body") + 1]
+        assert body.startswith(f"{friction.ISSUE_MARKER}{e3['key']} -->")
+        comment = next(c for c in calls if c[:2] == ["issue", "comment"])
+        assert comment[2] == "42" and "Again on 2026-09-13" in comment[comment.index("--body") + 1]
+        # Label creation failing (no permission / exists) must not stop the filing.
+        labels = [c for c in calls if c[:2] == ["label", "create"]]
+        assert len(labels) == 2
+
+    def test_label_create_failure_is_tolerated(self) -> None:
+        led, (e1, _, _), _ = _ledger_two_nights()
+
+        def fake(args: list[str]) -> str:
+            if args[:2] == ["label", "create"]:
+                raise subprocess.CalledProcessError(1, args)
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            return "https://github.com/o/r/issues/5\n"
+
+        out = friction.file_issues(led, repo="o/r", date="2026-09-13", run=fake)
+        assert out["opened"] == [5, 5]
+
+    def test_failure_mid_batch_keeps_the_mappings_already_made(self) -> None:
+        led, (e1, e2, e3), _ = _ledger_two_nights()
+        snapshots: list[dict] = []
+        calls = {"create": 0}
+
+        def flaky(args: list[str]) -> str:
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            if args[:2] == ["issue", "create"]:
+                calls["create"] += 1
+                if calls["create"] == 2:
+                    raise subprocess.CalledProcessError(1, args)
+                return "https://github.com/o/r/issues/7\n"
+            return ""
+
+        out = friction.file_issues(
+            led,
+            repo="o/r",
+            date="2026-09-13",
+            run=flaky,
+            persist=lambda led: snapshots.append(json.loads(json.dumps(led))),
+        )
+        assert out["opened"] == [7] and [f["op"] for f in out["failed"]] == ["create"]
+        # The first mapping was persisted BEFORE the second create failed ...
+        assert snapshots and snapshots[0]["entries"][e1["key"]]["issue"] == 7
+        # ... so a rerun files only the one that failed.
+        assert friction.plan_issues(led, date="2026-09-13")["create"] == [e3["key"]]
+
+    def test_recurrence_on_a_closed_issue_opens_a_fresh_one(self) -> None:
+        led, (e1, _, e3), _ = _ledger_two_nights()
+        led["entries"][e1["key"]]["issue"] = 42
+        led["entries"][e3["key"]]["issue"] = 43  # filed by tonight's earlier attempt, still open
+        calls: list[list[str]] = []
+
+        def fake(args: list[str]) -> str:
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            calls.append(args)
+            if args[:2] == ["issue", "view"]:
+                return '{"state": "CLOSED"}' if args[2] == "42" else '{"state": "OPEN"}'
+            if args[:2] == ["issue", "create"]:
+                return "https://github.com/o/r/issues/99\n"
+            return ""
+
+        out = friction.file_issues(led, repo="o/r", date="2026-09-13", run=fake)
+        assert out == {"opened": [99], "adopted": [], "commented": [], "failed": []}
+        row = led["entries"][e1["key"]]
+        assert row["issue"] == 99 and row["closed_issues"] == [42]
+        # Every row seen tonight that has an issue is checked -- a same-day rerun's
+        # fresh sighting must not stay mapped to a thread a human closed meanwhile.
+        assert sorted(c[2] for c in calls if c[:2] == ["issue", "view"]) == ["42", "43"]
+        assert led["entries"][e3["key"]]["issue"] == 43
+        create = next(c for c in calls if c[:2] == ["issue", "create"])
+        assert "earlier issue(s): #42" in create[create.index("--body") + 1]
+
+    def test_unknown_issue_state_keeps_the_comment_path(self) -> None:
+        led, (e1, _, _), _ = _ledger_two_nights()
+        led["entries"][e1["key"]]["issue"] = 42
+
+        def fake(args: list[str]) -> str:
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            if args[:2] == ["issue", "view"]:
+                raise subprocess.CalledProcessError(1, args)
+            if args[:2] == ["issue", "create"]:
+                return "https://github.com/o/r/issues/5\n"
+            return ""
+
+        out = friction.file_issues(led, repo="o/r", date="2026-09-13", run=fake)
+        assert out["commented"] == [42] and led["entries"][e1["key"]]["issue"] == 42
+
+    def test_area_label_mapping_names_only_registry_slugs(self) -> None:
+        assert friction.AREA_LABELS["schedule"] == "area: cron"
+        assert friction.AREA_LABELS["apps"] == "area: apps"
+        assert friction.DEFAULT_AREA_LABEL == "area: dashboard"
+        # A key the registry lacks could never fire; the registry is the one taxonomy.
+        assert set(friction.AREA_LABELS) <= set(scenarios.FEATURES)
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+class TestRendering:
+    def test_section_groups_by_feature_and_orders_by_severity(self) -> None:
+        led, (e1, e2, e3), _ = _ledger_two_nights()
+        led["entries"][e1["key"]]["issue"] = 42
+        md = friction.render_section(friction.tonight(led, "2026-09-13"), artifact_url="https://a")
+        assert md.startswith("## New-user friction\n")
+        assert "1 blocker · 1 slows-down · 0 cosmetic" in md
+        assert md.index("### Crew Members (`members`)") < md.index("### Settings (`settings`)")
+        assert "| slows-down |" in md and "| blocker |" in md
+        assert "2× · last 2026-09-13 · #42" in md and "| new |" in md
+        assert "[`members-dm-hello/attempt-1/02-left_click.png`](https://a)" in md
+
+    def test_empty_section_says_so(self) -> None:
+        assert "reported nothing confusing" in friction.render_section([])
+
+    def test_cells_are_inert(self) -> None:
+        e = _entry(what_confused="see `code` | <b>bold</b> [link](x) @maintainer ```")
+        md = friction.render_section([e])
+        row = next(ln for ln in md.splitlines() if ln.startswith("| slows-down |"))
+        cell = row.split("|")[2]
+        assert "`" not in cell and "<b>" not in cell and "[link](x)" not in cell
+        assert "@\u200bmaintainer" in cell and "```" not in cell
+
+    def test_cells_defang_urls_the_tester_read_off_the_screen(self) -> None:
+        e = _entry(
+            what_confused="A banner said go to https://evil.example/x or www.evil.example now"
+        )
+        md = friction.render_section([e])
+        assert "https://" not in md and "www." not in md
+        assert "https:\u200b//evil.example/x" in md and "www\u200b.evil.example" in md
+        body = friction.issue_body(e["key"], {**e, "count": 1, "first_seen": "d"})
+        assert "https://evil" not in body and "https:\u200b//evil.example/x" in body
+
+    def test_report_markdown_appends_the_section_when_the_channel_ran(self) -> None:
+        e = _entry()
+        summary = {
+            "scenarios": [
+                {
+                    "name": "members-dm-hello",
+                    "feature": "members",
+                    "status": "PASS",
+                    "attempts": [
+                        {"status": "PASS", "final_text": "VERDICT: PASS", "friction": [e]}
+                    ],
+                }
+            ],
+            "usage": {},
+            "friction_count": 1,
+        }
+        md = report.render_markdown(summary, artifact_url="https://a")
+        assert "## New-user friction" in md and e["what_confused"] in md
+        # Ledger-aware rows replace the run's own when supplied.
+        md2 = report.render_markdown(
+            summary, friction_entries=[{**e, "count": 3, "last_seen": "d"}]
+        )
+        assert "3× · last d" in md2
+        # A pre-channel summary renders as before.
+        summary.pop("friction_count")
+        assert "New-user friction" not in report.render_markdown(summary)
+        assert "new-user friction: 1 slows-down" in report.render_console(
+            {**summary, "friction_count": 1, "usd": 0}
+        )
+
+    def test_cli_merge_render_issues_dry_run(self, tmp_path: Path, capsys) -> None:
+        e = _entry()
+        summary = {
+            "scenarios": [
+                {
+                    "name": "members-dm-hello",
+                    "feature": "members",
+                    "status": "PASS",
+                    "attempts": [{"status": "PASS", "friction": [e]}],
+                }
+            ],
+            "friction_count": 1,
+        }
+        s = tmp_path / "summary.json"
+        s.write_text(json.dumps(summary), encoding="utf-8")
+        out = tmp_path / "friction.json"
+        led = tmp_path / "ledger.json"
+        assert (
+            friction.main(
+                [
+                    "merge",
+                    "--summary",
+                    str(s),
+                    "--out",
+                    str(out),
+                    "--out-ledger",
+                    str(led),
+                    "--date",
+                    "2026-09-12",
+                    "--run-url",
+                    "r",
+                    "--head-sha",
+                    "aaa",
+                ]
+            )
+            == 0
+        )
+        doc = json.loads(out.read_text(encoding="utf-8"))
+        assert doc["new_keys"] == [e["key"]] and doc["entries"][0]["count"] == 1
+        assert doc["run_keys"] == [e["key"]]
+        assert "1 friction entry, 1 new" in capsys.readouterr().out
+        assert (
+            friction.main(
+                [
+                    "issues",
+                    "--ledger",
+                    str(led),
+                    "--repo",
+                    "o/r",
+                    "--date",
+                    "2026-09-12",
+                    "--artifact-url",
+                    "https://a",
+                    "--friction",
+                    str(out),
+                    "--dry-run",
+                ]
+            )
+            == 0
+        )
+        assert json.loads(capsys.readouterr().out) == {"create": [e["key"]], "comment": []}
+        # snapshot rewrites tonight's rows from the ledger and keeps the run's provenance.
+        led_doc = json.loads(led.read_text(encoding="utf-8"))
+        led_doc["entries"][e["key"]]["issue"] = 77
+        # A row another run saw on the same date must not leak into this run's snapshot.
+        other = {**led_doc["entries"][e["key"]], "issue": None, "scenario": "elsewhere"}
+        led_doc["entries"]["deadbeefdeadbeef"] = other
+        led.write_text(json.dumps(led_doc), encoding="utf-8")
+        assert (
+            friction.main(
+                ["snapshot", "--ledger", str(led), "--out", str(out), "--date", "2026-09-12"]
+            )
+            == 0
+        )
+        doc = json.loads(out.read_text(encoding="utf-8"))
+        assert [r["key"] for r in doc["entries"]] == [e["key"]]
+        assert (
+            doc["entries"][0]["issue"] == 77 and doc["run_url"] == "r" and doc["head_sha"] == "aaa"
+        )
+        assert "snapshotted" in capsys.readouterr().out
+        assert (
+            friction.main(
+                [
+                    "merge",
+                    "--summary",
+                    str(tmp_path / "nope.json"),
+                    "--out",
+                    str(out),
+                    "--out-ledger",
+                    str(led),
+                    "--date",
+                    "d",
+                ]
+            )
+            == 2
+        )
+
+
+REPO = "kirodotdev/KiroCrew"
+
+
+def _run(run_id: int, **over: object) -> dict[str, object]:
+    doc: dict[str, object] = {
+        "id": run_id,
+        "path": friction.WORKFLOW_PATH,
+        "event": "schedule",
+        "head_branch": "main",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": f"2026-09-{run_id % 28 + 1:02d}T09:30:00Z",
+        "repository": {"full_name": REPO},
+        "head_repository": {"full_name": REPO},
+    }
+    doc.update(over)
+    return doc
+
+
+def _artifact(run_id: int, art_id: int = 900, **over: object) -> dict[str, object]:
+    doc: dict[str, object] = {
+        "id": art_id,
+        "name": friction.LEDGER_ARTIFACT,
+        "expired": False,
+        "workflow_run": {"id": run_id, "head_branch": "main"},
+    }
+    doc.update(over)
+    return doc
+
+
+class TestLedgerProvenance:
+    """The previous ledger comes ONLY from a scheduled run of this workflow on the
+    trusted branch. Every other origin -- another workflow, a pull_request or
+    dispatch run, a fork, a run that did not complete -- is rejected, however
+    its artifact is named."""
+
+    def test_source_runs_are_newest_first_and_exclude_self(self) -> None:
+        runs = [_run(3), _run(5, created_at="2026-09-20T09:30:00Z"), _run(4)]
+        assert friction.ledger_source_runs(runs, repo=REPO, branch="main") == [5, 4, 3]
+        assert friction.ledger_source_runs(runs, repo=REPO, branch="main", exclude_run_id=5) == [
+            4,
+            3,
+        ]
+
+    @pytest.mark.parametrize(
+        "over",
+        [
+            {"path": ".github/workflows/ci.yml"},  # another workflow (a PR lane)
+            {"event": "pull_request"},  # wrong event: fork-reachable
+            {"event": "workflow_dispatch"},  # a maintainer's ad-hoc run is not the nightly
+            {"head_branch": "feat/anything"},  # untrusted branch
+            {"head_repository": {"full_name": "someone/KiroCrew"}},  # fork head
+            {"repository": {"full_name": "someone/KiroCrew"}},  # foreign base
+            {"head_repository": None},  # provenance missing is provenance wrong
+            {"status": "in_progress", "conclusion": None},  # not finished
+            {"conclusion": "skipped"},  # the job never ran
+            {"status": "completed", "conclusion": None},
+            {"id": "12"},  # malformed id
+        ],
+    )
+    def test_every_provenance_field_must_agree(self, over: dict[str, object]) -> None:
+        bad = _run(9, **over)
+        assert friction.ledger_source_runs([bad, _run(2)], repo=REPO, branch="main") == [2]
+
+    def test_junk_in_the_listing_is_dropped_not_guessed_at(self) -> None:
+        assert friction.ledger_source_runs(
+            ["not-a-dict", None, {}, _run(2)], repo=REPO, branch="main"
+        ) == [2]
+
+    @pytest.mark.parametrize("conclusion", ["failure", "cancelled", "timed_out"])
+    def test_a_red_or_cut_short_nightly_still_counts_as_a_source(self, conclusion: str) -> None:
+        # A FAIL verdict, a cancellation or a timeout all land AFTER the ledger was
+        # written and uploaded; refusing such a run would re-file its issues.
+        assert friction.ledger_source_runs(
+            [_run(7, conclusion=conclusion)], repo=REPO, branch="main"
+        ) == [7]
+
+    def test_artifact_must_belong_to_that_run_and_branch(self) -> None:
+        assert friction.ledger_artifact_id([_artifact(7)], run_id=7, branch="main") == 900
+        for bad in (
+            _artifact(8),  # another run's artifact in the listing
+            _artifact(7, workflow_run={"id": 7, "head_branch": "feat/x"}),
+            _artifact(7, name="gui-user-test-123"),  # the screenshots artifact
+            _artifact(7, expired=True),
+            _artifact(7, workflow_run=None),
+            _artifact(7, id="900"),
+        ):
+            assert friction.ledger_artifact_id([bad], run_id=7, branch="main") is None
+
+    def test_pick_walks_newest_first_and_skips_runs_without_a_ledger(self) -> None:
+        calls: list[str] = []
+
+        def fetch(path: str) -> object:
+            calls.append(path)
+            if path == "actions/runs/99":  # tonight's first attempt: no ledger yet
+                return _run(99, status="in_progress", conclusion=None)
+            if path == f"actions/runs/99/artifacts?name={friction.LEDGER_ARTIFACT}":
+                return {"artifacts": []}
+            if path.startswith("actions/workflows/gui-user-test.yml/runs?"):
+                assert "event=schedule" in path and "branch=main" in path
+                return {"workflow_runs": [_run(4), _run(6), _run(5, event="pull_request")]}
+            if path == f"actions/runs/6/artifacts?name={friction.LEDGER_ARTIFACT}":
+                return {"artifacts": []}  # that night's merge step failed: nothing uploaded
+            if path == f"actions/runs/4/artifacts?name={friction.LEDGER_ARTIFACT}":
+                return {"artifacts": [_artifact(4, 41)]}
+            raise AssertionError(path)
+
+        assert friction.pick_ledger(repo=REPO, branch="main", self_run_id=99, fetch=fetch) == {
+            "run_id": 4,
+            "artifact_id": 41,
+        }
+        assert not any("/runs/5/" in c for c in calls)  # the PR run's artifacts are never listed
+
+    def test_a_rerun_reads_its_own_earlier_attempt_before_last_night(self) -> None:
+        # Attempt 1 of tonight's scheduled run filed issues and uploaded the ledger
+        # that records them; attempt 2 must start from THAT, not from last night's
+        # ledger, or it files every one of them again.
+        calls: list[str] = []
+
+        def fetch(path: str) -> object:
+            calls.append(path)
+            if path == "actions/runs/99":
+                return _run(99, status="in_progress", conclusion=None)
+            if path == f"actions/runs/99/artifacts?name={friction.LEDGER_ARTIFACT}":
+                return {"artifacts": [_artifact(99, 991)]}
+            raise AssertionError(path)
+
+        assert friction.pick_ledger(repo=REPO, branch="main", self_run_id=99, fetch=fetch) == {
+            "run_id": 99,
+            "artifact_id": 991,
+        }
+        assert not any("workflows/" in c for c in calls)
+
+    @pytest.mark.parametrize(
+        "me",
+        [
+            _run(99, event="workflow_dispatch", status="in_progress", conclusion=None),
+            _run(99, head_branch="feat/x", status="in_progress", conclusion=None),
+            _run(99, head_repository={"full_name": "someone/KiroCrew"}),
+            {"id": 99},
+            None,
+        ],
+    )
+    def test_an_ineligible_current_run_never_supplies_its_own_ledger(self, me: object) -> None:
+        # A dispatch or PR run never wrote a ledger; even if an artifact of that
+        # name sat on it, provenance says no and the walk continues to the nightlies.
+        def fetch(path: str) -> object:
+            if path == "actions/runs/99":
+                return me
+            if path == f"actions/runs/99/artifacts?name={friction.LEDGER_ARTIFACT}":
+                raise AssertionError("must not list an untrusted run's artifacts")
+            if path.startswith("actions/workflows/"):
+                return {"workflow_runs": [_run(4)]}
+            if path == f"actions/runs/4/artifacts?name={friction.LEDGER_ARTIFACT}":
+                return {"artifacts": [_artifact(4, 41)]}
+            raise AssertionError(path)
+
+        assert friction.pick_ledger(repo=REPO, branch="main", self_run_id=99, fetch=fetch) == {
+            "run_id": 4,
+            "artifact_id": 41,
+        }
+
+    def test_pick_with_no_eligible_run_is_a_first_night_not_an_error(self) -> None:
+        assert friction.pick_ledger(
+            repo=REPO,
+            branch="main",
+            self_run_id=None,
+            fetch=lambda path: {"workflow_runs": [_run(1, event="pull_request")]},
+        ) == {"run_id": None, "artifact_id": None}
+
+    def test_pick_fails_closed_on_api_errors_and_malformed_answers(self) -> None:
+        def boom(path: str) -> object:
+            raise subprocess.CalledProcessError(1, ["gh", "api", path])
+
+        with pytest.raises(subprocess.CalledProcessError):
+            friction.pick_ledger(repo=REPO, branch="main", self_run_id=None, fetch=boom)
+        with pytest.raises(friction.FrictionError):
+            friction.pick_ledger(
+                repo=REPO, branch="main", self_run_id=None, fetch=lambda p: {"message": "oops"}
+            )
+        with pytest.raises(friction.FrictionError):
+            friction.pick_ledger(
+                repo=REPO,
+                branch="main",
+                self_run_id=None,
+                fetch=lambda p: {"workflow_runs": [_run(1)]} if "workflows/" in p else {},
+            )
+
+    def test_cli_writes_the_pick_and_fails_closed(
+        self, monkeypatch, capsys, tmp_path: Path
+    ) -> None:
+        answers = {
+            f"repos/{REPO}/actions/runs/99": _run(99, status="in_progress", conclusion=None),
+            f"repos/{REPO}/actions/runs/99/artifacts?name={friction.LEDGER_ARTIFACT}": {
+                "artifacts": []
+            },
+            f"repos/{REPO}/actions/workflows/gui-user-test.yml/runs"
+            "?event=schedule&branch=main&status=completed&per_page=100&page=1": {
+                "workflow_runs": [_run(4)]
+            },
+            f"repos/{REPO}/actions/runs/4/artifacts?name={friction.LEDGER_ARTIFACT}": {
+                "artifacts": [_artifact(4, 41)]
+            },
+        }
+        monkeypatch.setattr(friction, "_gh", lambda args: json.dumps(answers[args[1]]))
+        out = tmp_path / "pick.json"
+        argv = ["pick-ledger", "--repo", REPO, "--branch", "main", "--out", str(out)]
+        assert friction.main([*argv, "--self-run", "99"]) == 0
+        assert json.loads(out.read_text(encoding="utf-8")) == {"run_id": 4, "artifact_id": 41}
+        # Nothing the API answered is echoed into the job log.
+        assert capsys.readouterr().out.strip() == "previous ledger found"
+
+        def boom(args: list[str]) -> str:
+            raise subprocess.CalledProcessError(1, ["gh", *args])
+
+        monkeypatch.setattr(friction, "_gh", boom)
+        assert friction.main(argv) == 2
+        # The failed run left the earlier answer untouched.
+        assert json.loads(out.read_text(encoding="utf-8")) == {"run_id": 4, "artifact_id": 41}
+
+
+class TestAtomicWrite:
+    def test_write_replaces_the_target_only_when_complete(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        target = tmp_path / "friction_ledger.json"
+        friction._write(target, {"v": 1})
+        assert json.loads(target.read_text(encoding="utf-8")) == {"v": 1}
+        assert [p.name for p in tmp_path.iterdir()] == ["friction_ledger.json"]  # no .tmp left
+
+        # A write that dies mid-way (disk full) leaves the previous document intact.
+        def cut_short(_tmp: object, _target: object) -> None:
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(friction.os, "replace", cut_short)
+        with pytest.raises(OSError):
+            friction._write(target, {"v": 2})
+        assert json.loads(target.read_text(encoding="utf-8")) == {"v": 1}
+        assert [p.name for p in tmp_path.iterdir()] == ["friction_ledger.json"]
+
+
+class TestReconcileAndBounds:
+    def test_an_open_issue_carrying_the_marker_is_adopted_not_duplicated(self) -> None:
+        led, (e1, e2, e3), _ = _ledger_two_nights()
+        calls: list[list[str]] = []
+
+        def fake(args: list[str]) -> str:
+            calls.append(args)
+            if args[:2] == ["issue", "view"]:
+                return '{"state": "OPEN"}'
+            if args[:2] == ["issue", "list"]:
+                key = args[args.index("--search") + 1].split(" ")[0]
+                if key == e3["key"]:
+                    # A stray mention of the digest in prose is NOT the marker.
+                    return json.dumps(
+                        [
+                            {"number": 8, "body": f"talks about {key} somewhere"},
+                            {"number": 9, "body": f"x {friction.ISSUE_MARKER}{key} --> y"},
+                        ]
+                    )
+                return "[]"
+            if args[:2] == ["issue", "create"]:
+                return "https://github.com/o/r/issues/91\n"
+            return ""
+
+        out = friction.file_issues(led, repo="o/r", date="2026-09-13", run=fake)
+        assert out["adopted"] == [9] and led["entries"][e3["key"]]["issue"] == 9
+        assert 91 in out["opened"]
+        created = [c for c in calls if c[:2] == ["issue", "create"]]
+        assert all(e3["key"] not in c[c.index("--body") + 1] for c in created)
+
+    def test_a_failed_reconcile_skips_the_key_rather_than_risking_a_duplicate(self) -> None:
+        led, (e1, _, e3), _ = _ledger_two_nights()
+
+        def fake(args: list[str]) -> str:
+            if args[:2] == ["issue", "list"]:
+                raise subprocess.CalledProcessError(1, args)
+            if args[:2] == ["issue", "create"]:
+                raise AssertionError("must not create after a failed reconcile")
+            return ""
+
+        out = friction.file_issues(led, repo="o/r", date="2026-09-13", run=fake)
+        assert out["opened"] == [] and {f["op"] for f in out["failed"]} == {"reconcile"}
+        assert led["entries"][e3["key"]].get("issue") is None
+
+    def test_section_stays_within_budget_and_counts_the_rest(self) -> None:
+        big = "x" * friction.FIELD_MAX
+        rows = [
+            {
+                **_entry(),
+                "key": f"k{i:03d}",
+                "what_confused": f"{big[:-4]}{i:04d}",
+                "surface": big,
+                "element": big,
+                "expected": big,
+                "actual": big,
+                "severity": "blocker" if i % 2 else "slows-down",
+            }
+            for i in range(80)
+        ]
+        section = friction.render_section(rows)
+        assert len(section) <= friction.SECTION_MAX_CHARS
+        assert "more row(s) not shown" in section
+        # The worst rows are the ones shown: the 40 blockers alone overrun the
+        # budget, so every shown row is a blocker and no slows-down made it in.
+        assert "| blocker |" in section and "| slows-down |" not in section
+        # A small set renders whole, no trailer.
+        assert "more row(s)" not in friction.render_section(rows[:3])
+
+
+class TestIssueReferenceDefang:
+    def test_hash_number_never_autolinks(self) -> None:
+        cell = friction._cell("saw #123 and kirodotdev/KiroCrew#45 but #hashtag stays")
+        assert "#\u200b123" in cell and "#\u200b45" in cell
+        assert "#123" not in cell and "#45" not in cell
+        assert "#hashtag" in cell
+
+
+class TestLedgerLookupPagination:
+    def test_walks_past_a_full_page_of_ledgerless_nights(self) -> None:
+        # 100 nightlies whose merge step failed sit in front of the one that
+        # still holds a ledger: a single page would have called this a first night.
+        pages = {
+            1: [_run(1000 - i) for i in range(100)],
+            2: [_run(900), _run(899)],
+        }
+        calls: list[str] = []
+
+        def fetch(path: str) -> object:
+            calls.append(path)
+            if path.startswith("actions/workflows/"):
+                page = int(path.rsplit("page=", 1)[1])
+                return {"workflow_runs": pages.get(page, [])}
+            if path.endswith(f"/artifacts?name={friction.LEDGER_ARTIFACT}"):
+                run_id = int(path.split("/")[2])
+                return {"artifacts": [_artifact(899, 8990)] if run_id == 899 else []}
+            raise AssertionError(path)
+
+        assert friction.pick_ledger(repo=REPO, branch="main", self_run_id=None, fetch=fetch) == {
+            "run_id": 899,
+            "artifact_id": 8990,
+        }
+        assert sum(1 for c in calls if "page=" in c) == 2
+
+    def test_a_short_page_ends_the_walk_and_the_walk_is_bounded(self) -> None:
+        seen: list[int] = []
+
+        def fetch(path: str) -> object:
+            if path.startswith("actions/workflows/"):
+                seen.append(int(path.rsplit("page=", 1)[1]))
+                return {"workflow_runs": [_run(1, event="pull_request")]}  # short, nothing eligible
+            raise AssertionError(path)
+
+        assert friction.pick_ledger(repo=REPO, branch="main", self_run_id=None, fetch=fetch) == {
+            "run_id": None,
+            "artifact_id": None,
+        }
+        assert seen == [1]
+
+        def endless(path: str) -> object:
+            if path.startswith("actions/workflows/"):
+                return {"workflow_runs": [_run(1, event="pull_request")] * 100}
+            raise AssertionError(path)
+
+        friction.pick_ledger(repo=REPO, branch="main", self_run_id=None, fetch=endless)
+        # bounded: MAX_RUN_PAGES pages at most, never an unbounded crawl
+        assert friction.MAX_RUN_PAGES == 5
+
+
+class TestArtifactUrlStamp:
+    def test_only_the_runs_own_keys_are_stamped(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        led, (e1, e2, e3), _ = _ledger_two_nights()
+        for e in (e1, e2, e3):
+            led["entries"][e["key"]]["last_seen"] = "2026-09-13"
+        ledger = tmp_path / "friction_ledger.json"
+        ledger.write_text(json.dumps(led), encoding="utf-8")
+        own = tmp_path / "friction.json"
+        own.write_text(json.dumps({"run_keys": [e1["key"]]}), encoding="utf-8")
+        rc = friction.main(
+            [
+                "issues",
+                "--ledger",
+                str(ledger),
+                "--repo",
+                "o/r",
+                "--date",
+                "2026-09-13",
+                "--artifact-url",
+                "https://a/b",
+                "--friction",
+                str(own),
+                "--dry-run",
+            ]
+        )
+        assert rc == 0
+        capsys.readouterr()
+        # --dry-run returns before the ledger is rewritten, so read the in-memory
+        # effect through a second, non-dry invocation with a fake gh.
+        monkeypatch.setattr(
+            friction, "_gh", lambda args: "[]" if args[:2] == ["issue", "list"] else ""
+        )
+        friction.main(
+            [
+                "issues",
+                "--ledger",
+                str(ledger),
+                "--repo",
+                "o/r",
+                "--date",
+                "2026-09-13",
+                "--artifact-url",
+                "https://a/b",
+                "--friction",
+                str(own),
+            ]
+        )
+        saved = json.loads(ledger.read_text(encoding="utf-8"))
+        assert saved["entries"][e1["key"]]["artifact_url"] == "https://a/b"
+        assert saved["entries"][e2["key"]].get("artifact_url") != "https://a/b"
+        assert saved["entries"][e3["key"]].get("artifact_url") != "https://a/b"
+        # Without the run's own keys nothing is stamped: refused, not guessed.
+        assert (
+            friction.main(
+                [
+                    "issues",
+                    "--ledger",
+                    str(ledger),
+                    "--repo",
+                    "o/r",
+                    "--date",
+                    "2026-09-13",
+                    "--artifact-url",
+                    "https://a/b",
+                ]
+            )
+            == 2
+        )
+
+
+class TestRerunAcrossMidnight:
+    def test_the_same_run_is_never_a_new_night_even_after_the_date_changed(self) -> None:
+        e = _entry()
+        led, _ = friction.merge_ledger(
+            friction.empty_ledger(), [e], date="2026-09-12", run_url="https://r/1"
+        )
+        row = led["entries"][e["key"]]
+        assert row["count"] == 1 and row["last_seen"] == "2026-09-12"
+        # Attempt 2 of the same run fires after midnight UTC: same run_url, new date.
+        led, new_keys = friction.merge_ledger(
+            led,
+            [{**e, "screenshot": "attempt-2/x.png"}],
+            date="2026-09-13",
+            run_url="https://r/1",
+        )
+        row = led["entries"][e["key"]]
+        assert new_keys == []
+        assert row["count"] == 1 and row["last_seen"] == "2026-09-12"
+        assert row["screenshot"] == e["screenshot"]  # attempt 1's evidence stands
+        # ... so the re-run has nothing "tonight" to file or comment on.
+        assert friction.tonight(led, "2026-09-13") == []
+        # A DIFFERENT run the next day is a recurrence as before.
+        led, _ = friction.merge_ledger(led, [e], date="2026-09-13", run_url="https://r/2")
+        assert led["entries"][e["key"]]["count"] == 2


### PR DESCRIPTION
Closes #10222. Part of #9578.

> for our GUI testers, I also want them to take from a new user perspective and report UI elements / workings / layouts that are confusing to them

## Summary

A second, independent channel on the GUI user-test lane: **what confused the tester**, reported beside PASS/FAIL and never folded into it. A scenario can pass with five confusions logged, or fail with none.

- **Persona** (`scenarios.PERSONAS`, new optional YAML field `persona`, default `new-user`). The tester is a first-time Kiro Crew user -- no docs, ordinary chat-app / editor background -- with a standing instruction to call `report_friction` the moment it pauses for more than a glance, cannot find a control, clicks the wrong thing, does not understand a label / icon / message, does not know what is happening, or finds the layout hides the main action, then carry on. `persona: none` is the bare tester (no tool, unchanged prompt) for expert-path scenarios or to measure the channel's own cost. The block is spliced into the harness system prompt after the non-negotiable RULES and before HOW TO WORK, so the persona cannot outrank the safety rules.
- **Entries** (`report_friction` tool, `test/gui_user/friction.py`): `surface`, `element`, `what_confused` (first person), `expected`, `actual`, `severity` ∈ blocker / slows-down / cosmetic. `friction.validate_entry` is the only way into `summary.json`: fields typed, trimmed and capped at 240 chars, unknown fields refused, `feature` must be a registry slug; the harness stamps `feature` (from the scenario), `scenario`, the last screenshot's artifact path and the step. Twelve per attempt; a duplicate, malformed or over-cap call gets a one-line tool result and never fails the task. Friction calls do not count against `max_steps`, and every friction entry in a batched response cites the screenshot and step the model was actually looking at when it decided the batch (not the state after an action that precedes it in the same response). `AttemptResult.friction[]` carries them; `summary["friction_count"]` marks a run that actually had the channel (set only for a real run with at least one friction-reporting persona -- a dry run or an all-`none` selection never claims "nothing confusing").
- **Cross-night identity**: `entry_key(feature, element, what_confused)` after case / whitespace / punctuation normalization. The workflow fetches the previous `gui-user-test-friction-ledger` artifact **from this run's own earlier attempt when it is a re-run of a scheduled night (that attempt already filed issues; the ledger upload overwrites for the same reason), else from the newest completed scheduled run of this workflow on the default branch only** (`friction.py pick-ledger`: run path, event, head branch, head+base repository and conclusion all checked, then the artifact's own `workflow_run` block against that run -- never a repository-wide name lookup, which a fork PR's artifact could satisfy; none = first night), `friction.py merge` folds tonight in (recurrence → `count`+1, `last_seen`, the newest sighting's surface / wording / evidence taken whole, worst severity kept; runs are told apart by `run_url`, so a second run on the same day refreshes the evidence under its own artifact without counting the day twice, and a re-run of the same run is the same run even after midnight UTC -- no count, no recurrence comment), writes `results/friction.json` (tonight's rows with counts and issue numbers) and -- on the scheduled run only -- re-uploads the ledger (90-day retention) after the issue step has recorded what it opened. A dispatch on any ref reads the ledger for its report but never writes it back, so runs on different refs cannot race each other's entries into the canonical ledger (the per-ref concurrency group already serializes one ref). Only a complete API answer with no eligible scheduled run holding a ledger starts a fresh one; a listing or download error fails the merge step, so a transient outage cannot replace the canonical ledger with an empty one. A night the harness did not run (no `friction.json`) carries the ledger forward and the issue step files nothing.
- **Where it shows**: `verdict.md`, the run summary and the nightly failure issue end with a **"New-user friction"** section -- one table per feature in registry order, worst severity first, capped at `SECTION_MAX_CHARS` = 30k with a counted trailer (issue bodies / comments stop at 64k), where / expected → actual / how many nights / screenshot link into the artifact. `report.py --friction results/friction.json` swaps in the ledger-aware rows (the merge step re-renders `verdict.md` with them, so the uploaded verdict carries the counts); on the nightly, `friction.py snapshot` rebuilds that file from the ledger right after the issue step, so the run summary and the nightly report show the issue numbers just opened (the uploaded artifact keeps the pre-filing snapshot). Model text is rendered inert (pipes, backticks, angle brackets, link brackets neutralized, `@` zero-width-joined, URL schemes and `www.` defanged, `#<digits>` zero-width-split so an on-screen `#123` never cross-references an issue so a URL the tester read off an injected page never autolinks in a bot-authored issue), same posture as the existing fenced final reports.
- **Issues** (nightly only, `friction.py issues`): each non-cosmetic row without an issue → first `gh issue list --search <key> in:body` and adopt an OPEN issue whose body carries the exact marker (a number the ledger lost to a cancelled run is never duplicated; a failed lookup skips the row for the night), else → `ux(<feature>): <what confused me>` with labels `ux`, `channel: gui-user-test`, `area:` mapped from the feature (`AREA_LABELS`, keyed only by registry slugs -- a test holds `AREA_LABELS ⊆ FEATURES` -- default `area: dashboard`), body marked `<!-- gui-user-friction <key> -->`; **at most five a night**, the rest wait in the summary and get their turn on a later night. A recurrence whose row has an issue → one "again on <date>" comment per date (`last_commented` makes a same-day rerun idempotent); every row seen tonight that has an issue is checked, and if a human has since **closed** that issue, the mapping is retired (kept under `closed_issues`) and a fresh issue is opened that links back to it. `friction.json` is scoped to the run's own keys, never to the date, so a same-day dispatch reports its own rows with its own artifact links, not the nightly's. Cosmetic never leaves the summary. The merge step runs under `set -euo pipefail`, so a failed ledger write after `friction.json` fails the step instead of letting a later render paint it green. The issues step exits with the `issues` command's code even though the snapshot runs afterwards, so a partial filing failure stays red. The ledger is written **atomically** (sibling temp file, `fsync`, `os.replace`; a cut-short write leaves the previous document intact) after **every** successful `gh` mutation, so a failure partway through a batch keeps the numbers already opened (a rerun files only what failed) and the step exits 2 with the failures listed. Labels are created with `--force` if missing (tolerated if not permitted). Workflow gains `actions: read` for the ledger download.

## Cost

Persona block ≈ 450 input tokens on every model call; each `report_friction` call is one extra round trip (≈ 7k input with the three kept screenshots, ≈ 150 output). At two to four friction calls per scenario that is ≈ +$0.10 per scenario on Sonnet pricing, ≈ **+$1 a night** on a twelve-scenario tier -- inside the $10 ceiling, with `persona: none` on low-priority scenarios as the lever if it ever binds. The nightly `--budget-usd` is unchanged here.

## What the report looks like

The lane's Bedrock role trusts `main` only, so a branch dispatch cannot produce a real sample (#9965 recorded the credential failure). The section below is rendered by `friction.py` from three **hand-written** entries fed through `merge` twice (two "nights") -- the exact shape the first nightly after merge will produce, with the tester's own wording in place of mine:

```
## New-user friction

_2 moment(s) where a first-time user stalled: 1 blocker · 1 slows-down · 0 cosmetic. Reported by the tester persona beside the verdict; a scenario can PASS and still list friction._

### Crew Members (`members`)

| Severity | What confused me | Where | Expected → actual | Seen | Screenshot |
|---|---|---|---|---|---|
| slows-down | I did not expect feature previews to live under Developer. | Settings page → Developer section header | A section named Previews or Labs near the top → It was the last item, under Developer | 2× · last 2026-09-13 | [`members-dm-hello/attempt-1/02-left_click.png`](artifact) |

### Settings (`settings`)

| Severity | What confused me | Where | Expected → actual | Seen | Screenshot |
|---|---|---|---|---|---|
| blocker | I could not tell whether the page had already changed theme or was still loading. | Settings › Display → Theme dropdown | An immediate visible change → Nothing changed for a second, then it did | new | [`settings-theme-toggle/attempt-1/03-left_click.png`](artifact) |
```

The nightly issue for the blocker row would be titled `ux(settings): I could not tell whether the page had already changed theme or was still loading.` with labels `ux`, `channel: gui-user-test`, `area: dashboard`.

## Tests

`test/gui_user/test_friction.py` (new, 58 tests / 76 cases, written not run under pytest locally -- CI runs them): persona default / `none` / unknown; prompt splice order; `report_friction` present only for a reporting persona in both tool modes and absent from the x11 action vocabulary; entry validation (trim, cap, rejects, unknown feature, non-mapping); key normalization; `collect` dedupe (a key repeated across attempts folds to the worst severity with the newest evidence, so a cosmetic first sighting cannot hide a blocker retry); harness `_record_friction` (stores with last screenshot, duplicate / malformed / cap answers never error); `AttemptResult.friction` round-trips through `asdict`; ledger merge (counts, worst severity, idempotent re-merge, `tonight` ordering, load shapes); issue plan (cosmetic skipped, cap, hold-over, recurrence comment) and `file_issues` against a fake `gh` (labels, title, marker, comment text, label-create failure tolerated); rendering (grouping, ordering, counts, issue numbers, inert cells, empty state, `report.render_markdown` with and without the channel, `--friction` override, console line); atomic `_write` (no temp file left behind; a failed replace keeps the prior document); reconcile (marker match adopted, digest-in-prose not, failed lookup skips the key); section budget (80 max-length rows → ≤30k, worst rows shown, trailer counts the rest); `cancelled` / `timed_out` nightlies accepted as ledger sources, `skipped` not; CLI `merge` / `issues --dry-run` / `snapshot` (rows carry the issue number, provenance kept) / `pick-ledger` (writes the pick to `--out`, echoes nothing from the API, exits 2 on an API failure leaving an earlier answer intact) / missing input → 2; ledger provenance (`ledger_source_runs` rejects another workflow, `pull_request` / `workflow_dispatch`, an untrusted branch, a fork head or foreign base repository, missing blocks, unfinished or cancelled runs, malformed ids and junk; accepts a red nightly; `ledger_artifact_id` rejects another run's artifact, another branch, another name, expired; `pick_ledger` reads a re-run's own prior attempt first, never takes a ledger from an untrusted current run (dispatch / other branch / fork / malformed), walks the nightlies newest first page by page (100 a page, bounded by `MAX_RUN_PAGES`), skips a run without a ledger, never lists a rejected run's artifacts, returns nulls for a first night and propagates API errors / malformed answers); a full `Runner.attempt` against a scripted client and a fake display (action + `report_friction` in one response → PASS, one step, the entry cites the start screenshot at step 0, text-only tool result, persona in the system prompt). Existing tests are untouched: `custom_tools()` and `SYSTEM_PROMPT` are unchanged objects. black / isort / flake8 clean; workflow YAML parses.

## Not in this PR

A harness step placeholder for the seeded home path (needed by the knowledge P0 scenario) and a seeded-spawn hook (needed to assert the collapsed subagent cards) -- both tracked from #10181. The scenario batches themselves are #10180 / #10182 on top of #10040; this PR is based on `main` and touches `test_scenarios_and_report.py` nowhere, so the stack rebases cleanly in either order.
