### PR TITLE
fix(aws-control): add opencode's auth.json to the standalone credential fence

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/crew/packaging/build.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/packaging/build.py
@@ -299,6 +299,7 @@ _SENSITIVE_RELATIVE_DIRS = (
     ".kube/config",
     ".local/share/amazon-q",
     ".local/share/kiro-cli",
+    ".local/share/opencode/auth.json",
     ".netrc",
     ".npmrc",
     ".pypirc",


### PR DESCRIPTION
## Summary

Main is currently red on Backend Tests: `test_the_local_subset_fences_every_foreign_credential_store` fails because two PRs merged ten minutes apart today collided semantically —

- #10006 (merged 15:58 PT) declared `.local/share/opencode/auth.json` as a credential leaf, which `security/paths.py` splices into the shared validator via `host_auth.credential_leaves()`.
- #9213 (merged 16:08 PT) added the packaging build's standalone fence with a hardcoded `_SENSITIVE_RELATIVE_DIRS`, written before the opencode leaf existed.

Each PR was green against a main that lacked the other. Combined, the fence-parity test fails: the shared validator classifies opencode's token as a foreign credential store and the standalone fence treats it as ordinary — which, in standalone mode (when `kiro_crew.security` cannot be imported), is exactly the gap the test exists to catch.

## Fix

One entry added to `_SENSITIVE_RELATIVE_DIRS`: the exact leaf `.local/share/opencode/auth.json`, mirroring how the list already carries amazon-q and kiro-cli stores.

The leaf, deliberately not the `.local/share/opencode` directory: the shared validator classifies only `auth.json`, and the converse parity test (`test_the_local_fence_is_never_stricter_than_the_shared_one`) rejects the directory-level entry as over-fencing — verified both ways locally before settling on the leaf.

## Testing

- `test_sensitive_source_and_report_identity.py`: 96/96 pass with this change; the parity test fails without it (reproduced on pristine main, Linux — it is not Windows-specific despite first surfacing on a Windows shard).
- Directory-level variant rejected by the never-stricter test (verified, see above).

First observed on [PR #9969's CI](https://github.com/kirodotdev/KiroCrew/pull/9969) (merge-commit run); reproduced on main directly.


## Pattern harvest

Rule candidate: process, not lint — this is the "two individually-green PRs whose union breaks an invariant" class (#10006 added a validator entry; #9213 added a parity-pinned mirror of the validator, authored before that entry existed). A merge queue (or retesting each PR against post-merge main before landing) catches the whole class; no code-level rule can, since each tree was correct in isolation. The parity test itself is already the right mechanical guard — it did catch the collision, on main, immediately.

Not generalizable at the code level beyond what the parity test already pins: the fence's hardcoded list is BY DESIGN (standalone mode cannot import the validator), and the test mechanically harvests every validator leaf, so any future omission of this kind stays impossible to miss.
