### PR TITLE
feat(mirrors): declare each backend's MCP projection as a typed kind

### DIFF
--- a/docs/request-for-change/rfc-agent-config-mirror.md
+++ b/docs/request-for-change/rfc-agent-config-mirror.md
@@ -205,6 +205,65 @@ The folder is where the answer goes; the test is what asks the question.
   synchronous accessor over a warmed cache (H13) — the existing
   `_session_mcp_servers` cache is the pattern to copy.
 
+### 3.8 The projection kind, above the dispositions
+
+§3.3's four dispositions answer "what happens to this concern". They cannot answer
+the prior question — "how does anything reach this backend at all?" — and the first
+implementation tried to answer it with prose: one registry name held both "declared
+to need no projection" and "the projection has not been written", each as a
+paragraph of explanation under the same key. A selectable backend could therefore
+sit there with an account of when its projection would arrive, and every check
+stayed green. That is the structural reason the same missing-tools defect shipped
+on four harnesses rather than being caught on the second.
+
+So the registry declares a **kind** per backend, and the two kinds that are not
+finished states are required to be addressable:
+
+| Kind | Means | Required beyond `reason` |
+|---|---|---|
+| `native` | the backend reads the agent spec itself | — |
+| `mirror` | a mirror in `providers/mirrors/` projects it; must have a registered class | — |
+| `external` | Crew projects it, from a module outside that folder | `projection` (dotted module), `tracking` |
+| `no-channel` | no transport the backend advertises can carry Crew's servers | `channel` (what would have to exist), `tracking` |
+
+`tracking` is an issue URL or a repo-relative `path#anchor`, and the parity test
+resolves it. `channel` is the field that makes a gap addressable rather than
+merely explained — the same role it already plays on a `no-channel` *disposition*,
+lifted one level up so it also covers the case where NO concern reaches the
+backend.
+
+Three rules carry the guard, all in `test/test_provider_mirrors.py`:
+
+- a `native` or `mirror` reason may not read as a schedule ("pending", "not yet
+  moved", "unwritten"), because an unfinished projection has its own kind now;
+- a selectable `no-channel` backend must additionally be named in
+  `../system-specs/modules/harness-onboarding.md`, since the declaration is what
+  code reads and the onboarding table is what a human reads before writing any of
+  it;
+- **every kind is cross-checked against something outside its own text**, so that
+  no kind rests on a list of forbidden words. `mirror` needs a registered class and a
+  `delivered`/`translated` `mcpServers` ruling; `external` needs an importable
+  module; `no-channel` needs the channel, a resolvable tracking pointer and the
+  onboarding row; and `native` is checked against `agent_sdk/mcp_refs.py`, which
+  already has to know whether a backend resolves a `@server` ref against the
+  spec's own `mcpServers` or against the wire array. The declaration and the
+  resolver acting on it may not diverge in either direction — which is what makes
+  the schedule-prose rule a second line rather than the only one.
+
+The kinds are checked in both directions. The negative half of that file adds a
+fake selectable backend carrying a prose-only declaration and asserts the rules
+reject it, because a guard nobody has watched fail is a guard nobody knows the
+shape of.
+
+**What this means for the §5 migration.** KAS is `external` in the interim, naming
+`acp/kas_agents.py` and pointing its `tracking` at §5. That is not a softening of
+PR 3 — it is the honest reading of the state PR 3 starts from, and it is what stops
+KAS from being a hand-waved exception in the meantime. Folding it to `mirror`
+additionally requires the unresolved-ref detector to ask a mirror for the server
+names its projection delivers, rather than reading an `mcpServers` array: KAS's
+channel is `_meta.kiro.customAgents`, so the array-shaped question has no answer
+there. That contract method belongs with the relocation, not ahead of it.
+
 ## 4. Hooks delivery plan
 
 Hooks are the worked example, because they are the one concern where all four
@@ -285,7 +344,7 @@ rediscover.
 |---|---|---|
 | 1 | The folder and the declaration: `providers/mirrors/` with `base.py`, `registry.py` and `README.md`, the interface on `LLMProvider` with a safe default, the four-value disposition vocabulary, capability set(s) in `acp_backends.py`, and the disposition table for all three existing mirrors filled in from the code as it is. No mirror code moves yet | none — no behaviour change |
 | 2 | **Move** Claude Code's mirror into `mirrors/claude_code.py` and re-express it as an implementation. Newest of the three and the only one with a live open PR, so it converts with the least archaeology | low |
-| 3 | **Move** KAS's mirror into `mirrors/kas.py` (keeping `kas_permissions.py` as its translation helper). Largest of the three; expected to need no logic change, only relocation plus a declared table | low, but the biggest diff |
+| 3 | **Move** KAS's mirror into `mirrors/kas.py` (keeping `kas_permissions.py` as its translation helper), flip its declaration from `external` to `mirror`, and give the mirror contract the "server names this projection delivers" method the unresolved-ref detector needs for a non-array channel. Largest of the three; expected to need no projection-logic change, only relocation plus a declared table | low, but the biggest diff |
 | 4 | **Move** the kiro-cli overlay into `mirrors/kiro_cli.py`, and correct `providers.md` | low |
 | 5 | Hooks H2 (Claude Code settings `hooks`) | behavioural |
 | 6 | Hooks H3 (KAS disk profile) + H4 parity test | behavioural |

--- a/docs/system-specs/modules/harness-onboarding.md
+++ b/docs/system-specs/modules/harness-onboarding.md
@@ -196,6 +196,26 @@ the reason. An explicit allowlist rather than a relaxed assertion is the point:
 a plain `baseline != known` still fails, so an id may sit outside the baseline
 only by being named.
 
+**Selectability additionally requires a decided MCP projection.** A harness an
+operator can choose is a harness whose sessions have — or provably do not have —
+Kiro Crew's own tools, and that answer is a declared kind in
+`src/kiro_crew/providers/mirrors/registry.py` (`PROJECTIONS`): `native`, `mirror`,
+`external` or `no-channel`. Work the checklist in
+[`providers/mirrors/README.md`](../../../src/kiro_crew/providers/mirrors/README.md)
+("Adding a backend: checklist") as part of this stage, not after it. The kind is
+not a formality and the failure it closes is specific: a session comes up holding
+`tools: ["@kirocrew-core", ...]` with nothing defining `kirocrew-core`, so every
+Crew tool is absent while the harness works and nothing anywhere is red. That
+shipped on four harnesses in a row, because a projection nobody had written was
+spelled the same way as a projection nobody needed.
+
+`no-channel` is a legitimate answer here, on the same terms as dormancy: it must be
+NAMED. A selectable `no-channel` harness has to name the channel that would have to
+exist and its tracking pointer in the declaration, and be named in this document —
+`test_provider_mirrors.py` checks both halves, so a gap recorded in only one of them
+fails. The reader of this file is the human who writes the code; the declaration is
+what the code reads; neither substitutes for the other.
+
 Selectability has exactly one gate, `resolve_selected_backend`, and it logs
 (H4). Do not add a static `enum` to `AgentConfig.acp_backend`: a literal frozen
 at import cannot see a boot-time registration, and `validate_config_data`

--- a/src/kiro_crew/agent_sdk/drivers/acp.py
+++ b/src/kiro_crew/agent_sdk/drivers/acp.py
@@ -113,10 +113,10 @@ def agent_spec_mcp_refs(agent: str) -> tuple[bool, list[tuple[str, list[str], bo
     **It reads the mirror seam, and that bounds what it can claim.** The wire
     array comes from ``providers.mirrors.mirror_for`` -- the same seam
     ``AcpClient._resolve_session_mcp_servers`` composes from -- so a backend whose
-    projection lives OUTSIDE that folder (KAS today, per its own ``NO_MIRROR``
-    reason) reports refs here that its own projection may well carry.
-    ``has_mirror`` is what lets the caller say which case it is instead of
-    collapsing the two.
+    projection lives OUTSIDE that folder (an ``external`` declaration) reports
+    refs here that its own projection may well carry. ``has_mirror`` is what lets
+    the caller say which case it is instead of collapsing the two, and
+    :func:`backend_mcp_projection` is what says which kind it is.
 
     ``permission_surface_owned=True`` models the ordinary spawn: the claude mirror
     withholds its whole array when Crew did not author the session's native
@@ -131,7 +131,7 @@ def agent_spec_mcp_refs(agent: str) -> tuple[bool, list[tuple[str, list[str], bo
     from kiro_crew.acp.session_mcp import agent_spec_snapshot
     from kiro_crew.acp_backends import selectable_backend_values
     from kiro_crew.agent_sdk.mcp_refs import unresolved_server_refs
-    from kiro_crew.providers.mirrors import NO_MIRROR, mirror_for
+    from kiro_crew.providers.mirrors import has_mirror, mirror_for
 
     spec = agent_spec_snapshot(agent)
     if not spec:
@@ -148,8 +148,39 @@ def agent_spec_mcp_refs(agent: str) -> tuple[bool, list[tuple[str, list[str], bo
             unresolved = unresolved_server_refs(spec, wire, backend=backend)
         except Exception:
             continue
-        rows.append((backend, unresolved, backend not in NO_MIRROR))
+        rows.append((backend, unresolved, has_mirror(backend)))
     return True, sorted(rows)
+
+
+def backend_mcp_projection(backend: str) -> tuple[str, str, str] | None:
+    """How *backend* is declared to receive Crew's MCP servers, as plain data.
+
+    Returns ``(kind, channel, tracking)`` -- the kind spelled as its wire value
+    (``native`` / ``mirror`` / ``external`` / ``no-channel``) -- or ``None`` for a
+    backend with no declaration, which is a state the parity test refuses rather
+    than one a consumer should render.
+
+    The record's ``reason`` is deliberately NOT projected. It is written for the
+    reader of the registry, at registry length, and the consumer renders the two
+    fields that answer an operator's question instead. A field nothing reads is a
+    field the next caller has to decide whether to trust.
+
+    Here rather than read by the consumer for the reason every function in this
+    module is here: the declaration lives in ``providers/mirrors``, and a consumer
+    importing it would take a boundary edge the agent-sdk-boundary gate refuses.
+    Plain strings only, so no mirror type crosses the boundary and a caller cannot
+    accidentally hold the record.
+
+    Never raises. A build whose registry cannot be imported is a broken tree, and
+    a diagnostic row is not the place to discover it.
+    """
+    try:
+        from kiro_crew.providers.mirrors import projection_for
+
+        declared = projection_for(backend)
+    except Exception:
+        return None
+    return (str(declared.kind.value), declared.channel, declared.tracking)
 
 
 def kiro_cli_resolves() -> bool:

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -1195,7 +1195,6 @@ def _doctor_unresolved_mcp_refs() -> None:
     prints a clean row there rather than every ref it declares -- the resolver keys
     that on the backend id, not on this function.
     """
-    from kiro_crew.acp_backends import POLICY_ID_BY_BACKEND
     from kiro_crew.agent_sdk.drivers.acp import agent_spec_mcp_refs
 
     try:
@@ -1208,7 +1207,7 @@ def _doctor_unresolved_mcp_refs() -> None:
         return
 
     for backend, unresolved, has_mirror in rows:
-        label = POLICY_ID_BY_BACKEND.get(backend, backend) or backend
+        label = _backend_policy_label(backend)
         if not unresolved:
             print(f"  mcp tool refs: \u2705 {label} \u2014 every @server ref resolves")
             continue
@@ -1224,9 +1223,10 @@ def _doctor_unresolved_mcp_refs() -> None:
                 "tools behind them are absent from its sessions with nothing to "
                 "say so. The shared MCP gateway can still deliver a server it "
                 "wrapped as a broker stub, which this row does not model. "
-                "Whether the omission is a decision or an unwritten projection "
-                "is recorded per backend in providers/mirrors/registry.py "
-                "(NO_MIRROR); a backend that projects elsewhere reads as "
+                "Which of those it is -- a decided no-channel harness or a "
+                "projection that lives outside providers/mirrors/ -- is the KIND "
+                "on that backend's entry in providers/mirrors/registry.py "
+                "(PROJECTIONS); a backend that projects elsewhere reads as "
                 "unprojected here."
             )
             continue
@@ -1237,6 +1237,75 @@ def _doctor_unresolved_mcp_refs() -> None:
             "transport, or a name the spec references but never defines. Compare "
             "the agent spec's mcpServers against its tools list."
         )
+
+
+def _doctor_selected_backend_projection(cfg: KiroCrewConfig) -> None:
+    """One row for the SELECTED backend when its declaration says ``no-channel``.
+
+    :func:`_doctor_unresolved_mcp_refs` answers this per selectable harness, off
+    the default spec's own refs. This answers a different question, about the one
+    harness the operator actually configured, and it answers it for a spec that
+    references no server at all: a ``no-channel`` backend has no transport that
+    can carry Crew's servers, so every Crew tool is absent from its sessions
+    whatever the spec says. That is a property of the harness, not of the spec,
+    and a spec with an empty ``tools`` list produces no unresolved ref to hang it
+    off.
+
+    Prints only for that one kind. ``native``, ``mirror`` and ``external`` all
+    mean the servers do reach the session, so a row there would be noise on every
+    stock install — and the refs row already speaks when a projection drops
+    something.
+
+    Reports only, and appends NO entry to ``issues``, on the terms
+    :func:`_doctor_strict_identity` and :func:`_doctor_unresolved_mcp_refs` both
+    set: choosing a harness whose transport cannot carry Crew's tools is a
+    supported configuration with a declared reason, not a broken install, and
+    failing doctor's exit code on it would make a deliberate choice read as a
+    fault.
+
+    Asks ``agent_sdk`` rather than reading the declaration here, for the reason
+    every other backend question in this module does: the record lives in
+    ``providers/mirrors`` and reaching it from a consumer would take a boundary
+    edge the agent-sdk-boundary gate refuses.
+    """
+    from kiro_crew.agent_sdk.drivers.acp import backend_mcp_projection
+
+    try:
+        backend = cfg.agent.acp_backend
+    except Exception:
+        return
+    declared = backend_mcp_projection(backend)
+    if declared is None:
+        return
+    kind, channel, tracking = declared
+    if kind != "no-channel":
+        return
+    label = _backend_policy_label(backend)
+    print(f"  mcp projection: \u23f9 {label} carries none of Kiro Crew's own tools")
+    _print_wrapped(
+        "This harness advertises no transport the session MCP array can use, so "
+        "Crew's servers are absent by declaration rather than by a "
+        "misconfiguration. The shared MCP gateway does not change that: a broker "
+        "stub is shaped as a stdio element too, so it lands in the same array. "
+        "Switching agent.acp_backend is the operator-side remedy; the line below "
+        "is what would have to be built instead."
+    )
+    # Read off a declaration a plugin-registered backend can author, so it is
+    # printed through the same display guard as every other value in this report.
+    _print_wrapped(f"Would need: {_safe_display(channel)}")
+    _print_wrapped(f"Tracked at: {_safe_display(tracking)}")
+
+
+def _backend_policy_label(backend: str) -> str:
+    """The human spelling of *backend*, matching the refs row's own labels.
+
+    ``ACP_BACKEND_KIRO`` is the empty string, so a bare id renders as nothing;
+    the policy mapping is the one place that already owns a printable name for
+    every id this build can spell.
+    """
+    from kiro_crew.acp_backends import POLICY_ID_BY_BACKEND
+
+    return POLICY_ID_BY_BACKEND.get(backend, backend) or backend
 
 
 def _doctor_agent_auth() -> None:
@@ -3493,6 +3562,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     _doctor_strict_identity(cfg)
     _doctor_mcp_gateway_daemon(issues)
     _doctor_unresolved_mcp_refs()
+    _doctor_selected_backend_projection(cfg)
 
     # ── Credentials (AWS / credential-vending MCP) ──
     # After identity, before the agent-facing sections: this is the answer to

--- a/src/kiro_crew/providers/mirrors/README.md
+++ b/src/kiro_crew/providers/mirrors/README.md
@@ -95,15 +95,72 @@ documented cause of the `hooks` regression: see `UNSUPPORTED_SPEC_KEYS` in
 `acp/kas_agents.py`, whose comment states the rule this vocabulary generalises —
 *no slot on the wire is not no such capability in the backend*.
 
-## Adding a backend
+## The four projection kinds
 
-1. Write `<backend>.py` here with a mirror class and its `rulings()`.
-2. Add it to `MIRRORS` in `registry.py` — or, if it genuinely needs no
-   projection, add it to `NO_MIRROR` **with the reason**. A backend in neither map
-   raises.
-3. Route the backend's session-params hook on `AcpClient` at the mirror.
-4. The parity test then holds you to it: every backend x every concern must
-   resolve to a disposition with a reason.
+A disposition answers "what happens to this concern"; a **kind** answers the prior
+question, "how does anything reach this backend at all?". Every backend id this
+build can spell has one `McpProjection` in `registry.py`, and the kind is what a
+test can read.
+
+| Kind | Means | Required fields |
+|---|---|---|
+| `native` | the backend reads `~/.kiro/agents/<name>.json` itself, so there is nothing to project | `reason` |
+| `mirror` | a mirror in this folder projects it; must have a class in `MIRRORS` | `reason` |
+| `external` | Crew projects it, from a module outside this folder | `reason`, `projection`, `tracking` |
+| `no-channel` | no transport this backend advertises can carry Crew's servers | `reason`, `channel`, `tracking` |
+
+`no-channel` is the only kind under which a session legitimately holds none of
+Crew's tools, and it is the one the prose form could not distinguish from a
+backlog item. A paragraph can explain a gap without ever giving it an address, and
+a gap with no address is indistinguishable from a decision — so the two kinds that
+are not finished states are required to be ADDRESSABLE, by the constructor rather
+than by a reviewer. `channel` names what would have to exist; `projection` names
+the module a reader goes to; `tracking` is an issue URL or a repo-relative
+`path#anchor` the parity test resolves.
+
+A `native` or `mirror` declaration may carry neither, and its `reason` may not read
+as a schedule: the parity test rejects "pending", "not yet moved", "unwritten" and
+their relatives on those two kinds.
+
+Every kind is additionally cross-checked against something outside its own text,
+so no kind's honesty rests on how its reason is worded. `mirror` needs a
+registered class and an `mcpServers` ruling of `delivered` or `translated`;
+`external` needs an importable module; `no-channel` needs a channel, a resolvable
+tracking pointer and an onboarding row; and `native` is checked against
+`agent_sdk/mcp_refs.py`, which has to know the same fact to resolve a `@server`
+ref at all — it satisfies a ref from the spec's OWN `mcpServers` for a
+spec-reading backend and from the wire array for every other. A declaration and
+the resolver acting on it may not diverge, in either direction. A selectable backend
+whose projection was not written could previously sit under one name with an
+explanation of when it would be, and every check stayed green — which is the
+structural reason the same missing-tools defect shipped on four harnesses in a row.
+
+## Adding a backend: checklist
+
+1. **Decide the kind.** Read its `initialize` result before deciding: what the
+   harness advertises is the answer, not what it resembles. A harness that
+   advertises no transport the `session/new` array can use is `no-channel`, and
+   that is a legitimate destination — named, not implied.
+2. **Write the mirror, or write the declaration.** `mirror` means a
+   `<backend>.py` here with a mirror class and its `rulings()`, registered in
+   `MIRRORS`. Every other kind means an entry in `PROJECTIONS` with the fields its
+   kind requires. A backend in neither table raises.
+3. **Route it.** For a `mirror`, point the backend's session-params hook on
+   `AcpClient` at the mirror so the declaration and the wire agree.
+4. **The parity test then holds you to it** (`test/test_provider_mirrors.py`):
+   one declaration per known and selectable id, `mirror` only with a class,
+   `mcpServers` ruled `delivered` or `translated` on a mirror, `native` only for an
+   id `agent_sdk/mcp_refs.py` resolves against the spec itself, a resolvable
+   `tracking`, an importable `projection`, and every concern answered with a
+   reason.
+5. **The doctor row.** A selected `no-channel` backend prints one informational
+   row naming its `channel` and `tracking`, so the operator who chose it learns
+   that Crew's tools are absent by declaration rather than by diagnosis.
+6. **The onboarding table row.** A selectable `no-channel` backend must also be
+   named in `docs/system-specs/modules/harness-onboarding.md`, and the parity test
+   checks it. The declaration is what code reads; the onboarding table is what a
+   human reads BEFORE writing any of this, so a gap recorded in only one of the
+   two is a gap the next author misses.
 
 The folder makes a mirror easy to find and easy to copy. The test is what asks
 the question. Both are needed — a folder alone is just a tidier place to forget.
@@ -123,12 +180,16 @@ A mirror declares and routes; a helper translates.
 
 ## Current state
 
-| Backend | Mirror | Notes |
+Declared in `PROJECTIONS` (`registry.py`); this table is a reading of it, not a
+second source.
+
+| Backend | Kind | Where it goes, and what is outstanding |
 |---|---|---|
-| `claude` | `claude_code.py` | both faces; `hooks` is its one open `no-channel` |
-| `codex` | `codex.py` | wire face only — Crew writes no codex file, so the `session/new` array is its whole channel. `hooks` is its one open `no-channel`; `disabledTools` is honoured by withholding a third-party server it narrows, and by refusing the call at the approval request for Crew's own control plane; the array, the withhold set and the deny pairs all come from one spec parse |
-| `` (kiro-cli) | `NO_MIRROR` | reads the spec itself via `--agent`; only a small `cli.json` overlay, whose home is still an open decision |
-| `kas` | `NO_MIRROR`, pending | has the most complete projection of any backend, not yet moved here |
+| `` (kiro-cli) | `native` | reads the spec itself via `--agent`. Its only native-config write is the small `cli.json` overlay, whose home is a separate decision |
+| `claude` | `mirror` | `claude_code.py`, both faces; `hooks` is its one open `no-channel` disposition |
+| `codex` | `mirror` | `codex.py`, wire face only — Crew writes no codex file, so the `session/new` array is its whole channel. `hooks` is its one open `no-channel` disposition; `disabledTools` is honoured by withholding a third-party server it narrows, and by refusing the call at the approval request for Crew's own control plane; the array, the withhold set and the deny pairs all come from one spec parse |
+| `kas` | `external` | `acp/kas_agents.py` (+ `acp/kas_permissions.py`), travelling as `_meta.kiro.customAgents`. The most complete projection of any backend, down a real channel — what is outstanding is only WHERE the code sits, and the RFC schedules that as a pure relocation of its own so a live harness's projection is not moved and changed in one diff |
+| `opencode` | `no-channel` | its `initialize` advertises `http` and `sse` MCP transports and no stdio, so the array cannot carry Crew's stdio servers, and its own config file lives in the operator's checkout. The shared MCP gateway does not reach it either: a broker stub is shaped as a stdio element too, so it lands in the same array. Its sessions hold none of Crew's own tools, gateway on or off |
 
 ## Verify against the adapter, not against the last mirror
 

--- a/src/kiro_crew/providers/mirrors/__init__.py
+++ b/src/kiro_crew/providers/mirrors/__init__.py
@@ -13,15 +13,27 @@ from kiro_crew.providers.mirrors.base import (
     Ruling,
     SessionProjection,
 )
-from kiro_crew.providers.mirrors.registry import MIRRORS, NO_MIRROR, mirror_for
+from kiro_crew.providers.mirrors.registry import (
+    MIRRORS,
+    PROJECTIONS,
+    McpProjection,
+    ProjectionKind,
+    has_mirror,
+    mirror_for,
+    projection_for,
+)
 
 __all__ = [
     "MIRRORS",
-    "NO_MIRROR",
+    "PROJECTIONS",
     "AgentConfigMirror",
     "Concern",
     "Disposition",
+    "McpProjection",
+    "ProjectionKind",
     "Ruling",
     "SessionProjection",
+    "has_mirror",
     "mirror_for",
+    "projection_for",
 ]

--- a/src/kiro_crew/providers/mirrors/registry.py
+++ b/src/kiro_crew/providers/mirrors/registry.py
@@ -1,14 +1,33 @@
-"""Which backend has a mirror, and — as a first-class entry — which has none.
+"""Which backend projects the agent spec how — as a typed declaration, per backend.
 
 The point of a registry rather than a lookup that returns ``None`` on a miss is
 that **absence has to be a statement**. A backend with no entry here fails the
-parity test; a backend that genuinely needs no projection says so, with its
-reason, in :data:`NO_MIRROR`. That is the difference between "declared not to
-need one" and "nobody got round to it", which is the distinction whose absence
-let the same missing-tools defect ship twice.
+parity test; a backend that genuinely needs no projection says so, in a record a
+test can read.
+
+A free-text reason was not enough to carry that distinction. "Declared not to
+need one" and "nobody got round to it" were both spelled as a paragraph of prose
+under one name, so a selectable backend could sit there with an explanation of
+why its projection had not been written and every check stayed green. That is the
+structural reason the same missing-tools defect shipped on four harnesses in a
+row. :class:`McpProjection` replaces the paragraph with a KIND, and the kinds
+that are not finished states carry the fields that make them addressable — what
+would have to exist, and where the work is tracked.
+
+The declaration lives here rather than in :mod:`kiro_crew.agent_sdk.backends`,
+which owns the capability sets, for one mechanical reason: that module is a leaf
+that imports neither ``kiro_crew.acp`` nor ``kiro_crew.providers``, and
+``config.loader`` reaches it from inside ``KiroCrewConfig.load()``. A table
+naming this folder's mirror classes would put that cycle back. The projection
+vocabulary (:class:`~kiro_crew.providers.mirrors.base.Concern`,
+:class:`~kiro_crew.providers.mirrors.base.Disposition`) already lives in this
+folder, so the declaration that selects between them belongs beside it.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
 
 from kiro_crew.acp_backends import (
     ACP_BACKEND_CLAUDE,
@@ -21,64 +40,196 @@ from kiro_crew.providers.mirrors.base import AgentConfigMirror
 from kiro_crew.providers.mirrors.claude_code import ClaudeCodeMirror
 from kiro_crew.providers.mirrors.codex import CodexMirror
 
+
+class ProjectionKind(str, Enum):
+    """How one backend's MCP surface is reached from the agent spec.
+
+    Closed, and an enum rather than a bare ``Literal`` for the same reason
+    :class:`~kiro_crew.providers.mirrors.base.Disposition` is one: the members are
+    read by name at call sites and by value in the doc tables, and a misspelled
+    string in a declaration must fail at import rather than resolve to a kind
+    nothing handles.
+    """
+
+    #: The backend reads ``~/.kiro/agents/<name>.json`` itself. There is nothing
+    #: to project, so the spec's servers reach the session by construction.
+    NATIVE = "native"
+    #: A mirror in this folder projects it. Must have a class in :data:`MIRRORS`.
+    MIRROR = "mirror"
+    #: Crew projects it, from a module outside this folder. A real projection with
+    #: a real channel, named by ``projection`` so a reader can go and read it.
+    EXTERNAL = "external"
+    #: No transport this backend advertises can carry Crew's servers. The only
+    #: kind under which a session legitimately holds none of Crew's tools, and the
+    #: only one that has to name what would have to exist for that to change.
+    NO_CHANNEL = "no-channel"
+
+
+@dataclass(frozen=True)
+class McpProjection:
+    """One backend's declared answer to "how do Crew's MCP servers get here?".
+
+    ``reason`` is required for every kind. The two kinds that are not finished
+    states additionally have to be ADDRESSABLE, and the constructor enforces it
+    rather than a reviewer: a ``no-channel`` names the ``channel`` that would have
+    to exist and the ``tracking`` that carries the decision, and an ``external``
+    names the ``projection`` module a reader goes to. That is the whole difference
+    between this record and the prose it replaces — a paragraph can explain a gap
+    without ever giving it an address, and a gap with no address is
+    indistinguishable from a decision.
+    """
+
+    kind: ProjectionKind
+    reason: str
+    #: ``no-channel`` only: the delivery path that would carry Crew's servers.
+    channel: str = ""
+    #: ``no-channel`` and ``external`` only: issue URL or repo-relative doc anchor.
+    tracking: str = ""
+    #: ``external`` only: the dotted module path holding the projection.
+    projection: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.reason.strip():
+            raise ValueError("an McpProjection needs a reason")
+        if self.kind is ProjectionKind.NO_CHANNEL:
+            if not self.channel.strip():
+                raise ValueError(
+                    "a no-channel projection must name the channel that would carry "
+                    "Crew's servers — an unaddressed gap reads as a decision"
+                )
+            if not self.tracking.strip():
+                raise ValueError(
+                    "a no-channel projection must name its tracking issue or doc "
+                    "anchor — 'not written yet' is not a kind"
+                )
+        elif self.channel:
+            raise ValueError("channel is only meaningful for a no-channel projection")
+        if self.kind is ProjectionKind.EXTERNAL:
+            if not self.projection.strip():
+                raise ValueError("an external projection must name the module that holds it")
+            if not self.tracking.strip():
+                raise ValueError(
+                    "an external projection must name the tracking issue or doc "
+                    "anchor for folding it into providers/mirrors/"
+                )
+        elif self.projection:
+            raise ValueError("projection is only meaningful for an external projection")
+        if self.kind in (ProjectionKind.NATIVE, ProjectionKind.MIRROR) and self.tracking:
+            raise ValueError("tracking is only meaningful for a kind that is not a finished state")
+
+
 #: Backends whose spec projection lives in this folder.
 MIRRORS: dict[str, type[AgentConfigMirror]] = {
     ACP_BACKEND_CLAUDE: ClaudeCodeMirror,
     ACP_BACKEND_CODEX: CodexMirror,
 }
 
-#: Backends that deliberately have no mirror, and why. Read as a claim to be
-#: checked, not as a backlog: each of these is a decision.
-NO_MIRROR: dict[str, str] = {
-    ACP_BACKEND_KIRO: (
-        "kiro-cli is handed --agent and reads ~/.kiro/agents/<name>.json itself, so "
-        "the spec needs no projection at all. Its only native-config write is the "
-        "<work_dir>/.kiro/settings/cli.json overlay (providers/acp.py "
-        "_write_cli_overlay / _write_tool_search_overlay) carrying model, effort and "
-        "tool-search settings — a small overlay rather than a projection, which is "
-        "why folding it into this folder is a separate decision and not assumed here"
+#: Every backend this build can spell, and how its MCP surface is reached.
+#:
+#: Read as a claim to be checked, not as a backlog. The parity test holds every
+#: selectable backend to exactly one entry here, so a new harness cannot reach the
+#: dashboard switch without one of these four answers being written down.
+PROJECTIONS: dict[str, McpProjection] = {
+    ACP_BACKEND_KIRO: McpProjection(
+        kind=ProjectionKind.NATIVE,
+        reason=(
+            "kiro-cli is handed --agent and reads ~/.kiro/agents/<name>.json itself, so "
+            "the spec needs no projection at all. Its only native-config write is the "
+            "<work_dir>/.kiro/settings/cli.json overlay (providers/acp.py "
+            "_write_cli_overlay / _write_tool_search_overlay) carrying model, effort and "
+            "tool-search settings — a small overlay rather than a projection, which is "
+            "why folding it into this folder is a separate decision and not assumed here"
+        ),
     ),
-    ACP_BACKEND_KAS: (
-        "KAS has the most complete projection of any backend (acp/kas_agents.py + "
-        "acp/kas_permissions.py: prompt inlined from file://, tools always explicit, "
-        "mcpServers minus broker stubs, permissions derived from allowedTools through "
-        "KAS's own capability vocabulary) — it simply has not moved into this folder "
-        "yet. Tracked as the next PR in the mirror stack; NOT a claim that it needs "
-        "no mirror"
+    ACP_BACKEND_CLAUDE: McpProjection(
+        kind=ProjectionKind.MIRROR,
+        reason="claude_code.py — both faces: the session/new mcpServers array and "
+        "<work_dir>/.claude/settings.local.json",
     ),
-    ACP_BACKEND_OPENCODE: (
-        "opencode is offered on a public build and serves sessions today, and its "
-        "mirror is unwritten for a reason that is not scheduling: the channel a "
-        "projection would travel down does not reach Crew's own tools. Its "
-        "initialize result advertises mcpCapabilities of http and sse and no stdio, "
-        "so the session/new mcpServers array cannot carry the stdio servers a "
-        "projection would put in it, which is why opencode is outside "
-        "ACP_BACKENDS_SESSION_MCP_ARRAY. What it reads instead is its own config "
-        "file's mcp block, and writing that would mean writing into a checked-out "
-        "repository -- the thing this harness's routing seed deliberately avoids by "
-        "travelling in the child's environment. So an opencode session carries the "
-        "shared gateway's broker stubs when _pooled_mcp_servers appends them and no "
-        "Crew tools at all when that gateway is off. Writing a mirror here needs the "
-        "transport question answered "
-        "first (an http or sse broker endpoint, or a config channel that is not the "
-        "user's repo); NOT a claim that it needs no mirror"
+    ACP_BACKEND_CODEX: McpProjection(
+        kind=ProjectionKind.MIRROR,
+        reason="codex.py — the wire face alone. Crew writes no codex file, so the "
+        "session/new array is this backend's whole MCP channel",
+    ),
+    ACP_BACKEND_KAS: McpProjection(
+        kind=ProjectionKind.EXTERNAL,
+        reason=(
+            "KAS has the most complete projection of any backend — prompt inlined from "
+            "file://, tools always explicit, mcpServers minus broker stubs, permissions "
+            "derived from allowedTools through KAS's own capability vocabulary — and it "
+            "travels as _meta.kiro.customAgents on session/new rather than as an "
+            "mcpServers array. A real projection down a real channel, so this is not a "
+            "gap: what is outstanding is only WHERE the code sits, and the RFC schedules "
+            "that as a pure relocation of its own so a live harness's projection is not "
+            "moved and changed in one diff"
+        ),
+        projection="kiro_crew.acp.kas_agents",
+        tracking="docs/request-for-change/rfc-agent-config-mirror.md#5-migration",
+    ),
+    ACP_BACKEND_OPENCODE: McpProjection(
+        kind=ProjectionKind.NO_CHANNEL,
+        reason=(
+            "opencode's initialize result advertises mcpCapabilities of http and sse and "
+            "no stdio, so the session/new mcpServers array cannot carry the stdio servers "
+            "a projection would put in it — which is why it is outside "
+            "ACP_BACKENDS_SESSION_MCP_ARRAY. What it reads instead is its own config "
+            "file's mcp block, and writing that would mean writing into a checked-out "
+            "repository, the thing this harness's routing seed deliberately avoids by "
+            "travelling in the child's environment. The shared MCP gateway does not "
+            "reach it either: _pooled_mcp_servers does append broker stubs for a "
+            "backend outside MIRRORS, but a stub is shaped as a stdio element too "
+            "(mcp_gateway.session_servers._acp_server_entry emits command/args/env), so "
+            "it lands in the very array this harness advertises no transport for. An "
+            "opencode session therefore holds none of Crew's own tools, gateway on or "
+            "off"
+        ),
+        channel=(
+            "an http or sse MCP endpoint the shared gateway serves, addressable from the "
+            "session/new array this harness does accept — or a config channel Crew owns "
+            "that is not the operator's checkout"
+        ),
+        tracking="docs/request-for-change/rfc-agent-config-mirror.md#5-migration",
     ),
 }
 
 
-def mirror_for(backend: str) -> AgentConfigMirror | None:
-    """The mirror for *backend*, or ``None`` when it declares it needs none.
+def projection_for(backend: str) -> McpProjection:
+    """*backend*'s declared MCP projection.
 
-    Raises for a backend that is in neither map: an unregistered backend is the
-    failure this module exists to catch, so it is loud rather than silently
-    mirror-less.
+    Raises for a backend with no entry: an undeclared backend is the failure this
+    module exists to catch, so it is loud rather than silently projection-less.
+    """
+    declared = PROJECTIONS.get(backend)
+    if declared is None:
+        raise KeyError(
+            f"backend {backend!r} has no agent-config mirror and no PROJECTIONS entry — "
+            "add one of the two; see providers/mirrors/README.md"
+        )
+    return declared
+
+
+def has_mirror(backend: str) -> bool:
+    """Does *backend*'s projection live in THIS folder?
+
+    The one bit of provenance a caller cannot recover from a projected array
+    alone: "no mirror registered" and "a mirror that dropped this server" are
+    different problems with different remedies, and so is "a projection that
+    lives elsewhere". False rather than raising for an unknown backend, because
+    the callers are diagnostics.
+    """
+    return backend in MIRRORS
+
+
+def mirror_for(backend: str) -> AgentConfigMirror | None:
+    """The mirror for *backend*, or ``None`` when its projection is not in this folder.
+
+    Raises for a backend that is in neither table: see :func:`projection_for`.
+    ``None`` covers all three of the other kinds, and a caller that needs to tell
+    them apart asks :func:`projection_for` — which is the whole reason the kind is
+    typed rather than inferred from this returning ``None``.
     """
     cls = MIRRORS.get(backend)
     if cls is not None:
         return cls()
-    if backend in NO_MIRROR:
-        return None
-    raise KeyError(
-        f"backend {backend!r} has no agent-config mirror and no NO_MIRROR entry — "
-        "add one of the two; see providers/mirrors/README.md"
-    )
+    projection_for(backend)
+    return None

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -525,6 +525,94 @@ class TestUnresolvedMcpRefs:
         assert capsys.readouterr().out == ""
 
 
+class TestSelectedBackendProjectionRow:
+    """The row for a harness whose transport carries none of Crew's own tools.
+
+    Distinct from the unresolved-refs row above, and the difference is what the
+    row is for: refs are read off the default spec, so a spec that references no
+    server produces no row at all -- while a ``no-channel`` harness has no
+    transport for Crew's servers whatever any spec says. That is a property of the
+    harness, and the operator who selected it gets told once.
+    """
+
+    def _cfg(self, backend: str):
+        return SimpleNamespace(agent=SimpleNamespace(acp_backend=backend))
+
+    def test_the_selected_no_channel_backend_gets_a_row_with_its_channel(self, capsys):
+        """Reads the shipped declaration, not a stub.
+
+        A stub would pass on a build where opencode's own entry has drifted back
+        to claiming a projection it does not have, which is the drift the typed
+        record exists to make visible.
+        """
+        cli_doctor._doctor_selected_backend_projection(self._cfg("opencode"))
+        out = capsys.readouterr().out
+        assert "opencode" in out
+        assert "none of Kiro Crew's own tools" in out
+        assert "Would need:" in out
+        assert "Tracked at:" in out
+
+    def test_a_backend_that_does_receive_its_servers_prints_nothing(self, capsys):
+        """Silence is the whole point on a stock install.
+
+        kiro-cli reads the spec itself, so a row there would be a permanent note
+        about a state that is correct -- and a report that talks on every install
+        is one people stop reading.
+        """
+        cli_doctor._doctor_selected_backend_projection(self._cfg(""))
+        assert capsys.readouterr().out == ""
+
+    def test_an_undeclared_backend_is_silent_rather_than_wrong(self, capsys):
+        """The parity test refuses this state; the report must not guess at it."""
+        cli_doctor._doctor_selected_backend_projection(self._cfg("a-backend-nobody-declared"))
+        assert capsys.readouterr().out == ""
+
+    def test_a_declaration_carrying_terminal_controls_is_rendered_inert(self, monkeypatch, capsys):
+        """An edition plugin authors its own declaration, so the text is scrubbed.
+
+        Same rule as the refs row: anything a party other than this file wrote
+        goes through ``_safe_display`` before reaching a terminal.
+        """
+        from kiro_crew.agent_sdk.drivers import acp as acp_driver
+
+        monkeypatch.setattr(
+            acp_driver,
+            "backend_mcp_projection",
+            lambda _b: ("no-channel", "http\x1b]0;pwned\x07", "tracked"),
+        )
+        cli_doctor._doctor_selected_backend_projection(self._cfg("opencode"))
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "http" in out
+
+    def test_the_row_never_moves_doctors_exit_code(self):
+        """It takes no ``issues`` list, so it structurally cannot append one.
+
+        Choosing a harness whose transport cannot carry Crew's tools is a
+        supported configuration with a declared reason, so it must not make
+        ``kirocrew doctor`` exit 1.
+        """
+        import inspect
+
+        params = list(inspect.signature(cli_doctor._doctor_selected_backend_projection).parameters)
+        assert params == ["cfg"]
+
+    def test_the_row_is_reached_from_the_report_itself(self):
+        """The check runs, rather than merely existing for its own tests to call."""
+        import inspect
+
+        assert "_doctor_selected_backend_projection(cfg)" in inspect.getsource(cli_doctor._doctor)
+
+    def test_an_unreadable_config_does_not_break_triage(self, capsys):
+        class _Boom:
+            @property
+            def agent(self):
+                raise RuntimeError("config unreadable")
+
+        cli_doctor._doctor_selected_backend_projection(_Boom())  # must not raise
+        assert capsys.readouterr().out == ""
+
+
 class TestSwapTotalProbe:
     """``SwapTotal`` parsed from /proc/meminfo → KiB, or None when unreadable."""
 

--- a/test/test_provider_mirrors.py
+++ b/test/test_provider_mirrors.py
@@ -11,52 +11,246 @@ Design: ``docs/request-for-change/rfc-agent-config-mirror.md``.
 
 from __future__ import annotations
 
+import importlib
+import re
+from pathlib import Path
+
 import pytest
 
-from kiro_crew.acp_backends import ACP_BACKENDS_KNOWN
+from kiro_crew.acp_backends import (
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_OPENCODE,
+    ACP_BACKENDS_KNOWN,
+)
+from kiro_crew.agent_sdk.backends import BASELINE_SELECTABLE_BACKENDS
+from kiro_crew.agent_sdk.mcp_refs import unresolved_server_refs
 from kiro_crew.providers.mirrors import (
     MIRRORS,
-    NO_MIRROR,
+    PROJECTIONS,
     Concern,
     Disposition,
+    McpProjection,
+    ProjectionKind,
     Ruling,
+    has_mirror,
     mirror_for,
+    projection_for,
 )
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Where a selectable harness's admission is recorded. A ``no-channel`` backend
+#: must be named there as well as here: the declaration says what the transport
+#: cannot carry, and the onboarding table is what a human reads BEFORE writing any
+#: of it, so a gap recorded in only one of the two is a gap the next author misses.
+_ONBOARDING_DOC = Path("docs/system-specs/modules/harness-onboarding.md")
+
+#: Prose that stands in for a decision. A kind is the decision now, so a reason
+#: carrying one of these is a schedule wearing a declaration's clothes -- the exact
+#: state that let a selectable backend ship with no projection and every check
+#: green.
+_SCHEDULE_PROSE: tuple[str, ...] = (
+    "pending",
+    "not yet moved",
+    "has not moved",
+    "unwritten",
+    "not written yet",
+    "nobody got round",
+    "next pr",
+    "coming soon",
+    "todo",
+)
+
+#: Kinds that describe a finished state. The other two are addressable on purpose
+#: (``channel`` / ``projection`` plus ``tracking``), so only these two are held to
+#: carrying no schedule at all.
+_SETTLED_KINDS = (ProjectionKind.NATIVE, ProjectionKind.MIRROR)
+
+
+def _slugify_heading(line: str) -> str:
+    """A markdown heading's GitHub anchor, near enough for a link check."""
+    text = line.lstrip("#").strip().lower()
+    text = re.sub(r"[^a-z0-9 \-]", "", text)
+    return re.sub(r"\s+", "-", text).strip("-")
+
+
+def _tracking_resolves(tracking: str) -> bool:
+    """Does *tracking* address something a reader can actually reach?
+
+    An https URL is taken at its word -- a test must not make a network call to
+    decide whether a declaration is well formed. A repo-relative ``path#anchor``
+    is checked properly, because that is the form a doc reorganisation silently
+    breaks, and a tracking pointer that resolves to nothing is the prose this
+    record replaced with extra steps.
+    """
+    if tracking.startswith("https://"):
+        return True
+    path, _, anchor = tracking.partition("#")
+    doc = _REPO_ROOT / path
+    if not doc.is_file():
+        return False
+    if not anchor:
+        return True
+    headings = [
+        _slugify_heading(line)
+        for line in doc.read_text(encoding="utf-8").splitlines()
+        if line.startswith("#")
+    ]
+    return anchor.lower() in headings
+
+
+#: A spec that references one server and defines it. Fed to the ref resolver to
+#: ask the only question that distinguishes a `native` backend structurally: is
+#: this an id whose refs are satisfied by the spec's OWN mcpServers, because the
+#: harness reads that file itself? Every other kind is judged against the wire
+#: array, so the same spec leaves the ref unresolved there.
+_NATIVE_PROBE_SPEC = {"tools": ["@probesrv"], "mcpServers": {"probesrv": {}}}
+
+
+def _resolver_reads_the_spec_itself(backend: str) -> bool:
+    """Does the ref resolver credit *backend* with the spec's own servers?
+
+    This is what makes `native` checkable by something other than a list of
+    forbidden words. `native` claims the harness reads
+    ``~/.kiro/agents/<name>.json`` itself, and exactly one other module already
+    has to know that:
+    ``agent_sdk.mcp_refs`` satisfies a ``@server`` ref from the spec's own
+    definitions for such a backend and from the wire array for every other. So a
+    declaration claiming `native` is cross-checked against the resolver that acts
+    on the claim, in a different package, rather than against how its prose is
+    worded.
+    """
+    return unresolved_server_refs(_NATIVE_PROBE_SPEC, [], backend=backend) == []
+
+
+def projection_complaints(
+    *,
+    projections: dict,
+    mirrors: dict,
+    known: frozenset,
+    selectable: frozenset,
+    onboarding: str,
+) -> list[str]:
+    """Every way a set of declarations fails the contract, as one list.
+
+    A function over its inputs rather than a test reading the module's globals,
+    for one reason: the rules have to be provable in BOTH directions. A suite that
+    only asserts the shipped tables pass cannot show that a prose-only entry on a
+    selectable backend would fail -- and "the guard would have caught it" is the
+    claim this whole file exists to make good on. The negative case feeds doctored
+    tables through this same function, so the rule under test is the rule that
+    ships.
+    """
+    complaints: list[str] = []
+
+    for backend in sorted(known | selectable):
+        declared = projections.get(backend)
+        if declared is None:
+            complaints.append(f"{backend!r}: no PROJECTIONS entry")
+            continue
+        in_mirrors = backend in mirrors
+        if declared.kind is ProjectionKind.MIRROR and not in_mirrors:
+            complaints.append(f"{backend!r}: declares kind=mirror with no MIRRORS class")
+        if in_mirrors and declared.kind is not ProjectionKind.MIRROR:
+            complaints.append(
+                f"{backend!r}: has a MIRRORS class but declares kind={declared.kind.value}"
+            )
+        if (declared.kind is ProjectionKind.NATIVE) != _resolver_reads_the_spec_itself(backend):
+            claimed = "claims native" if declared.kind is ProjectionKind.NATIVE else "does not"
+            complaints.append(
+                f"{backend!r}: {claimed} claim native, but agent_sdk.mcp_refs "
+                "disagrees about whether this backend resolves refs from the spec "
+                "itself -- the kind and the resolver acting on it must not diverge"
+            )
+        if declared.kind in _SETTLED_KINDS:
+            hit = [p for p in _SCHEDULE_PROSE if p in declared.reason.lower()]
+            if hit:
+                complaints.append(
+                    f"{backend!r}: kind={declared.kind.value} reason reads as a "
+                    f"schedule ({', '.join(hit)}) -- an unfinished projection has "
+                    "its own kind"
+                )
+        if declared.tracking and not _tracking_resolves(declared.tracking):
+            complaints.append(f"{backend!r}: tracking {declared.tracking!r} resolves to nothing")
+        if declared.kind is ProjectionKind.EXTERNAL:
+            try:
+                importlib.import_module(declared.projection)
+            except Exception as exc:
+                complaints.append(
+                    f"{backend!r}: external projection {declared.projection!r} "
+                    f"does not import ({exc})"
+                )
+        if declared.kind is ProjectionKind.NO_CHANNEL and backend in selectable:
+            if backend not in onboarding:
+                complaints.append(
+                    f"{backend!r}: selectable and no-channel, but "
+                    f"{_ONBOARDING_DOC} does not name it"
+                )
+    return complaints
+
+
+def _onboarding_text() -> str:
+    return (_REPO_ROOT / _ONBOARDING_DOC).read_text(encoding="utf-8")
 
 
 class TestEveryBackendIsAccountedFor:
-    def test_every_known_backend_has_a_mirror_or_a_stated_reason(self):
+    def test_every_known_and_selectable_backend_resolves_to_one_declaration(self):
         """The whole point: absence must be a statement, not an oversight.
 
-        A backend in neither map is the shape of the original defect -- nobody
-        declared it needed a projection, so nobody wrote one, and the session came
-        up missing its tools with no error.
+        A backend with no declaration is the shape of the original defect --
+        nobody said it needed a projection, so nobody wrote one, and the session
+        came up missing its tools with no error. Selectable ids are checked
+        alongside the known ones rather than assumed to be a subset: an edition
+        plugin registers its own, and the one that reaches the dashboard switch
+        without an entry here is exactly the one this rule is for.
         """
-        unaccounted = sorted(
-            b for b in ACP_BACKENDS_KNOWN if b not in MIRRORS and b not in NO_MIRROR
+        complaints = projection_complaints(
+            projections=PROJECTIONS,
+            mirrors=MIRRORS,
+            known=ACP_BACKENDS_KNOWN,
+            selectable=BASELINE_SELECTABLE_BACKENDS,
+            onboarding=_onboarding_text(),
         )
-        assert not unaccounted, (
-            f"backends with no mirror and no NO_MIRROR entry: {unaccounted}. "
-            "Add a mirror in providers/mirrors/ or a NO_MIRROR entry with the reason."
-        )
+        assert not complaints, "\n".join(complaints)
 
-    def test_no_backend_is_in_both_maps(self):
-        assert not (set(MIRRORS) & set(NO_MIRROR))
+    def test_every_declaration_states_a_real_reason(self):
+        for backend, declared in PROJECTIONS.items():
+            assert (
+                len(declared.reason.strip()) > 40
+            ), f"{backend!r} needs a real reason, not a label"
 
-    def test_every_no_mirror_entry_states_a_real_reason(self):
-        for backend, reason in NO_MIRROR.items():
-            assert len(reason.strip()) > 40, f"{backend!r} needs a real reason, not a label"
-
-    def test_an_unregistered_backend_raises_rather_than_returning_none(self):
+    def test_an_undeclared_backend_raises_rather_than_returning_none(self):
         """Fail loud. Returning None would read as 'declared to need no mirror'."""
         with pytest.raises(KeyError, match="no agent-config mirror"):
             mirror_for("a-backend-nobody-registered")
+        with pytest.raises(KeyError, match="no agent-config mirror"):
+            projection_for("a-backend-nobody-registered")
 
-    def test_mirror_for_returns_none_only_for_a_declared_no_mirror(self):
-        for backend in NO_MIRROR:
-            assert mirror_for(backend) is None
-        for backend in MIRRORS:
-            assert mirror_for(backend) is not None
+    def test_mirror_for_returns_none_for_every_kind_but_mirror(self):
+        for backend, declared in PROJECTIONS.items():
+            expected_mirror = declared.kind is ProjectionKind.MIRROR
+            assert (mirror_for(backend) is not None) is expected_mirror
+            assert has_mirror(backend) is expected_mirror
+
+    def test_kas_is_declared_external_rather_than_carrying_a_schedule(self):
+        """KAS is the entry the prose form got wrong, so it is pinned by name.
+
+        Its projection is real and complete and travels as
+        ``_meta.kiro.customAgents``; what is outstanding is only which folder the
+        code sits in. ``external`` says that and names the module, so the reader
+        who wants the projection can go and read it -- where the prose form said
+        "not moved here yet", which a test cannot tell apart from "not written".
+        """
+        declared = projection_for(ACP_BACKEND_KAS)
+        assert declared.kind is ProjectionKind.EXTERNAL
+        assert declared.projection == "kiro_crew.acp.kas_agents"
+        assert declared.tracking
+
+    def test_the_one_no_channel_backend_names_what_would_have_to_exist(self):
+        declared = projection_for(ACP_BACKEND_OPENCODE)
+        assert declared.kind is ProjectionKind.NO_CHANNEL
+        assert declared.channel.strip()
+        assert declared.tracking.strip()
 
 
 class TestRulingsAreComplete:
@@ -199,3 +393,189 @@ class TestClaudeCodeMirror:
         ruling = mirror_for("claude").rulings()[Concern.MCP_SERVERS]
         assert ruling.disposition is Disposition.DELIVERED
         assert "settings.local.json" in ruling.reason
+
+
+class TestAProseOnlyDeclarationFailsTheParityTest:
+    """The negative half, and the reason the rules are a function of their inputs.
+
+    Every assertion above says the shipped tables pass. None of them shows that
+    the tables COULD fail, and a guard nobody has watched fail is a guard nobody
+    knows the shape of. These feed a fake selectable backend through the same
+    checker the real test uses.
+    """
+
+    def _tables(self, declared: McpProjection) -> dict:
+        return dict(
+            projections={**PROJECTIONS, "fakebackend": declared},
+            mirrors=MIRRORS,
+            known=frozenset(ACP_BACKENDS_KNOWN | {"fakebackend"}),
+            selectable=frozenset(BASELINE_SELECTABLE_BACKENDS | {"fakebackend"}),
+            onboarding=_onboarding_text(),
+        )
+
+    def test_a_selectable_backend_with_no_declaration_at_all_fails(self):
+        complaints = projection_complaints(
+            projections=PROJECTIONS,
+            mirrors=MIRRORS,
+            known=frozenset(ACP_BACKENDS_KNOWN | {"fakebackend"}),
+            selectable=frozenset(BASELINE_SELECTABLE_BACKENDS | {"fakebackend"}),
+            onboarding=_onboarding_text(),
+        )
+        assert any("no PROJECTIONS entry" in c for c in complaints)
+
+    def test_a_settled_kind_carrying_a_schedule_fails(self):
+        """The exact entry the prose form allowed: a paragraph instead of a kind.
+
+        A backend claiming it needs no projection while its own reason explains
+        that the projection is pending is the state that shipped four times. It
+        parses, it reads plausibly, and nothing could fail on it.
+        """
+        complaints = projection_complaints(
+            **self._tables(
+                McpProjection(
+                    kind=ProjectionKind.NATIVE,
+                    reason=(
+                        "this harness has the most complete projection of any backend, "
+                        "it simply has not moved into this folder yet -- tracked as the "
+                        "next PR in the mirror stack"
+                    ),
+                )
+            )
+        )
+        assert any("reads as a schedule" in c for c in complaints)
+
+    def test_a_native_claim_the_ref_resolver_does_not_credit_fails(self):
+        """The one kind a list of forbidden words could not keep honest.
+
+        `mirror` needs a registered class, `external` needs an importable module,
+        `no-channel` needs a channel and an onboarding row -- each is checked
+        against something outside the declaration. `native` is checked against
+        ``agent_sdk.mcp_refs``, which has to know the same fact to resolve a ref at
+        all, so a backend declared `native` that the resolver judges against the
+        wire array is a divergence rather than a wording choice.
+        """
+        complaints = projection_complaints(
+            **self._tables(
+                McpProjection(
+                    kind=ProjectionKind.NATIVE,
+                    reason="this harness is handed the agent spec and reads it itself",
+                )
+            )
+        )
+        assert any("agent_sdk.mcp_refs disagrees" in c for c in complaints)
+
+    def test_a_no_channel_backend_absent_from_the_onboarding_table_fails(self):
+        complaints = projection_complaints(
+            **self._tables(
+                McpProjection(
+                    kind=ProjectionKind.NO_CHANNEL,
+                    reason="its initialize advertises no transport the array can use",
+                    channel="an http endpoint the shared gateway serves",
+                    tracking="docs/request-for-change/rfc-agent-config-mirror.md#5-migration",
+                )
+            )
+        )
+        assert any("does not name it" in c for c in complaints)
+
+    def test_a_tracking_pointer_that_resolves_to_nothing_fails(self):
+        complaints = projection_complaints(
+            **self._tables(
+                McpProjection(
+                    kind=ProjectionKind.EXTERNAL,
+                    reason="its projection lives beside the transport that carries it",
+                    projection="kiro_crew.acp.kas_agents",
+                    tracking="docs/request-for-change/rfc-agent-config-mirror.md#no-such-heading",
+                )
+            )
+        )
+        assert any("resolves to nothing" in c for c in complaints)
+
+    def test_an_external_projection_naming_no_module_fails(self):
+        complaints = projection_complaints(
+            **self._tables(
+                McpProjection(
+                    kind=ProjectionKind.EXTERNAL,
+                    reason="its projection lives beside the transport that carries it",
+                    projection="kiro_crew.acp.no_such_module",
+                    tracking="docs/request-for-change/rfc-agent-config-mirror.md#5-migration",
+                )
+            )
+        )
+        assert any("does not import" in c for c in complaints)
+
+    def test_a_mirror_kind_with_no_registered_class_fails(self):
+        complaints = projection_complaints(
+            **self._tables(
+                McpProjection(
+                    kind=ProjectionKind.MIRROR,
+                    reason="a mirror class in this folder projects the spec for it",
+                )
+            )
+        )
+        assert any("no MIRRORS class" in c for c in complaints)
+
+
+class TestMcpProjectionRejectsAnIncoherentClaim:
+    def test_a_reason_is_required(self):
+        with pytest.raises(ValueError, match="needs a reason"):
+            McpProjection(kind=ProjectionKind.NATIVE, reason="  ")
+
+    def test_no_channel_without_a_channel_is_refused(self):
+        with pytest.raises(ValueError, match="must name the channel"):
+            McpProjection(
+                kind=ProjectionKind.NO_CHANNEL,
+                reason="its transports cannot carry a stdio server",
+                tracking="https://example.invalid/1",
+            )
+
+    def test_no_channel_without_tracking_is_refused(self):
+        with pytest.raises(ValueError, match="not a kind"):
+            McpProjection(
+                kind=ProjectionKind.NO_CHANNEL,
+                reason="its transports cannot carry a stdio server",
+                channel="an http endpoint the gateway serves",
+            )
+
+    def test_external_without_a_module_is_refused(self):
+        with pytest.raises(ValueError, match="must name the module"):
+            McpProjection(
+                kind=ProjectionKind.EXTERNAL,
+                reason="the projection lives beside its transport",
+                tracking="https://example.invalid/1",
+            )
+
+    def test_a_channel_on_a_settled_kind_is_refused(self):
+        """A channel on a native declaration would read as a gap that is not one."""
+        with pytest.raises(ValueError, match="only meaningful for a no-channel"):
+            McpProjection(
+                kind=ProjectionKind.NATIVE,
+                reason="it reads the spec itself",
+                channel="somewhere",
+            )
+
+    def test_tracking_on_a_settled_kind_is_refused(self):
+        """A finished state has nothing outstanding, so it has nothing to track."""
+        with pytest.raises(ValueError, match="not a finished state"):
+            McpProjection(
+                kind=ProjectionKind.MIRROR,
+                reason="a mirror in this folder projects it",
+                tracking="https://example.invalid/1",
+            )
+
+
+class TestAMirrorMustActuallyDeliverItsServers:
+    @pytest.mark.parametrize("backend", sorted(MIRRORS))
+    def test_mcp_servers_is_delivered_or_translated_never_a_gap(self, backend):
+        """``kind=mirror`` is a claim about the servers, so the ruling must agree.
+
+        A mirror whose own ``mcpServers`` ruling is ``no-channel`` or ``withheld``
+        describes a backend that gets none of Crew's tools -- the very state
+        ``no-channel`` is the kind FOR. Allowing the two to disagree would let a
+        registered mirror stand in for the declaration that says so, which is the
+        prose problem again one level down.
+        """
+        ruling = mirror_for(backend).rulings()[Concern.MCP_SERVERS]
+        assert ruling.disposition in (
+            Disposition.DELIVERED,
+            Disposition.TRANSLATED,
+        ), f"{backend!r} is registered as a mirror but rules mcpServers {ruling.disposition.value}"


### PR DESCRIPTION
## Problem / Motivation

`providers/mirrors/registry.py` had one name, `NO_MIRROR`, holding two claims that are not the same claim:

- "this backend needs no projection" — a decision (kiro-cli reads the agent spec itself);
- "the projection has not been written" — a backlog item.

Both were spelled as a paragraph of prose under the same key, so a backend in `BASELINE_SELECTABLE_BACKENDS` could sit there with a well-written account of *when* its projection would arrive and the parity test would pass. KAS sat there as "pending", codex sat there until its mirror landed, and opencode sits there now.

That is the structural reason the same defect shipped four times: a session comes up holding `tools: ["@kirocrew-core", ...]` with nothing defining `kirocrew-core`, so every Crew tool is absent while the harness works and nothing anywhere is red. KAS, claude-agent-acp, codex, and then opencode in #10006 — each diagnosed from scratch.

## Why it matters

A selectable backend is one an operator can choose from the dashboard switch. Choosing one whose transport cannot carry Crew's tools is a legitimate configuration; discovering it by diagnosis is not. The runtime detector (#10000) and the mirrors folder both address the *fix*; nothing held a new backend to *deciding*, and prose is not a decision a test can read.

## What changed (motivation → approach → change)

**Goal:** a new selectable backend cannot ship without its MCP projection being a decided, addressable state.

**Approach — replace the prose with a kind.** `PROJECTIONS: dict[str, McpProjection]` declares one record per backend id, and the two kinds that are not finished states are required to be *addressable* by the constructor rather than by a reviewer:

| Kind | Means | Required beyond `reason` | Cross-checked against | Today |
|---|---|---|---|---|
| `native` | the backend reads `~/.kiro/agents/<name>.json` itself | — | `agent_sdk/mcp_refs.py` resolves its refs against the spec's own `mcpServers` | `` (kiro-cli) |
| `mirror` | a mirror in this folder projects it | — | a registered `MIRRORS` class **and** an `mcpServers` ruling of `delivered`/`translated` | `claude`, `codex` |
| `external` | Crew projects it, from a module outside this folder | `projection` (dotted module), `tracking` | the module imports | `kas` |
| `no-channel` | no transport the backend advertises can carry Crew's servers | `channel` (what would have to exist), `tracking` | a resolvable tracking pointer + a row in `harness-onboarding.md` | `opencode` |

`channel` already played exactly this role on a `no-channel` *disposition*; the kind lifts it one level up, so it also covers the case where **no** concern reaches the backend at all.

**Every kind is cross-checked against something outside its own text**, so no kind's honesty rests on how its `reason` is worded. `native` was the last one without such a check, and the check it gets is not a new capability set but the module that already has to know the same fact: `agent_sdk/mcp_refs.py` satisfies a `@server` ref from the spec's own `mcpServers` for a spec-reading backend and from the wire array for every other. A declaration and the resolver acting on it may not diverge, in either direction. The schedule-prose rule (`pending`, `not yet moved`, `unwritten` rejected on a settled kind) is a second line, not the only one.

**Where it lives, and why.** Beside `MIRRORS` in `providers/mirrors/registry.py`, not in `agent_sdk/backends.py`. `backends.py` owns the capability sets, but its own docstring makes its leaf property load-bearing: it imports neither `kiro_crew.acp` nor `kiro_crew.providers`, and `config.loader` reaches it from inside `KiroCrewConfig.load()`. A table naming this folder's mirror classes would put that cycle back. The projection vocabulary (`Concern`, `Disposition`, `Ruling`) already lives in this folder, so the declaration that selects between them belongs beside it.

**KAS is `external`, and that is the one design call worth arguing with.** Its projection is real, complete and travels down a real channel (`_meta.kiro.customAgents`, from `acp/kas_agents.py` + `acp/kas_permissions.py`) — so it is not `no-channel`, and calling it `native` would be false, since Crew does the projecting. What is outstanding is only *where the code sits*. I did not register a thin delegating `KasMirror`, for two reasons:

1. `rfc-agent-config-mirror.md` §5 already schedules that as PR 3, deliberately as a *pure relocation*, so a live harness's projection is not moved and changed in one diff.
2. It would not work without a contract change this PR should not make. `agent_spec_mcp_refs` reads a mirror's `mcpServers` **array**; KAS's channel is not an array, so a `KasMirror` whose wire face is honest would make `kirocrew doctor` report every KAS ref as unresolved *with* `has_mirror=True` — i.e. "this mirror dropped your servers", which is false. Folding KAS to `mirror` needs the detector to ask a mirror for the server names its projection delivers. That method belongs with the relocation; §5's PR 3 row now says so.

`external` keeps that honest in the meantime and, unlike the string it replaces, is checkable: the module must import, and the tracking pointer must resolve.

**opencode's declaration states that the shared MCP gateway does not rescue it.** `_pooled_mcp_servers` does append broker stubs for a backend outside `MIRRORS`, so it is tempting to read an opencode session as tool-bearing whenever the gateway is on. It is not: a stub is shaped as a stdio element too (`mcp_gateway/session_servers.py::_acp_server_entry` emits `command`/`args`/`env`), so it lands in the very array this harness advertises no transport for. The declaration, the README row and the doctor row all say so, in the same terms.

**Doctor** gains one informational row, for the *selected* backend only and only when its kind is `no-channel`. It is deliberately a different question from the unresolved-refs row above it: refs are read off the default spec, so a spec referencing no server produces no row, while a `no-channel` harness has no transport whatever any spec says. It appends nothing to `issues`, on the terms `_doctor_strict_identity` and `_doctor_unresolved_mcp_refs` both set — a supported configuration with a declared reason must not make a stock host exit 1. It reaches the declaration through `agent_sdk.drivers.acp.backend_mcp_projection`, which projects `(kind, channel, tracking)` and deliberately not `reason`: the reason is written at registry length for the reader of the registry, and a field nothing renders is one the next caller has to decide whether to trust. Plain strings only, so `cli_doctor` takes no new boundary edge.

**No live session path is touched.** `mirror_for()` behaviour is unchanged for every caller, and `MIRRORS` membership — the thing `AcpClient._pooled_mcp_servers` reads — has the same two members as before.

### Interaction with #10006 (merge-order independence)

#10006 merged at 2026-09-11 22:58Z and this branch is cut from a `main` that contains it, so the ordering is settled rather than assumed. The design is order-independent regardless, and here is why, concretely:

- #10006's contribution to this file is opencode's `NO_MIRROR` entry, which is a *well-formed no-channel declaration*: its reason cites what the harness advertised (`mcpCapabilities` of `http`/`sse`, no stdio) rather than a schedule. This PR translates that same reasoning into `kind=ProjectionKind.NO_CHANNEL` and adds the two fields it was missing (`channel`, `tracking`). Nothing in it is discarded.
- Had it landed after, the conflict would have been one entry in one dict, and the parity rule would have named exactly what the new entry owed: a kind, a channel and a tracking pointer.
- Its onboarding-doc row (`Worked example: the OpenCode harness`) is what parity rule (b) reads, so its documentation is load-bearing for this guard rather than incidental to it.

## Tests

`test/test_provider_mirrors.py`. The rules are a function of their inputs (`projection_complaints`) precisely so they can be proven in **both** directions — a guard nobody has watched fail is a guard nobody knows the shape of.

Positive, over the shipped tables:

- every id in `ACP_BACKENDS_KNOWN` **and** `BASELINE_SELECTABLE_BACKENDS` resolves to exactly one declaration (selectable is checked alongside known rather than assumed a subset — an edition plugin registers its own);
- `kind=mirror` iff a `MIRRORS` class exists, in both directions;
- `kind=native` iff `agent_sdk.mcp_refs` resolves that backend's refs against the spec itself, in both directions;
- a `mirror` backend's `rulings()[Concern.MCP_SERVERS]` is `delivered` or `translated`, never `no-channel`/`withheld`;
- `tracking` resolves (https taken at its word; a `path#anchor` checked against the real headings);
- an `external` `projection` module imports;
- a selectable `no-channel` backend is named in `harness-onboarding.md`;
- KAS is pinned as `external` naming `kiro_crew.acp.kas_agents`; opencode as `no-channel` with both fields.

Negative, feeding a fake selectable backend through the same checker:

- no declaration at all → fails;
- **a `native` declaration whose reason reads as a schedule → fails** (this is the entry the prose form allowed: it parses, it reads plausibly, nothing could fail on it);
- **a `native` claim the ref resolver does not credit → fails** (the check that keeps the one kind a word blacklist could not);
- `no-channel` absent from the onboarding table → fails;
- a `tracking` anchor that resolves to nothing → fails;
- an `external` `projection` naming no module → fails;
- `kind=mirror` with no registered class → fails.

Constructor: reason required; `no-channel` without a channel, or without tracking; `external` without a module; a channel or a tracking pointer on a settled kind — each refused.

`test/test_cli_doctor.py::TestSelectedBackendProjectionRow`: the selected `no-channel` backend gets a row naming its channel and tracking (read off the *shipped* declaration, not a stub, so drift is visible); a backend that does receive its servers prints nothing; an undeclared backend is silent rather than wrong; a declaration carrying OSC/ANSI is rendered inert; the row takes no `issues` list; the row is reached from `_doctor` itself; an unreadable config does not break triage.

## Manual verification

The `native` cross-check was revert-verified rather than assumed: flipping kiro's declaration from `native` to `external` makes `test_every_known_and_selectable_backend_resolves_to_one_declaration` fail naming the resolver divergence, and restoring it makes it pass. Otherwise N/A — the doctor row is exercised through `capsys` against the real declaration, and no path outside these two modules changes behaviour.

## Related Issues

Builds on #9987 (the mirrors folder) and #10000 (the runtime `@server`-ref detector), and closes the hole #10006 walked into. No linked issue: this is the guard those three PRs each individually left open, filed as the change rather than as a ticket. Vocabulary change recorded in `docs/request-for-change/rfc-agent-config-mirror.md` §3.8.

## Known gaps

- `rfc-crew-agent-sdk-boundary.md` still names `NO_MIRROR` in four places as part of a dated audit snapshot (`audited-at` front-matter). Not corrected here: that document records a state at a commit, and rewriting another RFC's audit narrative is a separate change. `docs-lint` passes.
- KAS stays `external` until §5's PR 3, which needs the mirror contract's "server names this projection delivers" method. Named above.
- The `no-channel` doctor row is per *selected* backend. Reporting it for every selectable one was considered and rejected: `_doctor_unresolved_mcp_refs` already iterates them, and a second row per harness on every stock host is how a useful note becomes one people disable.

## Checklist

- [x] At most two commits (one), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (mirrors `README.md`, RFC §3.8 + §5, `harness-onboarding.md` Stage 7)
- [x] No secrets, credentials, or internal references in the diff
