### PR TITLE
fix: treat a completed compaction turn as finished, not interrupted

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2103,9 +2103,16 @@ def is_turn_interrupted(messages: list[dict]) -> bool:
     ASSISTANT's but an error row follows it (the turn streamed partway then died,
     which is otherwise shape-identical to a clean completion).
 
-    One shape is explicitly excluded: a trailing ``stop_event``. The user pressing
-    Stop is a deliberate ending, not an interruption, and stopping before the
-    reply emitted any text produces the same ``[user, ...]`` tail as a crash.
+    Two shapes are explicitly excluded. A trailing ``stop_event``: the user
+    pressing Stop is a deliberate ending, not an interruption, and stopping
+    before the reply emitted any text produces the same ``[user, ...]`` tail as
+    a crash. And a ``/compact`` request answered by its compaction notice (the
+    assistant row ``chat_utils._append_compaction_notice`` tags
+    ``meta.kind="compaction"``): the slash command IS the whole request and the
+    notice IS its result, so nothing is missing. The discriminator is
+    deliberately BOTH halves -- the tag alone cannot decide, because an
+    automatic compaction can write the same tagged row inside an ordinary turn
+    whose real reply never arrived, and that tail is a genuine interruption.
 
     Selects the wording injected for the model (``_MANUAL_RESUME_MSG`` vs
     ``_MANUAL_CONTINUE_MSG``), gates whether the composer offers the Resume
