### PR TITLE
fix(design-critique): pin report onto the uploaded image url, not the model's echoed path

### DIFF
--- a/website/src/apps/design-critique/DesignCritiquePage.tsx
+++ b/website/src/apps/design-critique/DesignCritiquePage.tsx
@@ -11,7 +11,7 @@ import { Spinner } from './Motion'
 import { S } from './styles'
 import { designCritiqueApi, fileUrl } from './api'
 import {
-  detectKind, jsonFromMessages, looksLikeReport, lastAssistant, shortLabel, relTime, readableOn, normalizeReport, normalizeScope,
+  detectKind, jsonFromMessages, looksLikeReport, lastAssistant, shortLabel, relTime, readableOn, normalizeReport, normalizeScope, resolveScreens,
   loadHistory, saveHistory, beginPendingCritique, dropPendingCritique, loadJobs, saveJob, clearJob, loadSlots, saveSlots, trackSlot, untrackSlot,
   loadLive, markLive, unmarkLive,
 } from './utils'
@@ -245,15 +245,6 @@ export default function DesignCritiquePage() {
     setOpenAskId(null); setSel(null); setAskDraft('')
     if (askSlotRef.current) { dropSlot(askSlotRef.current); askSlotRef.current = '' }
     setOpen(new Set([0])); setActive(null); setZoom(false); setScreenIdx(0); setPhase('report')
-  }
-
-  // Prefer the critic's own rendered screens; fall back to whatever we uploaded.
-  const resolveScreens = (rep: Report, uploaded: Screen[]): Screen[] => {
-    const fromRep = Array.isArray(rep && rep.screens) ? rep.screens!.filter(s => s && s.path) : []
-    if (fromRep.length) {
-      return fromRep.map((s, i) => ({ step: s.step || i + 1, label: s.label || 'Screen ' + (i + 1), url: fileUrl(s.path!) }))
-    }
-    return (uploaded || []).map((u, i) => ({ step: i + 1, label: (rep && rep.screens && rep.screens[i] && rep.screens[i].label) || 'Screen ' + (i + 1), url: u.url }))
   }
 
   /**

--- a/website/src/apps/design-critique/utils.ts
+++ b/website/src/apps/design-critique/utils.ts
@@ -228,6 +228,23 @@ export function relTime(ts: number): string {
   return fmtRelative(ts)
 }
 
+// The screen the report pins onto must load from a url WE built, never from a
+// path the model handed back. We give the critic the images as `![screen](path)`,
+// and it echoes a `screens[].path` — but that echo can be a chat placeholder
+// (`[image: <id>_name.png]`) or an invented path, which /api/file-raw cannot serve,
+// so the preview collapses and the pins pile up. `uploaded` already carries the
+// real url for every screen (an uploaded file, or a backend-rendered PNG) in the
+// order the critic reviewed them, so pin onto that url and take only the (nicer)
+// label from the model. With no url of our own there is nothing to show — the
+// report falls to its "couldn't get the pixels" state rather than a dead link.
+export function resolveScreens(rep: Report, uploaded: Screen[]): Screen[] {
+  return (uploaded || []).map((u, i) => ({
+    step: i + 1,
+    label: (rep.screens && rep.screens[i] && rep.screens[i].label) || u.label,
+    url: u.url,
+  }))
+}
+
 export const loadHistory = (): HistoryEntry[] => { try { return JSON.parse(localStorage.getItem(HKEY) || '[]') } catch { return [] } }
 /**
  * Show an in-flight run in the critique list. Called when `+ New` backgrounds a

--- a/website/src/test/DesignCritiqueResolveScreens.test.ts
+++ b/website/src/test/DesignCritiqueResolveScreens.test.ts
@@ -1,0 +1,36 @@
+// Which url the report pins its findings onto. The critic is handed the images
+// as `![screen](path)` and echoes a `screens[].path` back; that echo is NOT a
+// trustworthy file path — it can be the chat placeholder `[image: <id>_name.png]`
+// or an invented string, and /api/file-raw then serves nothing, so the preview
+// image fails to load and the numbered pins collapse into a pile. `resolveScreens`
+// therefore pins onto the url the app already built for each uploaded/rendered
+// screen and uses the model only for the (nicer) label.
+import { describe, expect, it } from 'vitest'
+
+import { resolveScreens } from '../apps/design-critique/utils'
+import type { Report, Screen } from '../apps/design-critique/types'
+
+const url = '/api/file-raw?path=%2FUsers%2Fme%2F.kiro%2Fcrew%2Fuploads%2Fabc_shot.png'
+const uploaded: Screen[] = [{ step: 1, label: 'Screen 1', url }]
+
+describe('resolveScreens', () => {
+  it('pins onto the uploaded url even when the model echoes a chat placeholder path', () => {
+    const rep: Report = { screens: [{ step: 1, label: 'Home', path: '[image: abc_Screenshot_2026-09-11.png' }] }
+    const [screen] = resolveScreens(rep, uploaded)
+    expect(screen.url).toBe(url)
+    expect(screen.url).not.toContain('image%3A')
+    // the model's readable label is still used
+    expect(screen.label).toBe('Home')
+  })
+
+  it('keeps the uploaded label when the model omits one', () => {
+    const [screen] = resolveScreens({}, uploaded)
+    expect(screen.url).toBe(url)
+    expect(screen.label).toBe('Screen 1')
+  })
+
+  it('never invents a url from the model when the app has none of its own', () => {
+    const rep: Report = { screens: [{ step: 1, label: 'Real', path: '/tmp/render/1.png' }] }
+    expect(resolveScreens(rep, [])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

In a Design Critique report, the numbered issue pins pile into a tiny broken-image box instead of sitting on the screenshot. The screenshot behind the pins never loads, so the box collapses to nothing and pins 1, 2, 3… stack on top of each other.

## Why it matters

The report becomes unreadable. The pins are meant to point at places on the screen, and with no screen they point at nothing. Every critique whose stored image address is wrong lands here.

## What changed (motivation → approach → change)

The report shows a picture and pins findings onto it. The app builds that picture's address itself when you upload a screenshot (or when it renders a repo/URL/Figma to a PNG).

The critic is also asked to hand back the image path, and the app trusted that answer over its own. But the critic can hand back the chat's stand-in label for an attached image — `[image: <id>_name.png]` — instead of a real file path. The app then asks `/api/file-raw` for a file at that made-up address, gets nothing, and the picture comes up blank.

`resolveScreens` now always pins onto the address the app already built for each screen, in the order the critic reviewed them, and takes only the (nicer) label from the critic. The critic's path is never turned into an image address. When the app has no address of its own there is nothing to show, so the report falls to its "couldn't get the pixels" state instead of a dead link.

```mermaid
flowchart LR
  subgraph Before
    R1[report screen]:::ctx --> P1["model's echoed path<br/>[image: …png]"]:::removed --> F1[/api/file-raw]:::ctx --> X1[blank box, pins pile up]:::removed
  end
  subgraph After
    R2[report screen]:::ctx --> P2[uploaded/rendered url<br/>the app built]:::added --> F2[/api/file-raw]:::ctx --> X2[screenshot loads, pins land]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1,2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 3,4,5 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The report now loads the screenshot from the address the app controls, so the picture shows and the pins land on it.*

## Tests

New `website/src/test/DesignCritiqueResolveScreens.test.ts` locks in three cases: a critic that echoes the `[image: …]` placeholder still pins onto the uploaded url (the reported bug); a critic that returns no label keeps the uploaded label; and an empty uploaded set returns nothing rather than inventing a url from the critic's path. The existing 140 design-critique tests, including the full page-render coverage suite, still pass.

## Manual verification

N/A from a worktree — this surface renders only inside the signed-in dashboard, and the bug only appears when a live critic returns a placeholder path, which cannot be reproduced offline. The exact broken address was read from the app's saved history during diagnosis: `/api/file-raw?path=[image: cafc9b4b…_Screenshot_2026-09-11….png`, an unservable path. The fix routes that same screen to `/api/file-raw?path=/Users/…/.kiro/crew/uploads/cafc9b4b…png`, which exists on disk. Behaviour is pinned by the unit tests above.

## Screenshots / video

The diff changes no markup, layout, theme, or styling — it changes which address the report loads its image from, which the component renders identically for. The visible effect only appears with the production runtime data above, so there is no static delta to capture from a worktree. Before/after behaviour is in the diagram above.

## Related Issues

No linked issue: found and diagnosed directly from a user report of the broken report view.

## Pattern harvest

Rule candidate: review-prompt
Pattern: trusting a model-echoed file path/URL as authoritative when the caller already holds the real one — prefer the known-good value and never turn model output into a resource address.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
