### PR TITLE
fix: explain internal auth denials

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1562,6 +1562,20 @@ the destination's ordinary security checks and to the effective
 - `token_auth_middleware(local_only)` — single boolean controls all auth behavior
 - **Secure cookie flag via `origin.is_https_request()`**: the `mc_token_<port>` cookie (and the refresh cookie) set `Secure` only when the request is HTTPS — `is_https_request(request)` returns True for a direct HTTPS request, or when `X-Forwarded-Proto: https` is present **and the immediate peer is loopback** (a TLS-terminating tunnel/proxy forwarding into the loopback-bound gateway). Plain-HTTP localhost must NOT set `Secure` or the browser refuses to send the cookie back
 
+**Internal MCP authentication denial codes** — an internal tool can receive the same
+`403 Forbidden` body for several different failures. `token_auth.py` therefore labels
+the actionable internal paths without changing what they deny: `unix_peer_unverified`
+means the Unix-socket peer could not be confirmed as the gateway user;
+`peer_session_mismatch` means the verified peer belongs to a different session than
+its declared `X-Session-Key`; `caller_record_missing` means the current cron or
+subagent registry record no longer exists. `mcp_core._http_error_body` maps those
+codes to the matching recovery step: restart the gateway and recreate the session,
+restart or replace the mismatched session, or start a new session, respectively. The
+existing `internal_auth_mismatch` mapping remains the wrong-instance diagnostic.
+Unknown codes and uncoded `Forbidden` responses keep the backend wording, so a real
+permission denial is never relabelled as an identity failure. Every branch keeps its
+existing HTTP status, deny decision, ordering, and SEL audit.
+
 **Per-session logout (CWE-613)** (`token_auth.py`): the access cookie is a self-contained HMAC-signed token, so clearing it client-side (`Set-Cookie max_age=0`) does not stop a saved copy replaying until its `session_exp` (up to 20h). `RevokedNonceStore` is a persisted denylist of explicitly-revoked access-cookie nonces (`token_revoked_nonces.json`, mode `0600`, survives gateway restart; each entry stores the token's own `session_exp` as an eviction floor so the file cannot grow unbounded). `POST /api/auth/logout` → `revoke_access_cookie()` validates the token, then records its nonce; `validate_token` (cookie path) is **deny-by-default** — a token whose nonce is revoked, or that carries no nonce at all, is rejected. Link-click token exchange also mints a SEPARATE session cookie (fresh nonce, `register_nonce=False`) rather than reusing the one-time URL/link token as the long-lived cookie, and denylists the consumed link nonce so a captured link copy cannot be replayed as `mc_token_<port>` (the query-param LINK path does not consult the denylist, so legitimate re-navigation of the same link URL within the 5-minute window still re-exchanges for a fresh session cookie).
 
 **Structured monitor API authorization** (`dashboard/handlers/autonudge.py`):

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1685,7 +1685,7 @@ async def _verify_unix_peer(
             error=_reason,
         )
         _log_auth(request, "internal", "denied", _reason)
-        return _deny(request, "Forbidden")
+        return _deny(request, "Forbidden", "unix_peer_unverified")
     peer_pid = get_peer_pid(sock)
     if peer_pid is None:
         return None
@@ -1720,7 +1720,7 @@ async def _verify_unix_peer(
             "denied",
             f"peer identity mismatch (peer_pid={peer_pid})",
         )
-        return _deny(request, "Forbidden")
+        return _deny(request, "Forbidden", "peer_session_mismatch")
     # Positive kernel attestation. Debug-level on purpose — this fires on
     # every internal call from a claimed session; the SEL trail records the
     # deny arm, which is the permission decision that changes anything.

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -1596,6 +1596,23 @@ def _http_error_body(exc: urllib.error.HTTPError) -> dict:
             "the instance you meant) and retry; the gateway's security event log "
             "records both credential fingerprints for the mismatch."
         )
+    elif code == "caller_record_missing":
+        message = (
+            "this session's cron or subagent record no longer exists; start a new "
+            "session before retrying the tool."
+        )
+    elif code == "unix_peer_unverified":
+        message = (
+            "the gateway could not verify this Unix-socket caller as the same local "
+            "user. Restart the gateway and start a new session; if the error persists, "
+            "make sure the client and gateway run as the same OS user."
+        )
+    elif code == "peer_session_mismatch":
+        message = (
+            "this Unix-socket caller is bound to a different session than the "
+            "X-Session-Key it declared. Restart the affected session, or start a new "
+            "one, before retrying the tool."
+        )
     out: dict = {"error": message}
     if counted:
         out["counted"] = True

--- a/test/test_dashboard_peer_auth.py
+++ b/test/test_dashboard_peer_auth.py
@@ -253,6 +253,10 @@ async def test_unix_peer_mismatch_denied_with_sel(monkeypatch: pytest.MonkeyPatc
     )
     resp = await mw(req, _ok_handler)
     assert resp.status == 403
+    assert json.loads(resp.body) == {
+        "error": "Forbidden",
+        "code": "peer_session_mismatch",
+    }
     mismatches = [c for c in calls if c.get("operation") == "dashboard.peer-identity-mismatch"]
     assert len(mismatches) == 1
     assert mismatches[0]["outcome"] == "denied"
@@ -318,6 +322,10 @@ async def test_unix_peer_uid_mismatch_denied(monkeypatch: pytest.MonkeyPatch) ->
     )
     resp = await mw(req, _ok_handler)
     assert resp.status == 403
