### PR TITLE
fix: reject SKIP-reason, KEEP, and short Korean refusals as session titles

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -2141,7 +2141,18 @@ Two consequences fall out of naming in a non-latin script:
   free, and the full-width terminators `。！？` are matched without the ASCII
   rule's trailing-whitespace requirement (those scripts do not space after
   punctuation). A short refusal with no terminator remains a documented false
-  negative.
+  negative for those unspaced scripts. Korean is spaced, so the word ceiling
+  bounds its long sentences, but a SHORT Korean refusal clears every other
+  check -- and Korean puts the refusal verb last, so English-style prefix
+  openers cannot catch it. `_looks_like_prose` therefore also matches Korean
+  sentence shape: the sentence-final polite conjugations
+  (`_TITLE_KO_SENTENCE_ENDINGS`, the formal "-nida" family and the
+  informal-polite "-yo" family) plus the apology opener
+  (`_TITLE_KO_PROSE_OPENERS`), which a title as a noun phrase never carries. A
+  plain-form (banmal) Korean refusal remains a documented false negative, and
+  a sentence-form Korean title loses to the fallback name -- the deliberate
+  direction of the trade, since a fallback name is still the user's own words
+  while a stored refusal is the bug.
 - **The reveal animation needs characters.** The sidebar types a new title in one
   word at a time; a single-token title skipped the animation entirely, so
   `_title_reveal_prefixes` steps unspaced scripts two characters at a time
@@ -2149,6 +2160,14 @@ Two consequences fall out of naming in a non-latin script:
 
 `_clean_title` strips the full-width and CJK quote/period forms (`「」`, `“”`,
 `。`) alongside the ASCII ones, since that is what a zh/ja reply wraps a name in.
