### PR TITLE
fix: revert refused optimistic title on header rename failure (#10203)

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3977,6 +3977,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   )
 
   const cancelTitleRef = useRef(false)
+  // #10203: per-slot recovery state for header-rename failures. `gen` is a
+  // monotonic attempt generation: a recovery may apply ONLY while its own
+  // attempt is still the slot's latest, so a delayed recovery can never
+  // overwrite anything a newer attempt (failed or successful) did -- title
+  // equality alone cannot tell a stale optimistic value from a newer confirmed
+  // rename to the identical string. `baseline` is the last CONFIRMED title;
+  // `inflight` holds this slot's own un-settled optimistic titles, so a store
+  // title outside that set refreshes the baseline at commit time (a success
+  // here, or another client's rename delivered over SSE). The entry is dropped
+  // when the last pending attempt settles.
+  const renameRecoveryRef = useRef(new Map<string, { baseline: string; inflight: Set<string>; gen: number }>())
   // The session-title field is an Enter-to-commit input; the guard owns both the
   // composition latch and the keypress, so the rename cannot fire on the Enter that
   // commits an IME candidate.
@@ -6544,7 +6555,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 <div className="flex min-w-0 flex-1 items-center gap-1 px-1.5 py-0.5 rounded-l-[2px] rounded-r-md bg-bg-hover">
                   {currentSlot?.memory_mode === 'incognito' && <span title={i18nT('pages.chatPage.incognito_memory_writes_disabled')}><EyeOff size={13} className="shrink-0 text-warn" /></span>}
                   {currentSlot?.memory_mode === 'temporary' && <span title={i18nT('pages.chatPage.temporary_no_memory_reads_or_writes')}><VenetianMask size={13} className="shrink-0 text-aim" /></span>}
