### PR TITLE
fix(cli): name the unrecognised listener instead of "no gateway running"

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -1146,7 +1146,15 @@ that must not change, because the SPA's per-origin `localStorage` is keyed on it
    `/proc/<pid>/cmdline` (Linux), `ps -o command=` (macOS), `Win32_Process.CommandLine`
    via WMI (Windows). The Windows venv `kirocrew.exe` re-execs `python.exe`, so the
    match is on the command line (`-m kiro_crew gateway` / `\Scripts\kirocrew.exe gateway`),
-   not the image name.
+   not the image name. `_args_look_like_kirocrew` parses the command line structurally
+   and keys on a server subcommand plus a recognised module name. The module name is
+   matched against `port_resolution._gateway_module_roots()`: always `kiro_crew`, plus
+   the top-level module of every installed `kirocrew.plugins` entry point, so a composed
+   edition whose launcher execs its own module with `-m` classifies without the core
+   knowing any edition's name. When a listener exists but none of the pids classify,
+   `stop` names the pid(s) — with the cmdline basename when cheap — and exits 1 with SEL
+   `reason=unrecognized_listener`, rather than reporting "no gateway running" for a port
+   that is occupied.
 4. Terminate each verified PID: `os.kill(SIGTERM)` on POSIX; `taskkill /T /F`
    (via `platform_compat.kill_process_tree`) on Windows so the gateway's detached
    children are reaped too. Liveness is probed with `platform_compat.pid_exists`