+It also keeps the reply's first line only -- the rule
+`messaging/auto_title.clean_title` states as "Keeps the first line only" -- so a
+`SKIP` verdict followed by a reason collapses back to the bare control word.
+`_validate_title_reply` treats BOTH taught control words (`SKIP`, `KEEP`) as
+no-title sentinels on every path, matched case-insensitively, alone or with a
+punctuation-separated reason on one line (`_is_verdict_reply`) -- while a real
+title that merely opens with the word ("SKIP and KEEP handling", "KEEP-ALIVE
+header bug") survives.
 
 ### Foreign-agent import onboarding state
 

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -213,7 +213,9 @@ _TITLE_MAX_WORDS = 12
 #: is a single whitespace token, so ``_TITLE_MAX_WORDS`` can never fire for it —
 #: it needs the character ceiling below instead. Hangul and Cyrillic are
 #: deliberately absent: Korean and Russian do space their words, so the word
-#: ceiling already covers them.
+#: ceiling bounds a long sentence in them. A SHORT Korean refusal clears that
+#: ceiling, so it is caught by sentence shape instead -- see
+#: ``_TITLE_KO_SENTENCE_ENDINGS``.
 _UNSPACED_SCRIPT_RANGES = (
     (0x0E00, 0x0E7F),  # Thai
     (0x3040, 0x30FF),  # Hiragana + Katakana
@@ -279,6 +281,31 @@ _TITLE_PROSE_OPENERS = (
     "note:",
 )
 
+#: Korean refusal/prose shape. Hangul spaces its words, so the word ceiling
+#: bounds a long Korean sentence -- but a refusal is SHORT (five words in the
+#: observed case), and ``_TITLE_PROSE_OPENERS`` is English-only, so a short
+#: Korean refusal clears every other check. Korean
+#: is SOV: the verb that marks a sentence as a sentence comes LAST, so prefix
+#: openers cannot catch it -- match the sentence-final conjugation instead.
+#: The polite declarative endings close the sentence forms a titling model
+#: actually emits: "-nida" (U+B2C8 U+B2E4, the hamnida/seumnida/imnida
+#: family) and the informal-polite "-eoyo"/"-ayo"/"-haeyo" (U+C5B4/U+C544/
+#: U+D574 + U+C694). A noun-phrase title carries none of them; a plain-form
+#: (banmal) refusal stays a documented false negative. The one useful prefix
+#: is "joesong" (U+C8C4 U+C1A1, "sorry"), the apology opener. Both signals
+#: trade deliberately toward rejection: a sentence-form Korean title ("the
+#: login does not work") loses to the fallback name, which is the cheaper
+#: failure -- a fallback name is still the user's own words, a refusal stored
+#: as the name is the bug. Escapes keep the source ASCII; the runtime values
+#: are the Hangul strings.
+_TITLE_KO_PROSE_OPENERS = ("\uc8c4\uc1a1",)
+_TITLE_KO_SENTENCE_ENDINGS = (
+    "\ub2c8\ub2e4",
+    "\uc5b4\uc694",
+    "\uc544\uc694",
+    "\ud574\uc694",
+)
+
 
 def _unspaced_script_chars(s: str) -> int:
     """Count characters belonging to a script written without word spaces."""
@@ -297,7 +324,7 @@ def _looks_like_prose(title: str) -> bool:
     shape of a generation, so the reply is also validated here and treated as
     SKIP when it fails, which routes to the existing fallback title.
 
-    Four signals, each independently sufficient:
+    Five signals, each independently sufficient:
 
     - a refusal/narration opener (see ``_TITLE_PROSE_OPENERS``);
     - more words than any real title carries;
@@ -308,6 +335,11 @@ def _looks_like_prose(title: str) -> bool:
       must be followed by whitespace so "Node.js upgrade plan" and "Ship v1.2 to
       prod" stay valid; the full-width forms must not, because the scripts that
       use them do not space after punctuation.
+    - Korean sentence shape (see ``_TITLE_KO_SENTENCE_ENDINGS``). Hangul spaces
+      its words, but a refusal is short enough to clear the word ceiling, and a
+      prefix opener cannot catch an SOV language whose refusal verb comes last
+      -- so the sentence-final polite conjugation is matched instead, a grammar
+      fact rather than a phrase list.
 
     Known false negative: a SHORT refusal in an unspaced script with no
     terminator ("无法访问该链接") clears every ceiling and lands as the title.
@@ -320,6 +352,10 @@ def _looks_like_prose(title: str) -> bool:
         return False
     lowered = stripped.lower()
     if lowered.startswith(_TITLE_PROSE_OPENERS):
+        return True
+    if stripped.startswith(_TITLE_KO_PROSE_OPENERS):
+        return True
+    if stripped.endswith(_TITLE_KO_SENTENCE_ENDINGS):
         return True
     if len(stripped.split()) > _TITLE_MAX_WORDS:
         return True
@@ -743,9 +779,19 @@ async def _rephrase_plan_lite(
 
 
 def _clean_title(s: str) -> str:
-    """Normalize a (partial or final) LLM title: trim whitespace and wrapping
-    quotes/period, in their ASCII and full-width/CJK forms alike."""
-    return s.strip().strip(_TITLE_WRAP_CHARS).strip()
+    """Normalize a (partial or final) LLM title: keep the first line only,
+    then trim whitespace and wrapping quotes/period, in their ASCII and
+    full-width/CJK forms alike.
+
+    The first-line reduction mirrors the rule ``messaging/auto_title
+    .clean_title`` states as "Keeps the first line only": it collapses
+    ``SKIP\\n\\n<reason>`` back to the bare control word, and keeps a title the
+    model followed with an unasked-for explanation. One deliberate ordering
+    difference from the sibling: leading whitespace is stripped BEFORE the
+    split, so a reply opening with a blank line keeps its title rather than
+    reducing to the blank line.
+    """
+    return s.strip().split("\n", 1)[0].strip().strip(_TITLE_WRAP_CHARS).strip()
 
 
 def _title_reveal_prefixes(title: str) -> list[str]:
@@ -807,18 +853,66 @@ async def _reveal_title(
         await asyncio.sleep(_TITLE_REVEAL_STEP_SECS)
 
 
-def _validate_title_reply(text: str, *, control_words: tuple[str, ...] = ("SKIP",)) -> str:
+#: Characters that read as a verdict-reason separator right after a control
+#: word ("SKIP: too vague", "SKIP (too vague)"). Deliberately NOT every
+#: non-alphanumeric: "-" and "." separate only when spaced away from the next
+#: word, so identifier titles the prompt tells the model to keep verbatim
+#: ("KEEP-ALIVE header bug", "SKIP.md parser fix") survive, and "_" never
+#: separates ("SKIP_TESTS env var flag").
+_TITLE_VERDICT_TRAILERS = ":,;!?("
+
+
+def _is_verdict_reply(title: str, control_words: tuple[str, ...]) -> bool:
+    """True when *title* is a control word, alone or followed by a reason.
+
+    The word is matched case-insensitively on every shape: the words are
+    taught as literal ASCII, but a lowercased echo is still a verdict, with
+    or without a reason attached ("skip", "Skip: greetings only", "keep - the
+    title still fits"). What separates a verdict-plus-reason from a real
+    title OPENING with the word is the separator: punctuation (or a spaced
+    dash / spaced period) means verdict, while a plain following word or an
+    identifier joiner means title ("SKIP and KEEP handling", "Keep alive
+    timer bug", "SKIPPED frames in reveal", "KEEP-ALIVE header bug").
+    """
+    upper = title.upper()
+    if upper in control_words:
+        return True
+    for word in control_words:
+        if not upper.startswith(word):
+            continue
+        rest = title[len(word) :]
+        head = rest.lstrip()
+        spaced = len(head) != len(rest)
+        if not head:
+            return True
+        char = head[0]
+        if char in _TITLE_VERDICT_TRAILERS:
+            return True
+        if char == "-" and (spaced or len(head) < 2 or head[1].isspace()):
+            return True
+        if char == "." and (len(head) < 2 or head[1].isspace()):
+            return True
+    return False
+
+
+def _validate_title_reply(
+    text: str, *, control_words: tuple[str, ...] = ("SKIP", "KEEP")
+) -> str:
     """Clean, redact and shape-check an LLM title reply; ``""`` means no title.
 
     Shared by the initial titling and the refresh so the two paths cannot drift:
     both redact BEFORE anything else touches the reply (a refusal can quote the
     user's own message back — including a credential or exfiltration URL pasted
     into it) and both discard prose-shaped replies rather than persisting a
-    sentence as the session name. ``control_words`` are the caller's no-title
-    sentinels (SKIP for the initial prompt, SKIP/KEEP for the refresh).
+    sentence as the session name. ``control_words`` are the no-title sentinels.
+    BOTH taught words are defaults: the module's own prompts teach the model
+    SKIP and KEEP, so a reply of either word means "no title" on every path
+    -- an initial reply of KEEP is a confused model, not a session named
+    ``KEEP``. See ``_is_verdict_reply`` for how a verdict-plus-reason line is
+    told apart from a real title that opens with the word.
     """
     title = _clean_title(text)
-    if not title or title.upper() in control_words:
+    if not title or _is_verdict_reply(title, control_words):
         return ""
     title, _ = redact_exfiltration_urls(title)
     title, _ = redact_credentials(title)
@@ -878,7 +972,7 @@ async def _generate_refreshed_title(
         return ""
     logger.debug("Title refresh prompt (%d chars)", len(prompt))
     text = await run_bg_oneliner(state.sessions, prompt, model=_TITLE_MODEL)
-    title = _validate_title_reply(text, control_words=("SKIP", "KEEP"))
+    title = _validate_title_reply(text)
     if not title:
         logger.info("Title refresh returned KEEP/SKIP/empty — keeping current title")
         return ""

--- a/test/test_chat_title.py
+++ b/test/test_chat_title.py
@@ -27,6 +27,7 @@ from kiro_crew.dashboard.chat_title import (
     _looks_like_prose,
     _message_attachment_paths,
     _title_text,
+    _validate_title_reply,
 )
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot
 
@@ -890,3 +891,122 @@ class TestSlotTitleRouteRefusalCodes:
             body = await resp.json()
             assert body["error"] == "title required"
             assert body["code"] == "title_required"
+
+
+# --- Non-title replies must yield no title ----------------------------------
+# Three reply shapes the validator must reject: SKIP followed by a reason
+# (multi-line and one-line), KEEP on the initial titling path, and a short
+# Korean refusal. Korean strings are written as \u escapes to keep the source
+# ASCII; the runtime values are the Hangul sentences.
+
+# "haedang lingkeue jeopgeunhal su eopseumnida" -- "I cannot access that link"
+_KO_REFUSAL_SHORT = "\ud574\ub2f9 \ub9c1\ud06c\uc5d0 \uc811\uadfc\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4"
+# "joesonghajiman ... eopseumnida" -- "Sorry, I cannot open the external link,
+# so I cannot tell what the conversation is about"
+_KO_REFUSAL_LONG = (
+    "\uc8c4\uc1a1\ud558\uc9c0\ub9cc \uc678\ubd80 \ub9c1\ud06c\ub97c \uc5f4 \uc218 "
+    "\uc5c6\uc5b4\uc11c \ub300\ud654\uc758 \uc8fc\uc81c\ub97c \ud30c\uc545\ud560 "
+    "\uc218 \uc5c6\uc2b5\ub2c8\ub2e4"
+)
+# "joesonghajiman lingkeuleul yeol su eopseoyo" -- the same apology refusal in
+# the informal-polite register ("-yo" ending).
+_KO_REFUSAL_INFORMAL = (
+    "\uc8c4\uc1a1\ud558\uc9c0\ub9cc \ub9c1\ud06c\ub97c \uc5f4 \uc218 \uc5c6\uc5b4\uc694"
+)
+# "joesonghajiman lingkeuleul yeol su eopseum" -- apology opener with a
+# plain-form ending, pinning the opener branch independently of the endings.
+_KO_REFUSAL_OPENER_ONLY = (
+    "\uc8c4\uc1a1\ud558\uc9c0\ub9cc \ub9c1\ud06c\ub97c \uc5f4 \uc218 \uc5c6\uc74c"
+)
+# "lingkeuleul yeol su eopseoyo" -- informal-polite refusal with no apology,
+# pinning the "-yo" ending branch independently of the opener.
+_KO_REFUSAL_YO_ONLY = "\ub9c1\ud06c\ub97c \uc5f4 \uc218 \uc5c6\uc5b4\uc694"
+# "peuraibeosi paeneol beogeu sujeong" -- "PrivacyPanel bug fix", a legitimate
+# short Korean title (noun phrase: no sentence-final conjugation, no apology).
+_KO_REAL_TITLE = "\ud504\ub77c\uc774\ubc84\uc2dc \ud328\ub110 \ubc84\uadf8 \uc218\uc815"
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        # Multi-line: a reply reduces to its first line, so the
+        # verdict-plus-reason shape collapses to the bare control word.
+        "SKIP\n\nThe conversation is incomplete and does not establish a clear topic.",
+        "SKIP\nToo vague to name.",
+        # One-line: verdict plus reason on a single line, in any casing --
+        # a lowercased echo carrying a reason is still a verdict.
+        "SKIP - the topic is not clear yet",
+        "SKIP (too vague)",
+        "SKIP: greetings only",
+        "skip - too vague to name",
+        "Skip: greetings only",
+        "keep - the title still fits",
+        # Exact-match forms that must keep working.
+        "SKIP",
+        "skip",
+        "SKIP.",
+    ],
+)
+def test_skip_with_reason_yields_no_title(reply):
+    assert _validate_title_reply(reply) == ""
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        # The module's own refresh prompt teaches KEEP, so an initial reply
+        # of KEEP is a confused model, not a session named "KEEP".
+        "KEEP",
+        "keep",
+        "KEEP\n\nThe current title still fits the conversation.",
+        "KEEP - the title still fits",
+    ],
+)
+def test_keep_is_a_control_word_on_the_initial_path(reply):
+    assert _validate_title_reply(reply) == ""
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        _KO_REFUSAL_SHORT,
+        _KO_REFUSAL_LONG,
+        _KO_REFUSAL_INFORMAL,
+        _KO_REFUSAL_OPENER_ONLY,
+        _KO_REFUSAL_YO_ONLY,
+    ],
+)
+def test_korean_refusal_yields_no_title(reply):
+    # Hangul is spaced, so the word ceiling never fires on a SHORT refusal,
+    # and the English-only openers never match one. The sentence shape
+    # (final "-nida"/"-yo" conjugation, "joesong" apology opener) must; the
+    # opener-only and ending-only fixtures pin each branch independently.
+    assert _looks_like_prose(reply)
+    assert _validate_title_reply(reply) == ""
+
+
+@pytest.mark.parametrize(
+    "reply,expected",
+    [
+        # Real titles that OPEN with a control word must survive: a plain
+        # following word or an identifier joiner separates a title from a
+        # verdict-plus-reason, and the prompt tells the model to keep
+        # identifiers verbatim.
+        ("Keep alive timer bug", "Keep alive timer bug"),
+        ("Skip list benchmark", "Skip list benchmark"),
+        ("SKIPPED frames in reveal", "SKIPPED frames in reveal"),
+        ("SKIP and KEEP handling", "SKIP and KEEP handling"),
+        ("SKIP_TESTS env var flag", "SKIP_TESTS env var flag"),
+        ("KEEP-ALIVE header bug", "KEEP-ALIVE header bug"),
+        ("SKIP.md parser fix", "SKIP.md parser fix"),
+        # A title followed by an unasked-for explanation keeps its first line,
+        # mirroring messaging/auto_title.clean_title.
+        ("Fix login bug\n\nThis names the session's main topic.", "Fix login bug"),
+        # A reply opening with a blank line keeps its title.
+        ("\nFix login bug", "Fix login bug"),
+        # A legitimate short Korean title is not a refusal.
+        (_KO_REAL_TITLE, _KO_REAL_TITLE),
+    ],
+)
+def test_legitimate_titles_survive_the_new_checks(reply, expected):
+    assert _validate_title_reply(reply) == expected