-                  <Input className="session-header-title text-sm font-semibold text-muted font-body bg-transparent border-0 rounded-none p-0 m-0 min-w-0 flex-1 outline-none md:max-w-[50vw] focus:!shadow-none focus-visible:border-b focus-visible:border-accent" size={Math.min(Math.max(titleDraft.length + 2, 6), 80)} autoFocus value={titleDraft} onChange={e => setTitleDraft(e.target.value)} {...titleIme.bindComposition<HTMLInputElement>({ onBlur: () => { if (!cancelTitleRef.current && titleDraft.trim() && activeSlot && titleDraft !== title) { dispatch(sseSlotTitle({ key: activeSlot, title: titleDraft.trim() })); api.renameSlot(activeSlot, titleDraft.trim()).catch(e => showActionError(errMessage(e) || i18nT('pages.chatPage.unknown_error'), i18nT('pages.chatPage.could_not_rename_session'))) } cancelTitleRef.current = false; setEditingTitleSlot(null) } })} onKeyDown={e => { if (e.key === 'Enter' && titleIme.claimEnter(e)) (e.target as HTMLInputElement).blur(); if (e.key === 'Escape') { titleIme.reset(); cancelTitleRef.current = true; setEditingTitleSlot(null) } }} />
+                  {/* #10203: a refused rename must also revert the optimistic sseSlotTitle.
+                      Recovery re-reads the server truth (deduped through queryClient.fetchQuery)
+                      and applies ONLY this slot's title -- never the whole snapshot, whose late
+                      fulfillment could transiently clobber a newer concurrent write of another
+                      slot. A recovery may apply only while ITS OWN attempt is the slot's latest
+                      generation AND the store still holds its refused value, so a delayed
+                      recovery can never overwrite a newer attempt's outcome -- including a newer
+                      confirmed rename to the identical string, which title equality alone cannot
+                      distinguish. When the re-read fails (transport or auth failure takes
+                      renameSlot and chatSlots down together) fall back to a local revert to the
+                      recovery baseline in renameRecoveryRef: the last CONFIRMED title, refreshed
+                      at commit time from any store title that is not one of this slot's own
+                      pending optimistic values. */}
+                  <Input className="session-header-title text-sm font-semibold text-muted font-body bg-transparent border-0 rounded-none p-0 m-0 min-w-0 flex-1 outline-none md:max-w-[50vw] focus:!shadow-none focus-visible:border-b focus-visible:border-accent" size={Math.min(Math.max(titleDraft.length + 2, 6), 80)} autoFocus value={titleDraft} onChange={e => setTitleDraft(e.target.value)} {...titleIme.bindComposition<HTMLInputElement>({ onBlur: () => { if (!cancelTitleRef.current && titleDraft.trim() && activeSlot && titleDraft !== title) { const key = activeSlot; const refused = titleDraft.trim(); const rec = renameRecoveryRef.current.get(key) ?? { baseline: title, inflight: new Set<string>(), gen: 0 }; const current = boundStore.getState().dashboard.slots.find(s => s.key === key)?.title ?? title; if (!rec.inflight.has(current)) rec.baseline = current; rec.inflight.add(refused); rec.gen++; const myGen = rec.gen; renameRecoveryRef.current.set(key, rec); const settle = () => { rec.inflight.delete(refused); if (rec.inflight.size === 0 && rec.gen === myGen) renameRecoveryRef.current.delete(key) }; const mayRecover = () => rec.gen === myGen && boundStore.getState().dashboard.slots.find(s => s.key === key)?.title === refused; dispatch(sseSlotTitle({ key, title: refused })); api.renameSlot(key, refused).then(() => { if (rec.gen === myGen) rec.baseline = refused; settle() }, async e => { showActionError(errMessage(e) || i18nT('pages.chatPage.unknown_error'), i18nT('pages.chatPage.could_not_rename_session')); try { const server = (await queryClient.fetchQuery({ queryKey: ['chat-slots'], queryFn: () => api.chatSlots(), staleTime: 0, gcTime: 0 })).find((s: { key: string; title?: string }) => s.key === key); if (server?.title !== undefined && rec.gen === myGen) rec.baseline = server.title; if (mayRecover()) dispatch(sseSlotTitle({ key, title: server?.title ?? rec.baseline })) } catch { if (mayRecover()) dispatch(sseSlotTitle({ key, title: rec.baseline })) } finally { settle() } }) } cancelTitleRef.current = false; setEditingTitleSlot(null) } })} onKeyDown={e => { if (e.key === 'Enter' && titleIme.claimEnter(e)) (e.target as HTMLInputElement).blur(); if (e.key === 'Escape') { titleIme.reset(); cancelTitleRef.current = true; setEditingTitleSlot(null) } }} />
                 </div>
               ) : (
                 <div className="cursor-text flex min-w-0 items-center gap-1 px-1.5 py-0.5 rounded-l-[2px] rounded-r-md group-hover/header:bg-bg-hover transition-colors">

--- a/website/src/test/ChatPage.titleRenamePin.test.tsx
+++ b/website/src/test/ChatPage.titleRenamePin.test.tsx
@@ -13,7 +13,7 @@
  * commits) before any switch, which the last case pins down.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider } from 'react-redux'
