### PR TITLE
fix(mcp-gateway): warn once per env-key collision, not per rewrite

### DIFF
--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -31,6 +31,7 @@ import shlex
 import shutil
 import sys
 import tempfile
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Collection, Mapping
@@ -46,6 +47,29 @@ from kiro_crew.mcp_utils import mcp_server_alias
 from kiro_crew.sandbox import scrub_agent_denied_env
 
 logger = logging.getLogger(__name__)
+
+# Normalized ``KIROCREW_MCP_TARGET_<SERVER>`` keys already warned about as a
+# base-name collision, so the notice fires once per distinct colliding key per
+# process instead of once per rewrite pass. ``_collect_target_env`` runs on
+# every pass (one call per agent spec, plus one per kept overlay), so a
+# genuinely single ambiguous config would otherwise print the same WARNING line
+# on every boot pass -- a wall of identical text an operator cannot count
+# distinct problems from. Guarded by ``_collision_warn_lock`` so two threads
+# rewriting at once cannot both report the same key. Repeats drop to DEBUG.
+_collision_warn_lock = threading.Lock()
+_collision_warned_keys: set[str] = set()
+
+
+def _reset_collision_warnings() -> None:
+    """Clear the per-process env-key collision warning latch.
+
+    A test hook: the module-level ``_collision_warned_keys`` set persists for
+    the life of the process, so a test that asserts on the WARNING record must
+    reset it between cases to see the first-occurrence notice again.
+    """
+    with _collision_warn_lock:
+        _collision_warned_keys.clear()
+
 
 # Fingerprint of the last completed rewrite, stored inside the overlay dir so
 # an unchanged boot can skip re-parsing every agent spec, re-resolving every