### PR DESCRIPTION
## Problem / Motivation

`_validate_title_reply` in `src/kiro_crew/dashboard/chat_title.py` is the guard that keeps a model's non-title reply from becoming the session name. Three reply shapes defeat it and are stored as the sidebar title anyway:

1. `SKIP` followed by a reason. The control-word test is an exact match and the dashboard's `_clean_title` does no first-line reduction, so `SKIP\n\n<reason>` is stored whole, newline included; one-line shapes such as `SKIP - the topic is not clear yet` and `SKIP (too vague)` get through too.
2. A bare `KEEP` on the initial titling path. The default `control_words` was `("SKIP",)`; only the refresh call site passed `("SKIP", "KEEP")`, so a model answering with the other control word this same module teaches produces a session literally named `KEEP`.
3. A short Korean refusal. Hangul is excluded from `_UNSPACED_SCRIPT_RANGES` on the stated ground that the word ceiling covers spaced scripts, but a refusal is short enough to clear the ceiling, `ko` is a shipped UI language, and `_TITLE_PROSE_OPENERS` is English-only.

## Why it matters

The stored title is persisted sidebar chrome: every affected session permanently shows a control word, a multi-line verdict blob, or a refusal sentence as its name, on the initial titling, background refresh, and manual regenerate paths alike. The module's own contract ("the reply is also validated here and treated as SKIP when it fails") says these must route to the fallback name instead.