@@ -203,5 +203,172 @@ describe('ChatPage – header rename is pinned to the session it opened on', () 
     const revived = screen.queryByDisplayValue(TITLE_A)
     if (revived) act(() => { fireEvent.blur(revived) })
     expect(apiMocks.renameSlot).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * Regression for #10203 (the header-side mirror of #10151): a server-refused
+ * header rename dispatched the optimistic `sseSlotTitle` and then only reported
+ * the failure via `showActionError` -- the refused title stayed in the store
+ * (header AND sidebar read it) until an unrelated slot refetch or a reload.
+ * The `.catch` now re-reads the server truth and applies ONLY this slot's
+ * title, guarded on the store still holding the refused value -- never the
+ * whole snapshot, whose late fulfillment could clobber a newer concurrent
+ * write (the residual both review lanes flagged on a fetchSlots-based shape).
+ * When the re-read itself fails too, the catch falls back to a guarded local
+ * revert to the pre-rename title.
+ */
+describe('ChatPage - a refused header rename reverts the optimistic title (#10203)', () => {
+  beforeEach(() => { Object.keys(apiMocks).forEach(k => delete apiMocks[k]) })
+
+  it('snaps the store title back to the server truth when renameSlot rejects', async () => {
+    const store = renderChatPage()
+    const input = await openRename()
+    apiMocks.renameSlot = vi.fn().mockRejectedValue(new Error('refused'))
+    act(() => { fireEvent.change(input, { target: { value: 'Refused title' } }) })
+    act(() => { fireEvent.blur(input) })
+    // The optimistic title lands first (no microtask has run between the
+    // synchronous blur commit and this assertion)...
+    expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe('Refused title')
+    // ...then the catch re-reads the server truth and the keyed apply
+    // restores the value delivered by api.chatSlots.
+    await waitFor(() => {
+      expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe(TITLE_A)
+    })
+  })
+
+  it('falls back to a local revert when the recovery re-read also fails', async () => {
+    const store = renderChatPage()
+    const input = await openRename()
+    // Transport/auth failures take renameSlot and chatSlots down together, so
+    // the catch must revert locally to the pre-rename title.
+    apiMocks.renameSlot = vi.fn().mockRejectedValue(new Error('gateway down'))
+    apiMocks.chatSlots = vi.fn().mockRejectedValue(new Error('gateway down'))
+    act(() => { fireEvent.change(input, { target: { value: 'Refused title' } }) })
+    act(() => { fireEvent.blur(input) })
+    await waitFor(() => {
+      expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe(TITLE_A)
+    })
+  })
+
+  it('a late recovery never clobbers a newer concurrent title write', async () => {    const store = renderChatPage()
+    const input = await openRename()
+    // The rename is refused; while the recovery re-read is in flight, a newer
+    // server-persisted title for the same slot lands (another client, or a
+    // generated title). The guard must see the store no longer holds the
+    // refused value and apply nothing.
+    apiMocks.renameSlot = vi.fn().mockRejectedValue(new Error('refused'))
+    let releaseSlots!: (v: unknown) => void
+    apiMocks.chatSlots = vi.fn().mockReturnValue(new Promise(r => { releaseSlots = r }))
+    act(() => { fireEvent.change(input, { target: { value: 'Refused title' } }) })
+    act(() => { fireEvent.blur(input) })
+    // Let the catch start the re-read, then land the newer write before the
+    // stale snapshot resolves.
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    act(() => { store.dispatch({ type: 'dashboard/sseSlotTitle', payload: { key: 'chat-a', title: 'Newer concurrent title' } }) })
+    act(() => { releaseSlots([mkSlot('chat-a', TITLE_A), mkSlot('chat-b', TITLE_B)]) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe('Newer concurrent title')
+  })
+
+  it('overlapping refused renames revert to the confirmed title, not to each other', async () => {
+    const store = renderChatPage()
+    // First rename is refused and the recovery re-read is held pending, so the
+    // store keeps the first refused optimistic value on screen. The re-read is
+    // deduped through queryClient.fetchQuery, so a second attempt joins this
+    // same in-flight request.
+    const input = await openRename()
+    apiMocks.renameSlot = vi.fn().mockRejectedValue(new Error('refused'))
+    let rejectSlots!: (e: unknown) => void
+    apiMocks.chatSlots = vi.fn().mockReturnValue(new Promise((_r, rej) => { rejectSlots = rej }))
+    act(() => { fireEvent.change(input, { target: { value: 'Refused B' } }) })
+    act(() => { fireEvent.blur(input) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    // Second rename while the first recovery is pending: also refused. Its
+    // re-read joins the shared in-flight request, which then fails outright ->
+    // local fallback. It must restore the confirmed pre-rename baseline, not
+    // the first attempt's refused value.
+    const label = await screen.findByTestId('header-title')
+    act(() => { fireEvent.click(label) })
+    const second = screen.getByDisplayValue('Refused B') as HTMLInputElement
+    act(() => { fireEvent.change(second, { target: { value: 'Refused C' } }) })
+    act(() => { fireEvent.blur(second) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    act(() => { rejectSlots(new Error('gateway down')) })
+    await waitFor(() => {
+      expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe(TITLE_A)
+    })
+  })
+
+  it('a pending failure never drags a confirmed external rename back to the baseline', async () => {
+    const store = renderChatPage()
+    // First rename is refused with its re-read held pending (baseline = TITLE_A).
+    const input = await openRename()
+    apiMocks.renameSlot = vi.fn().mockRejectedValue(new Error('refused'))
+    let rejectSlots!: (e: unknown) => void
+    apiMocks.chatSlots = vi.fn().mockReturnValue(new Promise((_r, rej) => { rejectSlots = rej }))
+    act(() => { fireEvent.change(input, { target: { value: 'Refused B' } }) })
+    act(() => { fireEvent.blur(input) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    // Another client's CONFIRMED rename lands over SSE while B is pending.
+    act(() => { store.dispatch({ type: 'dashboard/sseSlotTitle', payload: { key: 'chat-a', title: 'Confirmed external' } }) })
+    // A second refused rename commits on top of the confirmed value; the shared
+    // re-read then fails outright -> local fallback. The baseline must have
+    // been refreshed to the confirmed title at commit time, so the fallback
+    // restores 'Confirmed external', never the stale TITLE_A.
+    const label = await screen.findByTestId('header-title')
+    act(() => { fireEvent.click(label) })
+    const second = screen.getByDisplayValue('Confirmed external') as HTMLInputElement
+    act(() => { fireEvent.change(second, { target: { value: 'Refused C' } }) })
+    act(() => { fireEvent.blur(second) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    act(() => { rejectSlots(new Error('gateway down')) })
+    await waitFor(() => {
+      expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe('Confirmed external')
+    })
+  })
+
+  it('a delayed recovery never overwrites a newer confirmed rename to the same title', async () => {
+    const store = renderChatPage()
+    // Attempt 1: rename to X is refused; its recovery re-read is held pending,
+    // so the snapshot it will eventually deliver predates everything below.
+    const input = await openRename()
+    apiMocks.renameSlot = vi.fn().mockRejectedValue(new Error('refused'))
+    let releaseSlots!: (v: unknown) => void
+    apiMocks.chatSlots = vi.fn().mockReturnValue(new Promise(r => { releaseSlots = r }))
+    act(() => { fireEvent.change(input, { target: { value: 'Title X' } }) })
+    act(() => { fireEvent.blur(input) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    // A newer title lands, then a SECOND attempt renames to the IDENTICAL
+    // string X and SUCCEEDS. Title equality alone cannot tell this confirmed X
+    // from attempt 1's stale optimistic X.
+    act(() => { store.dispatch({ type: 'dashboard/sseSlotTitle', payload: { key: 'chat-a', title: 'Title Y' } }) })
+    const label = await screen.findByTestId('header-title')
+    act(() => { fireEvent.click(label) })
+    const second = screen.getByDisplayValue('Title Y') as HTMLInputElement
+    apiMocks.renameSlot = vi.fn().mockResolvedValue({})
+    act(() => { fireEvent.change(second, { target: { value: 'Title X' } }) })
+    act(() => { fireEvent.blur(second) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe('Title X')
+    // Attempt 1's delayed re-read now resolves with its STALE pre-rename
+    // snapshot (server still says TITLE_A in it). Its generation is stale, so
+    // it must apply nothing: the newer confirmed X stays.
+    act(() => { releaseSlots([mkSlot('chat-a', TITLE_A), mkSlot('chat-b', TITLE_B)]) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe('Title X')
+  })
+
+  it('a successful rename keeps the new title and never refetches slots', async () => {
+    const store = renderChatPage()
+    const input = await openRename()
+    const slotsCallsBefore = apiMocks.chatSlots.mock.calls.length
+    act(() => { fireEvent.change(input, { target: { value: 'Renamed alpha' } }) })
+    act(() => { fireEvent.blur(input) })
+    // Flush a macrotask so a refetch scheduled any number of microtask hops
+    // down the resolved renameSlot promise would have landed by now.
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    expect(store.getState().dashboard.slots.find(s => s.key === 'chat-a')?.title).toBe('Renamed alpha')
+    expect(apiMocks.chatSlots.mock.calls.length).toBe(slotsCallsBefore)
   })
 })


### PR DESCRIPTION
## Problem / Motivation

The chat-header session-title rename in `website/src/pages/ChatPage.tsx` dispatches the optimistic `sseSlotTitle`, then calls `api.renameSlot`. Its `.catch` only reported the failure through `showActionError`: the refused optimistic title was never reverted, so the header and the sidebar kept showing a server-rejected title until an unrelated slot refetch or a reload. This is the header-side mirror of #10151, which covers the sidebar's inline rename; `renameSlot` has exactly two call sites and this was the remaining one.

## Why it matters

The user is told the rename failed while the UI keeps displaying the failed title as if it succeeded. The contradiction persists indefinitely on an idle dashboard, and the wrong title is what gets read, screenshotted, and searched for until something else happens to refetch slots.

## What changed (motivation -> approach -> change)

Slot titles live in the Redux dashboard slice (written by `sseSlots` / `fetchSlots.fulfilled`), so the recovery goes through Redux: the `.catch` now also dispatches `fetchSlots()`, whose `fulfilled` reconciler overwrites the stale optimistic title with the server truth. This is the recovery the delete-slot failure path already uses after its optimistic removal (`chatSlice` `deleteSlot`), and the shape the pending sidebar-rename fix (#10151 / PR #10172) adopts for the same defect class.

Because a transport or auth failure takes `renameSlot` and `chatSlots` down together (and `fetchSlots.rejected` restores nothing), the catch falls back to a local revert to the pre-rename title when the refetch does not fulfil, guarded on the store still holding the refused value so a newer concurrent title write is never clobbered.

Known residual (accepted, pre-existing shape): `fetchSlots.fulfilled` applies the whole snapshot, so a reply that predates a concurrent successful write inside one round-trip can briefly show the older title until the next slots frame. Same narrow window as the existing delete-slot recovery; a keyed partial apply would be a separate change.

## Tests

- `website/src/test/ChatPage.titleRenamePin.test.tsx`, three new cases driving the real header rename UI (click title -> input -> blur commits):
  - `renameSlot` rejects -> the store title snaps back to the server value delivered by `chatSlots` (mutation-verified: fails without the fix).
  - `renameSlot` and `chatSlots` both reject -> the local-revert fallback restores the pre-rename title.
  - successful rename -> the new title stays and slots are never refetched (macrotask flush).
- `npx tsc -b` clean; scoped `npx vitest run src/test/ChatPage.titleRenamePin.test.tsx` 9/9; scoped eslint clean on both touched files.

## Manual verification

Behavior-only revert of an optimistic value back to what the UI showed before the edit; no new visual surface. Covered by the DOM-driven vitest cases above.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** behavior-only revert of an optimistic value back to the pre-edit state; no new or changed visual surface (the failure toast and the title rendering both pre-date this PR).

## Related Issues

Closes #10203

## Pattern harvest

Rule candidate: an optimistic Redux dispatch whose paired request has a `.catch` that only reports (toast/notice) and never restores the value is the defect class here -- recovery must re-assert server truth (authoritative refetch, plus a guarded local revert when the refetch can share the failure mode), and `queryClient.invalidateQueries` recovers nothing that lives in Redux rather than under a registered query key.
