### PR TITLE
allow saving the mcp tool search toggle

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -911,6 +911,10 @@ flow again. Replay remains merge-only and idempotent.
 
 ## Dashboard (`dashboard/`)
 
+The Developer → Config MCP Tool Search toggle saves `agent.tool_search` as a
+boolean through `PATCH /api/config/kirocrew`. The config watcher refreshes the
+defaults used by new sessions.
+
 Modular aiohttp package at `127.0.0.1:5476` (configurable). Split into:
 - `folder_repository.py` — chat-folder load, serialized read-modify-write, rollback,
   full-value write confirmation, and breadcrumb traversal. `DashboardState` keeps

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1907,6 +1907,7 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     },
     "agent.sandbox": {"type": "enum", "values": ["auto", "off"]},
     "agent.sandbox_allow_no_isolation": {"type": "bool"},
+    "agent.tool_search": {"type": "bool"},
     "memory.private_provisioning_enabled": {"type": "bool"},
     "agent.completion_keep": {"type": "enum", "values": ["head", "tail", "both"]},
     "agent.completion_keep_chars": {

--- a/test/test_config_patch.py
+++ b/test/test_config_patch.py
@@ -385,6 +385,29 @@ class TestFloatValidator:
 
 class TestBoolValidator:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", [False, True])
+    async def test_tool_search_toggle_round_trips(self, tmp_config, value) -> None:
+        data = _seed_config()
+        data["agent"]["tool_search"] = not value
+        tmp_config.write_text(json.dumps(data), encoding="utf-8")
+        async with TestClient(TestServer(_make_app())) as client:
+            response = await _patch(client, "agent.tool_search", value)
+            assert response.status == 200
+            assert (await response.json())["agent"]["tool_search"] is value
+        data["agent"]["tool_search"] = value
+        assert json.loads(tmp_config.read_text(encoding="utf-8"))["agent"] == data["agent"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["false", 0, None])
+    async def test_tool_search_rejects_non_boolean(self, tmp_config, value) -> None:
+        before = tmp_config.read_bytes()
+        async with TestClient(TestServer(_make_app())) as client:
+            response = await _patch(client, "agent.tool_search", value)
+            assert response.status == 400
+            assert (await response.json())["error"] == "must be a boolean"
+        assert tmp_config.read_bytes() == before
+
+    @pytest.mark.asyncio
     async def test_valid_bool_passes(self, tmp_config) -> None:
         async with TestClient(TestServer(_make_app())) as c:
             resp = await _patch(c, "auto_update", True)


### PR DESCRIPTION
## Problem / Motivation

Clicking MCP Tool Search in Developer > Config fails with `field not editable: agent.tool_search` and leaves the toggle unchanged. The setting now saves in both directions and survives a page reload.

## Why it matters

Users cannot enable or disable MCP tool search through the dashboard's existing control.

## What changed (motivation → approach → change)

The UI already sends the correct path, but the config PATCH handler's editable fields omit `agent.tool_search`. Add it as a boolean so the request uses the existing validation, persistence, and config watcher.

The session manager already subscribes to this setting and refreshes defaults for new sessions. The owning dashboard spec now documents this behavior.

Production change: one added line. Regression tests and the spec update are included in the same commit.

## Tests

Five new regression cases in `test/test_config_patch.py`:

- Saving `false` and `true` returns the new value and persists it while preserving sibling agent settings.
- A string, integer, or null returns `must be a boolean` and leaves the config file unchanged.

All five cases failed against the fetched mainline before the fix.

```bash
KIROCREW_MAX_TEST_WORKERS=3 python -m pytest \
  test/test_config_patch.py \
  test/test_config_live.py \
  test/test_session_config_hot_reload.py \
  test/test_acp_tool_search.py \
  test/test_dashboard_handlers_core_coverage.py -q
```

Result: **441 passed**.

Formatting, import order, flake8, subprocess encoding, and documentation checks passed.

Type checking passed for the Linux/Python 3.12 target across 1,416 source files.
With the local Python 3.14 target, mypy reports `asyncio.PidfdChildWatcher` at
`cli.py:422`; the same error occurs on pristine mainline.

The full suite was run with `--maxfail=1`: **6,014 passed, 32 skipped, 1 failed**.
The failure is
`test/test_agent.py::TestResolveKirocrewBin::test_falls_back_to_shutil_which`.
It also fails when run alone against pristine mainline, so the full-suite
checkbox below remains unchecked.

## Manual verification

Reproduced in the browser against freshly fetched mainline `6575bee003513fb5687976ce815635aa034b5c04`, then repeated with the fix using the same disposable data home.

1. Open `/developer?tab=config` and scroll to Config Summary.
2. Click MCP Tool Search to turn it off.
3. Reload and confirm it stays off.
4. Turn it back on, reload, and confirm it stays on.

Before the fix, step 2 displays the error and leaves the toggle on. After the fix, both values save without an error and persist across reloads.

Raw response before the fix:

```http
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=utf-8

{"error": "field not editable: agent.tool_search"}
```

## Screenshots / video

Before: clicking the toggle fails.
<img width="1280" height="720" alt="ui-before" src="https://github.com/user-attachments/assets/8767a259-979a-451c-85f4-e7f33210bf59" />



After: off persists after reload.
<img width="1280" height="720" alt="ui-after-off" src="https://github.com/user-attachments/assets/5e4bd4a7-4783-4c42-9e18-49adb61cfc19" />

After: on also persists after reload.
<img width="1280" height="720" alt="ui-after-on" src="https://github.com/user-attachments/assets/476e6b7a-eebb-4f0c-9b57-1464d04e97a9" />



### Fixes

https://github.com/kirodotdev/KiroCrew/issues/10241

## Pattern harvest

Rule candidate: review-prompt

Pattern: when a UI control writes a config path, verify that the save handler accepts that path and that the value persists through the real write endpoint.

## Checklist

- [x] One commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff


## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