+    assert json.loads(resp.body) == {
+        "error": "Forbidden",
+        "code": "unix_peer_unverified",
+    }
     assert any(c.get("outcome") == "denied" for c in calls)
 
 
@@ -336,6 +344,10 @@ async def test_unix_peer_uid_unverifiable_denied(monkeypatch: pytest.MonkeyPatch
     )
     resp = await mw(req, _ok_handler)
     assert resp.status == 403
+    assert json.loads(resp.body) == {
+        "error": "Forbidden",
+        "code": "unix_peer_unverified",
+    }
     assert any("unverifiable" in c.get("error", "") for c in calls)
 
 

--- a/test/test_internal_secret_app_identity_3690.py
+++ b/test/test_internal_secret_app_identity_3690.py
@@ -22,6 +22,7 @@ below:
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -500,6 +501,10 @@ class TestADelegatedCallerWhoseRecordIsGoneIsRefused:
             "a cron whose job was deleted mid-run kept the dashboard user's "
             "reach; the deleted record was the only proof of its owner"
         )
+        assert json.loads(resp.body) == {
+            "error": "Forbidden",
+            "code": "caller_record_missing",
+        }
 
     @pytest.mark.asyncio
     async def test_a_subagent_missing_from_the_registry_is_refused(self) -> None:
@@ -507,6 +512,10 @@ class TestADelegatedCallerWhoseRecordIsGoneIsRefused:
         req, _ = _request("subagent:gone", {}, subagents={})
         resp = await mw(req, _ok)
         assert resp.status == 403
+        assert json.loads(resp.body) == {
+            "error": "Forbidden",
+            "code": "caller_record_missing",
+        }
 
     @pytest.mark.asyncio
     async def test_a_live_record_is_admitted(self) -> None:

--- a/test/test_mcp_core_coverage.py
+++ b/test/test_mcp_core_coverage.py
@@ -187,6 +187,31 @@ class TestHttpErrorBody:
         err = _http_error(400, json.dumps({"error": f"bad key {secret}"}).encode())
         assert secret not in _http_error_body(err)["error"]
 
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            ("caller_record_missing", "cron or subagent record no longer exists"),
+            ("unix_peer_unverified", "could not verify this Unix-socket caller"),
+            ("peer_session_mismatch", "bound to a different session"),
+        ],
+    )
+    def test_internal_auth_denial_codes_are_actionable(self, code: str, expected: str):
+        err = _http_error(403, json.dumps({"error": "Forbidden", "code": code}).encode())
+        out = _http_error_body(err)
+        assert expected in out["error"]
+        assert out["error"] != "Forbidden"
+        assert out["code"] == code
+
+    def test_unrelated_error_code_keeps_the_backend_message(self):
+        err = _http_error(
+            403,
+            b'{"error": "Forbidden", "code": "unrelated_auth_denial"}',
+        )
+        assert _http_error_body(err) == {
+            "error": "Forbidden",
+            "code": "unrelated_auth_denial",
+        }
+
 
 @pytest.mark.parametrize("verb", ["_get", "_patch", "_put", "_delete"])
 class TestVerbHelpers:


### PR DESCRIPTION
## Problem / Motivation

Internal MCP tools can return only `Error: Forbidden` when local caller identity checks fail. The response already knows the cause, but the shared decoder explains only `internal_auth_mismatch`.

## Why it matters

The opaque message sends people after a permission or credential bug they do not have. An orphaned cron or subagent session cannot recover by retrying, while Unix peer failures need a gateway or session restart.

## What changed (motivation → approach → change)

Two Unix-socket deny sites now attach distinct machine-readable codes. Their status, ordering, audit records, and deny decisions stay unchanged.

`mcp_core._http_error_body` maps those codes and the existing `caller_record_missing` code to short explanations with a concrete next step. Uncoded denials and unknown codes keep the backend message, so a real permission denial is not relabelled as an identity failure.

The security specification records the code-to-remedy contract.

## Tests

- `test/test_dashboard_peer_auth.py` pins `peer_session_mismatch` and both `unix_peer_unverified` outcomes while retaining the existing 403 and audit assertions.
- `test/test_internal_secret_app_identity_3690.py` pins `caller_record_missing` for missing cron and subagent records.
- `test/test_mcp_core_coverage.py` checks all three explanations and proves an unrelated code remains generic.
- The required touched-file and drift-guard run passed: 330 tests.
- Black, isort, Flake8, mypy, docs lint, frontend build/type/lint/tests, Electron tests, bundle checks, and the remaining resolved profile gates passed.
- The one full backend run reported 98,559 passed, 79 failed, 375 skipped, and 9 xfailed. A serial replay of all 79 failed node IDs produced the same 79 failures on `origin/main` and this head, with zero head-only failures; they are host-environment failures unrelated to this diff.

## Manual verification

A fresh isolated Linux pod ran a cron session that waited for 60 seconds. The cron record was deleted during that wait, then the same session called `learn_list`.

Before the change, the exact result was `Error: Forbidden` while the audit log said `delegated caller's own record is gone` and `delegated record missing`.

After the change, the exact result was `Error: this session's cron or subagent record no longer exists; start a new session before retrying the tool.` The same two denial audit entries remained unchanged.

## Related Issues

Fixes #10227

Related: #9841

This supersedes the narrower caller-record-only draft in #10221.

## Pattern harvest

Rule candidate: review-prompt

Pattern: An actionable server denial stays opaque when its machine-readable code is preserved by a shared client decoder but has no code-specific message.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