@@ -2126,6 +2133,7 @@ def is_turn_interrupted(messages: list[dict]) -> bool:
     distinction would buy a branch and nothing else.
     """
     saw_trailing_error = False
+    saw_compaction_result = False
     for m in reversed(messages):
         role = m.get("role")
         meta = m.get("meta") or {}
@@ -2139,9 +2147,37 @@ def is_turn_interrupted(messages: list[dict]) -> bool:
         if is_stop_event_row(m):
             return False
         if is_system_notice(role, meta):
+            # Remember a compaction RESULT row on the newest turn. Skipping the
+            # row is still right in general (an auto-compaction notice inside
+            # an ordinary turn is not that turn's reply), but when the user row
+            # this scan lands on IS the ``/compact`` request, this row is that
+            # request's whole result -- see the user branch below. The recycle
+            # and stuck-turn notices borrow ``kind="compaction"`` for the
+            # follow-up scan's skip and mark themselves with ``meta["notice"]``;
+            # they report no compaction, so they must not complete one.
+            if (
+                isinstance(meta, dict)
+                and meta.get("kind") == "compaction"
+                and not meta.get("notice")
+            ):
+                saw_compaction_result = True
             continue
         if role in ("user", "assistant") and m.get("content"):
-            return True if role == "user" else saw_trailing_error
+            if role != "user":
+                return saw_trailing_error
+            # A ``/compact`` answered by its compaction notice is a FINISHED
+            # turn -- unless an error row trails the notice, which is the same
+            # evidence the plain-assistant branch honors. Matched on the first
+            # whitespace token, the same rule the runner uses for
+            # ``user_requested_compaction``.
+            content = m.get("content")
+            if (
+                saw_compaction_result
+                and isinstance(content, str)
+                and content.split()[:1] == ["/compact"]
+            ):
+                return saw_trailing_error
+            return True
         if role == "error":
             saw_trailing_error = True
     return False
@@ -5618,8 +5654,15 @@ class DashboardState:
             try:
                 # Tag kind="compaction" so the dashboard's follow-up [OPTIONS:]
                 # backward scan skips this proactive system notice, matching the
-                # auto-compact notice invariant.
-                slot.append("assistant", message, "msg msg-a", meta={"kind": "compaction"})
+                # auto-compact notice invariant. `notice` marks it as borrowing
+                # the tag: it reports no compaction, so `is_turn_interrupted`
+                # must not read it as a `/compact` request's result.
+                slot.append(
+                    "assistant",
+                    message,
+                    "msg msg-a",
+                    meta={"kind": "compaction", "notice": "session_recycled"},
+                )
             except Exception:
                 logging.getLogger(__name__).exception(
                     "Failed to append recycle notice to slot %s", slot_key
@@ -5663,7 +5706,15 @@ class DashboardState:
                 # kind="compaction" for the same reason as the recycle notice: it
                 # keeps the dashboard's follow-up [OPTIONS:] backward scan from
                 # treating a proactive system notice as the turn's own output.
-                slot.append("assistant", message, "msg msg-a", meta={"kind": "compaction"})
+                # `notice` marks the borrowed tag: a stuck turn is the OPPOSITE
+                # of a completed one, so `is_turn_interrupted` must not read
+                # this row as a `/compact` request's result.
+                slot.append(
+                    "assistant",
+                    message,
+                    "msg msg-a",
+                    meta={"kind": "compaction", "notice": "stuck_turn"},
+                )
             except Exception:
                 logging.getLogger(__name__).exception(
                     "Failed to append stuck-turn notice to slot %s", slot_key

--- a/test/test_is_interrupted.py
+++ b/test/test_is_interrupted.py
@@ -152,3 +152,115 @@ class TestDeliberateStop:
             _is_interrupted(slot(user(), stop_event(), user(), assistant(), error()))
             is True
         )
+
+
+def compaction_notice(content: str = "Conversation compacted: summary") -> dict:
+    """A compaction result row: an assistant row tagged ``meta.kind="compaction"``.
+
+    Four writers emit this shape -- ``chat_utils._append_compaction_notice``
+    plus three direct ``slot.append`` sites in ``state.py`` (the proactive
+    auto-compact paths, which bypass the chat_utils helper to avoid an import
+    cycle). The tag, not the writer, is what this predicate keys on.
+    """
+    return {"role": "assistant", "content": content, "meta": {"kind": "compaction"}}
+
+
+class TestCompletedCompaction:
+    """A ``/compact`` answered by its compaction notice is FINISHED.
+
+    The five tail shapes pin the discriminator from both sides: the tag alone
+    must not decide (case D is a real interruption carrying the same tagged
+    row), and the request alone must not decide (case C got nothing back). Only
+    the pair -- a ``/compact`` user row whose compaction result row is present
+    -- reads as a completed turn.
+    """
+
+    def test_compact_answered_by_notice_is_finished(self):
+        # Case A: the slash command IS the request and the notice IS its result.
+        assert (
+            _is_interrupted(
+                slot(user(), assistant(), user("/compact"), compaction_notice())
+            )
+            is False
+        )
+
+    def test_untagged_lookalike_text_reads_as_an_ordinary_reply(self):
+        # Case B: the same text without the tag is a plain assistant reply, so
+        # it already reads as the floor. Isolates the tag as A's trigger.
+        assert (
+            _is_interrupted(
+                slot(user("/compact"), assistant("Conversation compacted: summary"))
+            )
+            is False
+        )
+
+    def test_compact_with_nothing_back_is_interrupted(self):
+        # Case C: the request went out and no result row ever arrived.
+        assert _is_interrupted(slot(user(), assistant(), user("/compact"))) is True
+
+    def test_auto_compaction_inside_an_unanswered_turn_is_interrupted(self):
+        # Case D: an automatic compaction wrote its notice inside a turn whose
+        # real reply never came. Skipping the notice is deliberate and correct
+        # here -- the tag alone must not flip this shape.
+        assert _is_interrupted(slot(user("do the thing"), compaction_notice())) is True
+
+    def test_ordinary_completed_turn_is_finished(self):
+        # Case E: the unchanged baseline.
+        assert _is_interrupted(slot(user(), assistant())) is False
+
+    def test_compact_with_arguments_still_counts(self):
+        # The runner keys ``user_requested_compaction`` on the first whitespace
+        # token, so trailing text does not change what the turn asked for.
+        assert (
+            _is_interrupted(slot(user("/compact focus on tests"), compaction_notice()))
+            is False
+        )
+
+    def test_stale_compact_does_not_mask_a_later_unanswered_turn(self):
+        # The pair must belong to the NEWEST turn: a later user row that got
+        # nothing back is a genuine interruption whatever happened before it.
+        assert (
+            _is_interrupted(slot(user("/compact"), compaction_notice(), user()))
+            is True
+        )
+
+    def test_error_trailing_the_notice_is_still_interrupted(self):
+        # The same evidence rule as the plain-assistant branch: a completed
+        # compaction followed by an error row ended badly, and hiding the
+        # Resume control on that tail would strand the user.
+        assert (
+            _is_interrupted(slot(user("/compact"), compaction_notice(), error()))
+            is True
+        )
+
+    def test_first_token_match_uses_pythons_whitespace_rule(self):
+        # The runner keys on content.split()[0], where U+0085 separates tokens
+        # and U+FEFF does not. The TS mirror pins the same pair, so the two
+        # sides cannot split identical content differently.
+        assert (
+            _is_interrupted(slot(user("/compact\x85focus"), compaction_notice()))
+            is False
+        )
+        assert (
+            _is_interrupted(
+                slot(user("/compact\ufeffcontinue"), compaction_notice())
+            )
+            is True
+        )
+        assert (
+            _is_interrupted(slot(user("\ufeff/compact"), compaction_notice()))
+            is True
+        )
+
+    def test_borrowed_tag_notices_do_not_complete_a_compact(self):
+        # The recycle and stuck-turn notices reuse kind="compaction" for the
+        # follow-up scan's skip and mark themselves with meta["notice"]. A
+        # stuck /compact is the opposite of a completed one: the turn stays
+        # interrupted so Resume remains offered.
+        for notice_kind in ("stuck_turn", "session_recycled"):
+            row = {
+                "role": "assistant",
+                "content": "notice text",
+                "meta": {"kind": "compaction", "notice": notice_kind},
+            }
+            assert _is_interrupted(slot(user("/compact"), row)) is True

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -3543,6 +3543,19 @@ export const selectContinuable = (state: RootState): boolean => {
   return false
 }
 
+/** The characters Python's no-argument `str.split()` splits on. JS `\s` is NOT
+ *  the same set: it adds U+FEFF and lacks U+0085 and U+001C-001F, so a `\s`
+ *  scan of the same content can produce a different first token than the
+ *  backend's `content.split()[0]` -- the rule `is_turn_interrupted` and the
+ *  runner's `user_requested_compaction` key on. */
+const PYTHON_WHITESPACE_RE = /[\t\n\v\f\r\u001c-\u001f \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/
+
+/** First whitespace-separated token by PYTHON's splitting rule, or undefined
+ *  for all-whitespace content. Mirrors `content.split()[:1]` in
+ *  `src/kiro_crew/dashboard/state.py`. */
+const firstPythonToken = (content: string): string | undefined =>
+  content.split(PYTHON_WHITESPACE_RE).find(Boolean)
+
 /**
  * True when the transcript SHOWS the last turn ending without the assistant
  * handing the floor back — the user's row is last, or an `error` row trails the
@@ -3555,10 +3568,19 @@ export const selectContinuable = (state: RootState): boolean => {
  *
  * A false result means "nothing in the transcript proves an interruption", never
  * "the turn definitely finished": the force-quit case leaves no evidence.
+ *
+ * A `/compact` answered by its compaction notice (the assistant row tagged
+ * `meta.kind="compaction"`) reads as FINISHED: the slash command IS the whole
+ * request and the notice IS its result. The tag alone cannot decide -- an
+ * automatic compaction can write the same tagged row inside an ordinary turn
+ * whose real reply never arrived, and that tail is a genuine interruption --
+ * so the rule needs BOTH halves, matching `is_turn_interrupted` in
+ * `src/kiro_crew/dashboard/state.py`.
  */
 export const selectTurnInterrupted = (state: RootState): boolean => {
   const msgs = state.chat.messages
   let sawTrailingError = false
+  let sawCompactionResult = false
   for (let i = msgs.length - 1; i >= 0; i--) {
     const m = msgs[i]
     // A deliberate Stop ENDS the turn; it does not interrupt it. This must be
@@ -3576,8 +3598,25 @@ export const selectTurnInterrupted = (state: RootState): boolean => {
     if (m.role === 'error') { sawTrailingError = true; continue }
     if (CONTINUE_SCAN_SKIP.has(m.role)) continue
     if ((m.role === 'user' || m.role === 'assistant') && m.content) {
-      if (m.role === 'assistant' && isSystemNoticeKind((m.meta as { kind?: string } | undefined)?.kind)) continue
-      return m.role === 'user' ? true : sawTrailingError
+      const meta = m.meta as { kind?: string; notice?: string } | undefined
+      if (m.role === 'assistant' && isSystemNoticeKind(meta?.kind)) {
+        // Remember a compaction RESULT row on the newest turn; whether it
+        // completes the turn depends on the user row it leads back to. The
+        // recycle and stuck-turn notices borrow `kind="compaction"` and mark
+        // themselves with `meta.notice`; they report no compaction, so they
+        // must not complete one.
+        if (meta?.kind === 'compaction' && !meta?.notice) sawCompactionResult = true
+        continue
+      }
+      if (m.role !== 'user') return sawTrailingError
+      // A `/compact` answered by its compaction notice is a FINISHED turn --
+      // unless an error row trails the notice, the same evidence the
+      // plain-assistant branch honors. First-whitespace-token match using
+      // PYTHON's whitespace set (the backend rule is `content.split()`, and
+      // JS `\s` / `trim()` disagree with it on U+FEFF and U+0085), so the two
+      // mirrors cannot split the same content differently.
+      if (sawCompactionResult && firstPythonToken(m.content) === '/compact') return sawTrailingError
+      return true
     }
   }
   return false

--- a/website/src/test/chatSlice.continuable.test.ts
+++ b/website/src/test/chatSlice.continuable.test.ts
@@ -247,6 +247,93 @@ describe('selectTurnInterrupted', () => {
     }))).toBe(true)
   })
 
+  // The completed-/compact shapes, mirroring `is_turn_interrupted` in
+  // `src/kiro_crew/dashboard/state.py` (test_is_interrupted.py pins the same
+  // five tails). Only the PAIR -- a /compact user row whose compaction result
+  // row is present -- reads as finished; the tag alone must not decide (the
+  // auto-compaction case above is a real interruption carrying the same row).
+  it('is FALSE when /compact is answered by its compaction notice (case A)', () => {
+    expect(selectTurnInterrupted(state({
+      messages: [
+        msg('user', 'q'), msg('assistant', 'a'),
+        msg('user', '/compact'),
+        msg('assistant', 'Conversation compacted: summary', { kind: 'compaction' }),
+      ],
+    }))).toBe(false)
+  })
+
+  it('already reads an untagged lookalike reply as the floor (case B)', () => {
+    expect(selectTurnInterrupted(state({
+      messages: [msg('user', '/compact'), msg('assistant', 'Conversation compacted: summary')],
+    }))).toBe(false)
+  })
+
+  it('is true when /compact got nothing back (case C)', () => {
+    expect(selectTurnInterrupted(state({
+      messages: [msg('user', 'q'), msg('assistant', 'a'), msg('user', '/compact')],
+    }))).toBe(true)
+  })
+
+  it('matches /compact on its first whitespace token, arguments included', () => {
+    expect(selectTurnInterrupted(state({
+      messages: [
+        msg('user', '/compact focus on tests'),
+        msg('assistant', 'Conversation compacted: summary', { kind: 'compaction' }),
+      ],
+    }))).toBe(false)
+  })
+
+  it('does not let a stale completed /compact mask a later unanswered turn', () => {
+    expect(selectTurnInterrupted(state({
+      messages: [
+        msg('user', '/compact'),
+        msg('assistant', 'Conversation compacted: summary', { kind: 'compaction' }),
+        msg('user', 'next request'),
+      ],
+    }))).toBe(true)
+  })
+
+  it('stays true when an error row trails the compaction notice', () => {
+    // Same evidence rule as the plain-assistant branch: a completed compaction
+    // followed by an error ended badly; hiding Resume there strands the user.
+    expect(selectTurnInterrupted(state({
+      messages: [
+        msg('user', '/compact'),
+        msg('assistant', 'Conversation compacted: summary', { kind: 'compaction' }),
+        msg('error', 'Connection lost -- please retry.'),
+      ],
+    }))).toBe(true)
+  })
+
+  it("matches the first token by Python's whitespace rule, not JS \\s", () => {
+    // The backend rule is content.split()[0]: U+0085 separates tokens, U+FEFF
+    // does not, and trim() must not eat a leading BOM. test_is_interrupted.py
+    // pins the same three tails so the mirrors cannot diverge on them.
+    const notice = msg('assistant', 'Conversation compacted: summary', { kind: 'compaction' })
+    expect(selectTurnInterrupted(state({
+      messages: [msg('user', '/compact\u0085focus'), notice],
+    }))).toBe(false)
+    expect(selectTurnInterrupted(state({
+      messages: [msg('user', '/compact\uFEFFcontinue'), notice],
+    }))).toBe(true)
+    expect(selectTurnInterrupted(state({
+      messages: [msg('user', '\uFEFF/compact'), notice],
+    }))).toBe(true)
+  })
+
+  it('does not let a borrowed-tag notice (stuck turn, recycle) complete a /compact', () => {
+    // Those writers reuse kind="compaction" for the follow-up scan's skip and
+    // mark themselves with meta.notice; a stuck /compact stays interrupted.
+    for (const noticeKind of ['stuck_turn', 'session_recycled']) {
+      expect(selectTurnInterrupted(state({
+        messages: [
+          msg('user', '/compact'),
+          msg('assistant', 'notice text', { kind: 'compaction', notice: noticeKind }),
+        ],
+      }))).toBe(true)
+    }
+  })
+
   it('reads past an injected recovery row to the real floor beneath it', () => {
     expect(selectTurnInterrupted(state({
       messages: [msg('user'), msg('inject', '[Continue — requested by the user]\nresume')],


### PR DESCRIPTION
## Problem / Motivation

A `/compact` turn that completes successfully leaves the session flagged as interrupted. The sidebar shows `Turn interrupted / Resume`, and pressing Resume injects a recovery continuation claiming the previous turn was interrupted -- it was not, and the model spends a turn discovering that.

## Why it matters

Every manual `/compact` in a dashboard chat ends in a false alarm. The issue's own transcript survey found 13 of 14 `/compact` turns reported interrupted, and 2 wasted Resume presses. It also breaks the promise #1692 states for this flag: never claim an interruption the transcript cannot show.

## What changed (motivation -> approach -> change)

`/compact` writes no ordinary assistant row; its result is an assistant row tagged `meta.kind="compaction"`. `is_turn_interrupted` (`src/kiro_crew/dashboard/state.py`) skips that row as a system notice, lands on the `/compact` user row, and returns True.

The tag alone cannot fix this: an automatic compaction can write the same tagged row inside an ordinary turn whose real reply never arrived, and that tail is a genuine interruption. So the scan now remembers a compaction result row on the newest turn and reads the PAIR -- a user row whose first whitespace token is `/compact`, with its tagged result row present -- as a finished turn. An error row trailing the notice still reads as interrupted, the same evidence rule the plain-assistant branch uses. `/compact` is matched on the first whitespace token, the same rule the runner uses for `user_requested_compaction`.

`selectTurnInterrupted` (`website/src/store/chatSlice.ts`) mirrors the rule exactly. It matches the first token with Python's whitespace set, because JS `\s` and `trim()` disagree with Python's `str.split()` on U+FEFF and U+0085 and the two mirrors must not split the same content differently.

The session-recycle and stuck-turn notices borrow `kind="compaction"` so the follow-up scan skips them. They report no compaction, so they now mark themselves with `meta.notice` and the predicate refuses to read a marked row as a `/compact` result -- a stuck `/compact` stays interrupted and keeps its Resume offer.

| tail | Before | After |
|---|---|---|
| A: `/compact`, compaction notice | :red_square: interrupted (wrong) | :green_square: finished |
| B: `/compact`, untagged lookalike reply | :blue_square: finished | :blue_square: finished |
| C: `/compact`, nothing came back | :blue_square: interrupted | :blue_square: interrupted |
| D: ordinary request, notice, nothing back | :blue_square: interrupted | :blue_square: interrupted |
| E: ordinary request, reply | :blue_square: finished | :blue_square: finished |

:green_square: fixed - :blue_square: unchanged

*A completed `/compact` now reads as finished; every other tail keeps its answer.*

## Tests

`test/test_is_interrupted.py` pins all five tail shapes above, plus: `/compact` with arguments still counts (first-token rule), a stale completed `/compact` does not mask a later unanswered turn, an error row trailing the notice stays interrupted, a borrowed-tag notice (stuck turn, session recycle) does not complete a `/compact`, and the Python-vs-JS whitespace edges (U+0085 separates, U+FEFF does not, a leading BOM is not trimmed). `website/src/test/chatSlice.continuable.test.ts` pins the same tails against the TS mirror, so the two sides cannot drift apart silently.

## Manual verification

Ran the issue's deterministic repro against this branch: the case A assertion that fails on `main` passes, and all five shapes match the issue's `want` column. N/A beyond that -- the change is one pure predicate with unit coverage on both sides.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** logic-only selector change; both UI states it toggles between (plain composer vs Resume card) are pre-existing components, unchanged in appearance.

## Related Issues

Closes #10218

## Pattern harvest

Rule candidate: review-prompt
Pattern: a Python predicate and its TS mirror must pin cross-language semantic gaps (whitespace sets, trim) with twin tests on both sides, or identical-looking token rules silently diverge.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