## What changed (motivation -> approach -> change)

Symptom -> root cause -> fix, per shape:

- Multi-line replies were stored whole because the dashboard `_clean_title` lacked the first-line reduction its sibling `messaging/auto_title.clean_title` documents ("Keeps the first line only"). `_clean_title` now keeps the first line, collapsing `SKIP\n\n<reason>` back to the bare control word and keeping a real title that is followed by an unasked-for explanation.
- One-line verdict-plus-reason and bare `KEEP` slipped through because control words were matched by exact string only, and only on the refresh path. The default `control_words` is now `("SKIP", "KEEP")`, and a new `_is_verdict_reply` matches the word case-insensitively, alone or followed by a punctuation-separated reason (`SKIP: too vague`, `skip - too vague`, `Keep - the title still fits`). The separator classes are chosen so a real title that merely opens with the word survives: a plain following word (`SKIP and KEEP handling`, `Keep alive timer bug`) and identifier joiners (`KEEP-ALIVE header bug`, `SKIP.md parser fix`, `SKIP_TESTS env var flag`) are titles, since the titling prompt explicitly tells the model to keep identifiers verbatim.
- Korean refusals passed because every existing signal is either English-only or aimed at unspaced scripts, and Korean puts the refusal verb last, so prefix openers structurally cannot catch it. `_looks_like_prose` now matches Korean sentence shape: the sentence-final polite conjugations (formal `-nida` family, informal-polite `-yo` family) and the `joesong` apology opener. A noun-phrase title carries none of these. The trade runs deliberately toward rejection: a sentence-form Korean title falls back to the truncated-message name (still the user's own words), while a stored refusal is the bug. A plain-form (banmal) refusal remains a documented false negative, matching the module's existing stance for unspaced scripts.

The spec bullet for the prose guard and `_clean_title` in `docs/system-specs/modules/config.md` is updated in the same commit.

Known adjacent gap kept out of scope: `messaging/auto_title.clean_title` (the Slack/Telegram naming path) still accepts the one-line verdict-plus-reason and `KEEP` shapes and has no prose guard; that is a separate surface and will be filed as its own issue rather than widening this diff.

## Tests

Added to `test/test_chat_title.py` (all parametrized against `_validate_title_reply` / `_looks_like_prose`):

- `test_skip_with_reason_yields_no_title`: multi-line `SKIP\n\n<reason>`, one-line `SKIP - ...`/`SKIP (...)`/`SKIP: ...` in upper, lower and title case, plus the exact-match forms that must keep working.
- `test_keep_is_a_control_word_on_the_initial_path`: bare `KEEP`/`keep`, multi-line `KEEP` with reason, one-line `KEEP - ...` -- all on the DEFAULT (initial) path.
- `test_korean_refusal_yields_no_title`: both refusals reported in the issue, plus an informal `-yo` refusal, an opener-only fixture and an ending-only fixture so each Korean branch is pinned independently.
- `test_legitimate_titles_survive_the_new_checks`: control-word-opening titles in every separator class named above, a title followed by an explanation (keeps its first line), a blank-line-led reply, and a legitimate short Korean noun-phrase title.

Full runs locally: `test_chat_title.py` + `test_title_refresh.py` + `test_pending_title.py` + `test_messaging_auto_title.py` = 230 passed. flake8, isort, the black ratchet gate, comment-history, brand-name and docs-lint gates all pass.

## Manual verification

N/A -- unit coverage sufficient: the validator is a pure function and every caller (`_generate_title_via_kiro`, `_generate_refreshed_title`, `api_chat_slot_generate_title`) routes `""` to the existing fallback path, which is already covered by the pending-title and refresh suites.

## Related Issues

Closes #10207

## Pattern harvest

Rule candidate: review-prompt
Pattern: "control-word sentinel matched by exact string only -- verdict-plus-reason and cross-path control words bypass the guard"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