@@ -2076,12 +2100,24 @@ def _collect_target_env(
             # ambiguous config is visible rather than silently first-wins.
             existing = target_env.get(env_key)
             if existing is not None and existing != spec:
-                logger.warning(
-                    "mcp-gateway rewriter: KIROCREW_MCP_TARGET env-key collision on "
-                    "%s (distinct server names normalize identically); the "
-                    "args-hashed key is used at resolve time, base stays "
-                    "first-wins", env_key,
-                )
+                with _collision_warn_lock:
+                    first = env_key not in _collision_warned_keys
+                    if first:
+                        _collision_warned_keys.add(env_key)
+                if first:
+                    logger.warning(
+                        "mcp-gateway rewriter: KIROCREW_MCP_TARGET env-key collision on "
+                        "%s (distinct server names normalize identically); the "
+                        "args-hashed key is used at resolve time, base stays "
+                        "first-wins",
+                        env_key,
+                    )
+                else:
+                    logger.debug(
+                        "mcp-gateway rewriter: KIROCREW_MCP_TARGET env-key collision on "
+                        "%s again (already reported this pass or a prior one)",
+                        env_key,
+                    )
             target_env.setdefault(env_key, spec)
             # Args-disambiguated key: idempotent per (server, command+args), so
             # divergent same-named servers do not collide on first-wins.

--- a/test/test_mcp_gateway_rewriter_collision_warning.py
+++ b/test/test_mcp_gateway_rewriter_collision_warning.py
@@ -1,0 +1,123 @@
+"""Regression tests: the env-key collision warning fires once per key.
+
+``_collect_target_env`` runs on every rewrite pass (one call per agent spec,
+plus one per kept overlay), so a single ambiguous config — two distinct server
+names that normalize to one ``KIROCREW_MCP_TARGET_<SERVER>`` env key — would
+print the same WARNING line on every pass. The emitter latches each distinct
+normalized key at module level so the notice fires once per key per process.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kiro_crew.mcp_gateway import rewriter
+from kiro_crew.mcp_gateway.rewriter import (
+    _WRAPPER_MARKER,
+    _collect_target_env,
+    _reset_collision_warnings,
+)
+
+_COLLISION_TEXT = "KIROCREW_MCP_TARGET env-key collision on"
+
+
+@pytest.fixture(autouse=True)
+def reset_collision_latch():
+    """Clear the per-process warning latch around each case.
+
+    The latch is module-level and persists for the life of the process, so a
+    test asserting on the first-occurrence WARNING must reset it or a prior
+    test that already tripped the same key would suppress the record.
+    """
+    _reset_collision_warnings()
+    yield
+    _reset_collision_warnings()
+
+
+def _wrapped_entry(target_command: str, target_arg: str) -> dict:
+    """A rewritten (wrapped) MCP entry shaped as ``_build_stub_entry`` emits."""
+    return {
+        _WRAPPER_MARKER: True,
+        "command": "/bin/stub",
+        "args": [
+            "--target-command",
+            target_command,
+            f"--target-args={target_arg}",
+        ],
+    }
+
+
+def test_colliding_pair_warns_once_across_two_passes(caplog):
+    """Two server names normalizing to one env key, rewritten twice, produce
+    exactly one WARNING record for that key."""
+    # "builder-mcp" and "builder_mcp" both normalize to
+    # KIROCREW_MCP_TARGET_BUILDER_MCP; distinct target specs make it a real
+    # collision rather than a first-wins no-op.
+    servers = {
+        "builder-mcp": _wrapped_entry("/opt/a/builder", "--mode=a"),
+        "builder_mcp": _wrapped_entry("/opt/b/builder", "--mode=b"),
+    }
+
+    with caplog.at_level(logging.DEBUG, logger=rewriter.logger.name):
+        _collect_target_env(dict(servers), {})  # pass 1 (one spec)
+        _collect_target_env(dict(servers), {})  # pass 2 (a later rewrite)
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and _COLLISION_TEXT in r.getMessage()
+    ]
+    assert len(warnings) == 1, [r.getMessage() for r in warnings]
+    assert "KIROCREW_MCP_TARGET_BUILDER_MCP" in warnings[0].getMessage()
+    # The full first-occurrence text is preserved.
+    assert "the args-hashed key is used at resolve time" in warnings[0].getMessage()
+
+
+def test_two_distinct_colliding_keys_each_warn_once(caplog):
+    """Two different colliding key groups each get their own single WARNING."""
+    servers = {
+        "builder-mcp": _wrapped_entry("/opt/a/builder", "--mode=a"),
+        "builder_mcp": _wrapped_entry("/opt/b/builder", "--mode=b"),
+        "search-mcp": _wrapped_entry("/opt/a/search", "--mode=a"),
+        "search_mcp": _wrapped_entry("/opt/b/search", "--mode=b"),
+    }
+
+    with caplog.at_level(logging.DEBUG, logger=rewriter.logger.name):
+        _collect_target_env(dict(servers), {})
+        _collect_target_env(dict(servers), {})
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and _COLLISION_TEXT in r.getMessage()
+    ]
+    keyed = {
+        "BUILDER_MCP": sum("KIROCREW_MCP_TARGET_BUILDER_MCP" in r.getMessage() for r in warnings),
+        "SEARCH_MCP": sum("KIROCREW_MCP_TARGET_SEARCH_MCP" in r.getMessage() for r in warnings),
+    }
+    assert keyed == {"BUILDER_MCP": 1, "SEARCH_MCP": 1}, [r.getMessage() for r in warnings]
+
+
+def test_reset_hook_lets_the_warning_fire_again(caplog):
+    """The reset hook clears the latch so a fresh case sees the notice again."""
+    servers = {
+        "builder-mcp": _wrapped_entry("/opt/a/builder", "--mode=a"),
+        "builder_mcp": _wrapped_entry("/opt/b/builder", "--mode=b"),
+    }
+
+    with caplog.at_level(logging.WARNING, logger=rewriter.logger.name):
+        _collect_target_env(dict(servers), {})
+        first = [r for r in caplog.records if _COLLISION_TEXT in r.getMessage()]
+        assert len(first) == 1
+
+        caplog.clear()
+        _collect_target_env(dict(servers), {})
+        assert not [r for r in caplog.records if _COLLISION_TEXT in r.getMessage()]
+
+        caplog.clear()
+        _reset_collision_warnings()
+        _collect_target_env(dict(servers), {})
+        after = [r for r in caplog.records if _COLLISION_TEXT in r.getMessage()]
+        assert len(after) == 1


### PR DESCRIPTION
## Problem / Motivation

At gateway start an operator saw the `KIROCREW_MCP_TARGET` env-key collision
WARNING printed six identical times within one second:

```
WARNING kiro_crew.mcp_gateway.rewriter: mcp-gateway rewriter: KIROCREW_MCP_TARGET env-key collision on KIROCREW_MCP_TARGET_BUILDER_MCP (distinct server names normalize identically); the args-hashed key is used at resolve time, base stays first-wins
```

A wall of identical lines gives no way to tell whether six distinct problems
exist or one config is being reported repeatedly.

## Why it matters

The collision itself is real and already handled (two configured server names
such as `builder-mcp` and `builder_mcp` normalize to one env key; the rewriter
disambiguates with an args-hashed key at resolve time). The defect is pure log
noise that defeats the warning's purpose — an operator cannot count distinct
ambiguous configs from the output.

## What changed (motivation → approach → change)

`_collect_target_env` runs on every rewrite pass — once per agent spec, plus
once per kept overlay — and re-derives the base `KIROCREW_MCP_TARGET_<SERVER>`
keys each time, so the WARNING fired on every pass that re-encountered the
colliding pair.

The emitter now latches each distinct normalized colliding key in a
module-level `set[str]` guarded by a `threading.Lock` (matching the warn-once
convention already used in `mcp_discovery.py`, `metrics/inventory_gauges.py`,
etc.). The full-text WARNING fires once per key per process; later occurrences
drop to DEBUG. A `_reset_collision_warnings` hook clears the latch for tests.
The collision handling itself is unchanged.

## Tests

Added `test/test_mcp_gateway_rewriter_collision_warning.py`:

- a colliding pair rewritten over two passes yields exactly one WARNING record
  for that key (via `caplog`), with the full first-occurrence text preserved;
- two DIFFERENT colliding key groups each get exactly one WARNING;
- the reset hook re-arms the notice.
- autouse fixture resets the module latch around each case.

Ran the new file plus every rewriter/target-env test file
(`test_mcp_gateway_cluster_fixes.py`, `test_mcp_gateway_target_map_drift.py`,
`test_mcp_resolve_once.py`, `test_mcp_gateway_adopted_daemon_repair.py`):
173 passed.

## Manual verification

Confirmed by test: two `_collect_target_env` passes over a colliding pair
produce a single WARNING; a third pass after `_reset_collision_warnings()`
produces one again. All pre-commit gates pass (black baseline unchanged —
inserted code is black-clean; isort, flake8, mypy, comment-history,
harness-parity, subprocess-encoding, docs-lint).

## Related Issues

no linked issue: assigned directly as a single-defect fix task.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A per-item WARNING inside a function called once per spec/pass floods
the log; latch first-seen keys in module state (warn once, DEBUG after) with a
test reset hook, rather than logging unconditionally on each pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (n/a: no spec documents this warning)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
