### PR TITLE
fix(governance): honour third-tier ScopedMap member narrowing (#9430)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -1867,8 +1867,8 @@ def _serialize_ruleset(value: object) -> dict:
         return {
             "mode": "intersect",
             "components": [
-                _serialize_ruleset(value.ceiling),
-                _serialize_ruleset(value.profile),
+                _serialize_ruleset(value.outer),
+                _serialize_ruleset(value.inner),
             ],
         }
     return {}

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -917,20 +917,30 @@ class _AndRuleset:
     """The AND of two rulesets; ``permits`` requires both to permit.
 
     Used when :meth:`ScopedRuleset.compose` cannot flatten to a single ruleset.
+    The halves are named ``outer`` / ``inner`` rather than ceiling/profile: a
+    fold of three or more tiers nests one ``_AndRuleset`` inside another, so a
+    half may itself be a composed pair (another policy tier), not the profile.
+    The two-party denial labels keep the ``policy:`` / ``profile:`` prefixes
+    and layers; a denial from a NESTED inner pair propagates that pair's own
+    layer and label instead of being stamped ``profile``.
     Deliberately NOT a ``ScopedRuleset`` subclass — it satisfies
     :class:`RulesetLike` structurally, so the evaluator stays shape-agnostic.
     """
 
-    ceiling: RulesetLike
-    profile: RulesetLike
+    outer: RulesetLike
+    inner: RulesetLike
 
     def permits(self, item: str) -> Decision:
-        c = self.ceiling.permits(item)
-        if not c.permitted:
-            return Decision(False, f"policy: {c.reason}", rule="rule2-intersect", layer="policy")
-        p = self.profile.permits(item)
-        if not p.permitted:
-            return Decision(False, f"profile: {p.reason}", rule="rule2-intersect", layer="profile")
+        o = self.outer.permits(item)
+        if not o.permitted:
+            return Decision(False, f"policy: {o.reason}", rule="rule2-intersect", layer="policy")
+        i = self.inner.permits(item)
+        if not i.permitted:
+            if isinstance(self.inner, _AndRuleset):
+                # A nested pair is another policy tier, not the profile — its
+                # decision already carries the right prefix and layer.
+                return Decision(False, i.reason, rule="rule2-intersect", layer=i.layer)
+            return Decision(False, f"profile: {i.reason}", rule="rule2-intersect", layer="profile")
         return Decision(True, "permitted by both levels", rule="rule2-intersect", layer="both")
 
 
@@ -1099,7 +1109,14 @@ class ScopedMap:
     def compose(self, narrower: "ScopedMap") -> "ScopedMap":
         # members intersect; posture is policy-only so the ceiling's wins.
         base = self.members
-        composed = base.compose(narrower.members) if isinstance(base, ScopedRuleset) else base
+        if isinstance(base, ScopedRuleset):
+            composed: RulesetLike = base.compose(narrower.members)
+        else:
+            # An earlier fold already produced an ``_AndRuleset``; wrap it the
+            # same way the sibling composers (``CapabilityGate.compose``,
+            # ``_compose_controls``) do, so a third — and any later — tier's
+            # narrowing is honoured instead of being silently dropped.
+            composed = _AndRuleset(base, narrower.members)
         return ScopedMap(members=composed, posture=self.posture)
 
     def permits_member(self, member: str) -> Decision:

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -41,6 +41,7 @@ from kiro_crew.platform.governance import (
     assert_governance_floor,
     assert_policy_signature_satisfied,
     compose_profiles,
+    compose_tier_ladder,
     deny_all_profile,
     load_security_policy,
     mcp_title_to_ref,
@@ -314,6 +315,96 @@ class TestScopedMap:
         assert not composed.permits_member("discord").permitted  # profile narrowed
         # posture is policy-only → preserved from ceiling.
         assert composed.posture_permits("slack", "allowed_team_ids", "T1").permitted
+
+    def test_three_tier_members_all_tighten(self):
+        # Regression: once one fold has produced an ``_AndRuleset``, the next
+        # fold must still honour that tier's narrowing instead of returning
+        # the existing pair unchanged.
+        t1 = ScopedMap.from_dict(
+            {"members": {"mode": "allow", "allow": ["slack", "discord", "telegram"]}},
+            allow_posture=True,
+        )
+        t2 = ScopedMap.from_dict(
+            {"members": {"mode": "allow", "allow": ["slack", "discord"]}}, allow_posture=False
+        )
+        t3 = ScopedMap.from_dict(
+            {"members": {"mode": "allow", "allow": ["slack"]}}, allow_posture=False
+        )
+        composed = t1.compose(t2).compose(t3)
+        assert composed.permits_member("slack").permitted
+        # The third tier must tighten the already-composed pair.
+        assert not composed.permits_member("discord").permitted
+        assert not composed.permits_member("telegram").permitted
+
+    def test_nested_inner_denial_not_labelled_profile(self):
+        # When the inner half of an ``_AndRuleset`` is itself a nested pair,
+        # its denial is another policy tier, not the profile: the nested
+        # decision's own layer and label must propagate.
+        t1 = ScopedMap.from_dict(
+            {"members": {"mode": "allow", "allow": ["slack", "discord", "telegram"]}},
+            allow_posture=True,
+        )
+        t2 = ScopedMap.from_dict(
+            {"members": {"mode": "allow", "allow": ["slack"]}}, allow_posture=False
+        )
+        t3 = ScopedMap.from_dict(
+            {"members": {"mode": "allow", "allow": ["slack", "telegram"]}}, allow_posture=False
+        )
+        composed = t1.compose(t2.compose(t3))
+        decision = composed.permits_member("discord")  # denied by t2, a nested tier
+        assert not decision.permitted
+        assert decision.layer == "policy"
+        assert not decision.reason.startswith("profile:")
+
+    def test_extends_chain_third_link_channels_narrowing_applies(self):
+        # Same shape through the public entry point: a three-link ``extends``
+        # chain carrying a channels ScopedMap.
+        grandparent = parse_profile(
+            {
+                "name": "gp",
+                "channels": {
+                    "members": {"mode": "allow", "allow": ["slack", "discord", "telegram"]}
+                },
+            }
+        )
+        parent = parse_profile(
+            {
+                "name": "parent",
+                "extends": "gp",
+                "channels": {"members": {"mode": "allow", "allow": ["slack", "discord"]}},
+            }
+        )
+        child = parse_profile(
+            {
+                "name": "child",
+                "extends": "parent",
+                "channels": {"members": {"mode": "allow", "allow": ["slack"]}},
+            }
+        )
+        merged = compose_profiles(compose_profiles(grandparent, parent), child)
+        assert resolve(None, merged, "channels", "slack").permitted
+        assert not resolve(None, merged, "channels", "discord").permitted
+        assert not resolve(None, merged, "channels", "telegram").permitted
+
+    def test_tier_ladder_third_tier_channels_members_tighten(self):
+        # The tier ladder folds through the same ``ScopedMap.compose`` path;
+        # the lowest tier's channels narrowing must survive a three-tier fold.
+        managed = parse_policy(
+            _policy_body(
+                channels={"members": {"mode": "allow", "allow": ["slack", "discord", "telegram"]}}
+            )
+        )
+        central = parse_policy(
+            _policy_body(channels={"members": {"mode": "allow", "allow": ["slack", "discord"]}})
+        )
+        subordinate = parse_policy(
+            _policy_body(channels={"members": {"mode": "allow", "allow": ["slack"]}})
+        )
+        ceiling = compose_tier_ladder(managed, central, subordinate)
+        assert ceiling is not None
+        assert resolve(ceiling, None, "channels", "slack").permitted
+        assert not resolve(ceiling, None, "channels", "discord").permitted
+        assert not resolve(ceiling, None, "channels", "telegram").permitted
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem / Motivation

`ScopedMap.compose` in `src/kiro_crew/platform/governance.py` only intersects `members` when `self.members` is a plain `ScopedRuleset`. Once one fold has produced an `_AndRuleset` (any allow-mode pair, or a deny pair with different matchers), the next fold hits the `else base` branch and returns the existing pair unchanged — the third tier's `channels.members` ruleset is silently dropped. Reachable on main through a three-link `extends` chain (`compose_profiles(compose_profiles(gp, parent), child)` → `_compose_controls` → `ScopedMap.compose`) and through the tier ladder (`compose_tier_ladder` → `_intersect_ceilings` → `_compose_controls`) for managed / central / subordinate.

Direction of the defect: a MISSED tightening only — nothing loosens a ceiling.

Secondary: `_AndRuleset` names its halves `ceiling` / `profile` and labels the second half's denial `profile: ...` with `layer="profile"`, which mislabels a nested tier denial (the inner half of a multi-tier fold is another policy tier, not the profile).

## Why it matters

An operator who narrows `channels.members` at the third governance tier (a child profile in an `extends` chain, or the subordinate tier under a managed + central ladder) believes the restriction is enforced when it is not. The composed decision still permits members the lowest tier meant to exclude, and the mislabelled denial layer makes `policy explain` / the audit record point at the wrong tier.

## What changed (motivation → approach → change)

Root cause: the `else base` fallthrough in `ScopedMap.compose`. The sibling composers already handle this shape correctly — `CapabilityGate.compose` does `_AndRuleset(base, ruleset)` when base is not a `ScopedRuleset`, and `_compose_controls` wraps an `_AndRuleset` ceiling the same way — so the fix applies the identical wrap: when `self.members` is already composed, return `_AndRuleset(base, narrower.members)`. Nested `_AndRuleset(_AndRuleset(a, b), c)` evaluates all three in `permits` (a deny anywhere denies), so nesting is sufficient; no n-ary redesign.

With nesting now reachable by design, the `_AndRuleset` halves are renamed to the tier-neutral `outer` / `inner`, and the denial labels are made tier-aware: the outer denial keeps `layer="policy"`; the inner denial is stamped `profile: ...` / `layer="profile"` only when the inner half is a leaf (`ScopedRuleset`). When the inner half is itself a nested `_AndRuleset`, its own decision's layer and reason propagate instead. `rule="rule2-intersect"` and the two-party `policy: ` / `profile: ` prefixes are unchanged, so `resolve()`'s `layer` consumers and existing tests stay green. The only external attribute reader, `_serialize_ruleset` in `src/kiro_crew/dashboard/handlers/security.py`, is updated to the new field names (its emitted JSON shape is unchanged); a repo-wide grep finds no other `.ceiling` / `.profile` read on an `_AndRuleset`.

## Tests

Four tests added to `TestScopedMap` in `test/test_governance_policy.py`:

- `test_three_tier_members_all_tighten` — `t1.compose(t2).compose(t3)` over three allow-mode member sets; the `discord` denial asserts the third tier's tightening is honoured (this assertion fails on main).
- `test_nested_inner_denial_not_labelled_profile` — a denial coming from a nested inner pair keeps `layer="policy"` and is not stamped `profile:`.
- `test_extends_chain_third_link_channels_narrowing_applies` — the same shape through the public entry point: a three-link `extends` chain carrying a `channels` ScopedMap, composed via `compose_profiles`, resolved via `resolve()`.
- `test_tier_ladder_third_tier_channels_members_tighten` — the same shape through `compose_tier_ladder` over three parsed policy documents (PR #7362's ladder merged, so the ladder entry point is covered directly).

The existing `test_members_intersect_posture_from_ceiling` (posture stays policy-only) is unchanged and still passes.

## Manual verification

N/A — unit coverage sufficient: the change is a pure in-memory composition rule with no I/O, and the new tests exercise both public entry points (`compose_profiles`, `compose_tier_ladder`) plus the direct `ScopedMap.compose` fold.

## Related Issues

Closes #9430 (deferred from #7362 review item M5)

## Pattern harvest

Rule candidate: review-prompt
Pattern: a type-dispatch compose with an `else <identity>` branch silently drops the narrower operand — every composer's fallthrough must wrap, not return the base unchanged.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc documents the renamed private fields
- [x] No secrets, credentials, or internal references in the diff