@@ -1187,6 +1195,16 @@ that must not change, because the SPA's per-origin `localStorage` is keyed on it
      `try / except SystemExit` so a TOCTOU race (gateway exits between the
      listener check and `_stop`'s own lookup → `_stop` calls `sys.exit(1)`)
      does not abort the restart before the spawn.
+   - When a listener IS present but none of the pids classify as a Kiro Crew
+     gateway, `_stop` declines it (see step 3 above) and the incumbent list is
+     empty, so restart resolves the incumbent through `gateway.lock` instead
+     (`_incumbent_from_lock_holder`): a live holder that did not acknowledge the
+     shutdown is refused by `_refuse_lock_holder` and no replacement is spawned.
+     A gateway booted from a module the classifier does not recognise lands exactly
+     there — it holds the lock and `stop` could not signal it — so recognition, not
+     the restart path, is what makes the ordinary stop → wait → spawn path run. A
+     foreign listener that holds no lock still leaves the spawn to proceed and fail
+     on its own bind.
    - Spawn a detached `kirocrew gateway` via `subprocess.Popen`, stdin set
      to `subprocess.DEVNULL`, and stdout + stderr redirected to
      `~/.kiro/crew/gateway.log` (the same file the `kirocrew logs` command

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -8,6 +8,7 @@ import http.client
 import json
 import logging
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -382,6 +383,26 @@ def _report_authenticated_shutdown(port: int) -> bool:
     return True
 
 
+#: Longest process basename ``_stop`` echoes to the operator's terminal.
+_MAX_ECHOED_NAME_LEN = 64
+
+
+def _terminal_safe_name(name: str) -> str:
+    """Reduce an untrusted process name to characters safe to print.
+
+    The name comes from another process's own ``argv[0]``: any local process
+    can bind the gateway port and choose it, so it is attacker-producible text
+    headed for the operator's terminal. Every non-printable code point is dropped
+    -- C0/C1 controls (so ESC and BEL, which start and end ANSI SGR and OSC
+    sequences), and Unicode format characters -- and the result is capped, so a
+    crafted name can neither drive the terminal nor flood the line.
+    ``str.isprintable`` is the filter: it keeps letters, digits, punctuation and
+    ordinary spaces of every script and rejects the whole control and format
+    classes without enumerating escape grammars.
+    """
+    return "".join(ch for ch in name if ch.isprintable())[:_MAX_ECHOED_NAME_LEN]
+
+
 def _stop(cli_port: int | None = None) -> None:
     """Stop a running KiroCrew gateway.
 
@@ -493,16 +514,45 @@ def _stop(cli_port: int | None = None) -> None:
     # Only kill processes that are actually KiroCrew gateways.
     # Note: TOCTOU race exists between this check and the kill — the PID could be
     # recycled. Acceptable risk for an interactive CLI tool with low blast radius.
+    unrecognized = [p for p in pids if not _is_kirocrew_process(p)]
     pids = [p for p in pids if _is_kirocrew_process(p)]
     if not pids:
+        # Something holds the port, but nothing on it classifies as a Kiro Crew
+        # gateway. Reporting "no gateway running" here is misleading — the port
+        # is occupied — and it sends ``kirocrew restart`` on to spawn a
+        # replacement the KIROCREW_HOME lock then refuses. Name the pids and, when
+        # a cmdline is cheap to read, its basename, so the operator can see what
+        # actually holds the port (an unregistered wrapper module is the common
+        # case). Exit 1 with a distinct audit reason.
+        basenames: list[str] = []
+        for p in unrecognized:
+            cmdline = platform_compat.process_command_line(p)
+            if not cmdline:
+                continue
+            # Tokenize the way _args_look_like_kirocrew does: a quoted executable
+            # path ("C:\Program Files\...\python.exe") is one token, so its
+            # basename is reported rather than the fragment before the first space.
+            try:
+                tokens = shlex.split(cmdline, posix=not platform_compat.IS_WINDOWS)
+            except ValueError:
+                tokens = cmdline.split()
+            if tokens:
+                safe = _terminal_safe_name(_basename_stem(tokens[0]))
+                if safe:
+                    basenames.append(safe)
+        pid_list = ", ".join(str(p) for p in unrecognized)
+        detail = f" ({', '.join(basenames)})" if basenames else ""
         sel().log_api_access(
             caller="cli",
             operation="gateway_stop",
             outcome="no_target",
             source="cli",
-            resources=f"port={port} reason=no_kirocrew_process",
+            resources=f"port={port} reason=unrecognized_listener pids={unrecognized}",
         )
-        print(f"No Kiro Crew gateway currently running on port {port}.")
+        print(
+            f"Port {port} is held by pid {pid_list}{detail}, not recognised as a "
+            f"Kiro Crew gateway. Not stopping it."
+        )
         sys.exit(1)
 
     sent: set[int] = set()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2316,14 +2316,47 @@ class TestStop:
         assert "reason=lsof_not_found" in resources
 
     def test_no_kirocrew_process(self, capsys):
-        # A listener exists but its cmdline isn't a kirocrew gateway → refuse to kill.
+        # A listener exists but its cmdline isn't a kirocrew gateway → refuse to kill,
+        # but name the pid so the operator can see what holds the port.
         from kiro_crew.cli_server import _stop
 
         with self._mock_sel(), self._ports([1234]), self._cmdline("nginx: worker"):
             with pytest.raises(SystemExit) as exc:
                 _stop(5476)
             assert exc.value.code == 1
-        assert "No Kiro Crew gateway" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "1234" in out
+        assert "not recognised" in out
+        assert "(nginx:)" in out
+
+    def test_unrecognised_listener_names_a_quoted_executable_basename(self, capsys):
+        # A quoted executable path is one token; the message must carry its
+        # basename, not the fragment before the first space.
+        from kiro_crew.cli_server import _stop
+
+        quoted = '"/opt/some tool/bin/otherd" --port 5476'
+        with self._mock_sel(), self._ports([4321]), self._cmdline(quoted):
+            with pytest.raises(SystemExit):
+                _stop(5476)
+        out = capsys.readouterr().out
+        assert "(otherd)" in out
+        assert "/opt/some" not in out
+
+    def test_unrecognised_listener_name_cannot_drive_the_terminal(self, capsys):
+        # argv[0] is chosen by whoever holds the port: escape sequences, OSC
+        # title changes and BEL must be stripped before the name is echoed, and
+        # the name is capped so it cannot flood the line.
+        from kiro_crew.cli_server import _MAX_ECHOED_NAME_LEN, _stop, _terminal_safe_name
+
+        hostile = "/tmp/\x1b[31mred\x1b[0m\x1b]0;owned\x07" + "x" * 200
+        with self._mock_sel(), self._ports([4321]), self._cmdline(f"'{hostile}' --port 5476"):
+            with pytest.raises(SystemExit):
+                _stop(5476)
+        out = capsys.readouterr().out
+        assert "\x1b" not in out and "\x07" not in out
+        assert "[31mred[0m]0;owned" in out  # printable residue only, no ESC/BEL
+        assert len(out.split("(", 1)[1].split(")", 1)[0]) <= _MAX_ECHOED_NAME_LEN
+        assert _terminal_safe_name("\x1b\x07\u200b") == ""
 
     def test_successful_stop(self, capsys):
         from kiro_crew.cli_server import _stop


### PR DESCRIPTION
## Problem / Motivation

With a Kiro Crew gateway listening on port 5476 whose command line the classifier did not recognise (a composed edition booted from its own module — the case #10280 has since taught the classifier about), `kirocrew stop` printed:

```
No Kiro Crew gateway currently running on port 5476.
```

and exited 1, while `ps` showed the gateway alive on that port. The message is the one written for an EMPTY port, so the operator read it as "the port is free", tried a restart that could not succeed, and only `kill <pid>` recovered.

**Evidence from the affected host (security event log, sanitized, 2026-09-11 UTC):**

```
22:07:10  api_access  cli  gateway_stop     outcome=no_target  port=5476 reason=no_kirocrew_process
22:07:11  api_access  cli  gateway_restart  outcome=denied     port=5476 via=fork pid=666158 reason=replacement_died exit=1
22:13:53  api_access  cli  gateway_stop     outcome=no_target  port=5476 reason=no_kirocrew_process
```

At 22:13:53 the listener (pid 101060, `... python3.12 -m <edition module> gateway --no-open --no-crons`, parent `.../bin/kirocrew gateway`) was alive and answering HTTP on 5476; the operator saw "no gateway running", and the restart one second after the 22:07 stop spawned a replacement that the `KIROCREW_HOME` lock refused (`gateway.lock is held by pid 101060 ... another gateway already owns ...`). The audit row carries no pid and a reason that reads as "nothing there".

## Why it matters

`stop` is the operator's ground truth for "is a gateway on this port". Reporting an occupied port as empty sends them down the wrong recovery path (restart, then a hunt for a replacement that never existed) and leaves an audit trail that cannot be distinguished from a genuinely idle port. Recognition failures will recur — any future launcher shape the classifier has not seen — so the message for "occupied but unrecognised" must be honest on its own, independent of how good the classifier is.

## What changed (motivation → approach → change)

Root cause: `_stop` filters the listening pids through `_is_kirocrew_process`; when the filter leaves nothing it falls into the same branch as "no listener at all" and prints that branch's message.

Approach: keep the fail-closed behaviour (never signal a process the classifier does not vouch for) but say what is true: the port is held by pid(s) N, they are not recognised as a Kiro Crew gateway, and nothing is being stopped. Recognition itself is not touched here — `main` now derives gateway module roots from installed `kirocrew.plugins` entry points (#10280), which resolves the composed-edition case; this PR is the message and audit contract that stays honest when recognition fails for the next reason.

Change:
- **`cli_server._stop`** — on listeners with no recognised gateway: print `Port <p> is held by pid <n>[ (<basename>)], not recognised as a Kiro Crew gateway. Not stopping it.`, exit 1, audit `reason=unrecognized_listener pids=[...]`. The empty-port message and exit code are unchanged.
- **`test/test_cli.py`** — the unrecognised-listener test pins the pid in the output, the "not recognised" wording and the audit reason.
- **`docs/system-specs/modules/cli.md`** — describes the classifier as `main` has it (entry-point-derived roots) and the message contract, in the same commit.

`_restart` is untouched: it already resolves an empty incumbent list through `gateway.lock` and refuses a live holder that did not acknowledge the shutdown (#9626).

## Tests

`test/test_cli.py::TestStop` unrecognised-listener case (pid named, "not recognised" wording, `reason=unrecognized_listener` audit). Ran `test_cli.py`, `test_cli_server_more_coverage.py`, `test_restart_command.py` on the rebased tree: 505 passed, 2 skipped. black-baseline, flake8, mypy, comment-history, brand-name, harness-parity and docs-lint gates pass.

## Manual verification

Not run against a live gateway (the host policy forbids signalling the running gateway from the agent). The failure itself was observed live on the affected host (audit rows above, plus the operator's terminal transcript); the fixed branch is verified by the unit test that reproduces that branch.

## Related Issues

no linked issue: observed on an internal host while diagnosing an unrelated app defect; #10280 covers the recognition half.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a filter that can empty a non-empty candidate list must not share its "nothing found" message with the genuinely-empty case — "none qualified" and "none present" are different facts and need different words and audit reasons.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
