### PR TITLE
feat(terminal): touch swipe-to-scroll for full-screen and mouse-tracking apps

### DIFF
--- a/website/src/components/CliPanel.tsx
+++ b/website/src/components/CliPanel.tsx
@@ -10,6 +10,7 @@ import { getTerminalFont, resolveTerminalFontFamily, subscribeTerminalFont } fro
 import { ansiPaletteFromVars } from '../utils/terminalPalette'
 import { useIsTouchDevice } from '../hooks/useIsTouchDevice'
 import { useTerminalTouchSelection, type TouchSelectStatus } from '../hooks/useTerminalTouchSelection'
+import { useTerminalTouchScroll } from '../hooks/useTerminalTouchScroll'
 import TerminalCompletion from './TerminalCompletion'
 import TerminalKeyBar from './TerminalKeyBar'
 import ErrorNotice from './ErrorNotice'
@@ -293,6 +294,13 @@ function TerminalView({ sessionId, cwd, visible, onSendToChat }: { sessionId: st
   // (the staged Select key only reaches the last line or the whole buffer).
   // Inert on mouse devices, where xterm's drag-selection already works.
   const touchSelect = useTerminalTouchSelection(term, touchDevice)
+
+  // One-finger swipe-to-scroll. Full-screen apps (claude, vim, less) have no
+  // scrollback to pan, so the drag is translated into the scroll input they
+  // expect — arrow keys, or SGR wheel reports at the finger cell when the app
+  // holds mouse tracking. Inert on the normal screen, where xterm/browser
+  // already pan the scrollback.
+  useTerminalTouchScroll(term, sessionId, containerRef)
 
   // Re-measure + refit, gated on pane visibility (see remeasureAndFit). Stable
   // per cached term/fit, so the effects below don't re-subscribe.

--- a/website/src/hooks/useTerminalTouchScroll.ts
+++ b/website/src/hooks/useTerminalTouchScroll.ts
@@ -1,0 +1,94 @@
+import { useEffect, type RefObject } from 'react'
+import type { Terminal } from '@xterm/xterm'
+import { touchScrollAction, scrollSequence, touchCellFromRect } from '../state/touchScroll'
+import { sendRawBytesToTerminalSession } from '../utils/terminalRegistry'
+
+/** px of vertical drag per scroll step. */
+const TOUCH_LINE_PX = 24
+
+/**
+ * One-finger touch swipe-to-scroll for the xterm terminal.
+ *
+ * xterm's built-in touch scroll pans its own scrollback, which works at a shell
+ * prompt but does nothing for a full-screen app: an alt-screen program (claude,
+ * vim, less) has no scrollback, and while it holds mouse tracking xterm refuses
+ * to pan at all. Those apps scroll on scroll INPUT — a mouse wheel on desktop —
+ * which a touch drag never produces. This translates the drag into that input:
+ *
+ *   - normal screen, no mouse tracking → left to xterm/browser (native pan)
+ *   - alt screen, no mouse tracking     → arrow keys (pagers)
+ *   - mouse tracking on (any screen)    → SGR wheel reports at the finger cell
+ *
+ * Listeners are attached natively (not via React props) so `preventDefault` on
+ * `touchmove` is honored, and `touch-action: none` is toggled on the container
+ * whenever we intend to intercept — otherwise the browser claims the vertical
+ * pan first and delivers the subsequent moves as non-cancelable events.
+ */
+export function useTerminalTouchScroll(
+  term: Terminal,
+  sessionId: string,
+  containerRef: RefObject<HTMLElement | null>,
+): void {
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const mouseActive = () => term.modes.mouseTrackingMode !== 'none'
+    const isAlt = () => term.buffer.active.type === 'alternate'
+
+    // touch-action must be `none` BEFORE a gesture starts for us to be able to
+    // swallow it, so track the intercept state on buffer/mode changes rather
+    // than at touchstart (too late for the current gesture).
+    const syncTouchAction = () => {
+      container.classList.toggle('term-scroll-intercept', mouseActive() || isAlt())
+    }
+    syncTouchAction()
+    const bufDisp = term.buffer.onBufferChange(syncTouchAction)
+
+    let touchY: number | null = null
+    let accum = 0
+
+    const onStart = (e: TouchEvent) => {
+      touchY = e.touches.length === 1 ? e.touches[0].clientY : null
+      accum = 0
+    }
+    const onMove = (e: TouchEvent) => {
+      if (touchY == null || e.touches.length !== 1) return
+      const action = touchScrollAction(isAlt(), mouseActive())
+      if (action === 'native') return // let the browser pan xterm's scrollback
+
+      e.preventDefault() // we drive the app; don't also pan the page
+      const y = e.touches[0].clientY
+      accum += touchY - y // finger up (y decreases) = scroll DOWN in content
+      touchY = y
+      const steps = Math.trunc(accum / TOUCH_LINE_PX)
+      if (steps === 0) return
+      accum -= steps * TOUCH_LINE_PX // keep the remainder for smoothness
+
+      const dir = steps > 0 ? 'down' : 'up'
+      const appCursor = Boolean(term.modes.applicationCursorKeysMode)
+      const screen = container.querySelector('.xterm-screen') ?? container
+      const rect = screen.getBoundingClientRect()
+      const [col, row] = touchCellFromRect(rect, term.cols, term.rows, e.touches[0].clientX, y)
+      const bytes = scrollSequence(action, dir, Math.abs(steps), appCursor, col, row)
+      sendRawBytesToTerminalSession(sessionId, bytes)
+    }
+    const onEnd = () => {
+      touchY = null
+      accum = 0
+    }
+
+    container.addEventListener('touchstart', onStart, { passive: true })
+    container.addEventListener('touchmove', onMove, { passive: false })
+    container.addEventListener('touchend', onEnd, { passive: true })
+    container.addEventListener('touchcancel', onEnd, { passive: true })
+    return () => {
+      bufDisp.dispose()
+      container.classList.remove('term-scroll-intercept')
+      container.removeEventListener('touchstart', onStart)
+      container.removeEventListener('touchmove', onMove)
+      container.removeEventListener('touchend', onEnd)
+      container.removeEventListener('touchcancel', onEnd)
+    }
+  }, [term, sessionId, containerRef])
+}

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -2519,6 +2519,12 @@ body.mc-focus-mode.mc-focus-rail .focus-chrome-rail{
   html { touch-action: pan-x pan-y; }
 }
 
+/* Swipe-to-scroll intercept: when a full-screen or mouse-tracking terminal app
+   is active, the drag is turned into scroll input for the app, so the browser
+   must not claim the vertical pan first. Toggled by useTerminalTouchScroll.
+   `none` is strictly narrower than the root, so the intersection stays `none`. */
+.term-scroll-intercept { touch-action: none; }
+
 /* ── Liquid-glass design system ──
  * Two composable classes for any surface that should look like Apple-style
  * liquid glass — file chips, sidebar, chat input, follow-up bar, etc.

--- a/website/src/state/touchScroll.ts
+++ b/website/src/state/touchScroll.ts
@@ -1,0 +1,98 @@
+// Pure core of one-finger touch swipe-to-scroll.
+//
+// A vertical drag maps to one of three transports:
+//   - 'wheel'  — mouse tracking is ON (claude, vim `mouse=a`, htop, tmux, fzf):
+//     the app scrolls its own pane on mouse-WHEEL reports, which a bare touch
+//     never generates, so we synthesize them in the SGR 1006 encoding modern
+//     TUIs negotiate.
+//   - 'arrows' — alt screen, mouse tracking OFF (less, man, git log): a pager
+//     with no scrollback that pages on arrow keys.
+//   - 'native' — normal screen, mouse tracking OFF: let the browser pan xterm's
+//     scrollback natively (the viewport is overflow-y:scroll).
+
+export type TouchScrollAction = 'native' | 'arrows' | 'wheel'
+
+/** Decide how a one-finger vertical drag should scroll, by mouse mode + screen. */
+export function touchScrollAction(
+  isAltScreen: boolean,
+  mouseTrackingActive: boolean,
+): TouchScrollAction {
+  // Mouse tracking is checked FIRST, before the buffer type. When it is on,
+  // xterm's own touch handler refuses to native-pan the viewport, so 'native'
+  // would scroll nothing — the app owns the pointer and a synthesized wheel
+  // report is the only thing that scrolls. The buffer type is also not a
+  // reliable proxy: after a reconnect/replay the app's mouse mode is re-emitted
+  // before the alt-screen enter is re-applied, so the buffer can still read
+  // `normal` while the app is really a mouse-tracking full-screen app.
+  if (mouseTrackingActive) return 'wheel'
+  return isAltScreen ? 'arrows' : 'native'
+}
+
+/** Clamp a fling to a sane number of discrete steps (no hundreds-of-keys burst). */
+const MAX_STEPS = 6
+
+const enc = (s: string) => new TextEncoder().encode(s)
+
+/**
+ * The bytes for `n` scroll steps in a direction, for the 'arrows' or 'wheel'
+ * transport. `n` is clamped to [0, MAX_STEPS]; a non-positive count yields no
+ * bytes. Not called for 'native' (the browser handles that with no synthesis).
+ *
+ * `appCursor` is the terminal's DECCKM (application cursor keys) mode. less/vim
+ * enable it, and then an arrow key is `ESC O A/B` (SS3), NOT `ESC [ A/B` (CSI) —
+ * the CSI form scrolls nothing there. Wheel reports are not cursor keys, so
+ * `appCursor` does not affect them.
+ *
+ * SGR 1006 wheel report: `ESC [ < Cb ; Cx ; Cy M`, wheel-up Cb=64, wheel-down
+ * Cb=65, at the 1-based grid cell (`col`;`row`) under the finger. Most TUIs
+ * scroll regardless of the cell, but a position-sensitive app — claude's Ink
+ * transcript — only scrolls when the report lands inside its scroll box, and
+ * the top-left cell `1;1` is a border that scrolls nothing. `col`/`row` default
+ * to 1 for callers that do not care; ignored for the 'arrows' transport.
+ */
+export function scrollSequence(
+  transport: 'arrows' | 'wheel',
+  direction: 'up' | 'down',
+  n: number,
+  appCursor = false,
+  col = 1,
+  row = 1,
+): Uint8Array {
+  const count = Math.min(Math.max(0, Math.trunc(n)), MAX_STEPS)
+  if (count === 0) return new Uint8Array(0)
+  let unit: string
+  if (transport === 'arrows') {
+    const csi = direction === 'up' ? '\x1b[A' : '\x1b[B'
+    const ss3 = direction === 'up' ? '\x1bOA' : '\x1bOB'
+    unit = appCursor ? ss3 : csi
+  } else {
+    const cb = direction === 'up' ? 64 : 65
+    const cx = Math.max(1, Math.trunc(col))
+    const cy = Math.max(1, Math.trunc(row))
+    unit = `\x1b[<${cb};${cx};${cy}M`
+  }
+  return enc(unit.repeat(count))
+}
+
+/**
+ * Map a touch point (client coords) to the 1-based terminal cell under it, from
+ * the terminal's rendered box and grid size. The synthesized wheel report is
+ * placed here so a position-sensitive TUI scrolls its own box. Clamped to
+ * [1, cols] / [1, rows].
+ */
+export function touchCellFromRect(
+  rect: { left: number; top: number; width: number; height: number },
+  cols: number,
+  rows: number,
+  clientX: number,
+  clientY: number,
+): [number, number] {
+  const cw = rect.width / Math.max(1, cols)
+  const ch = rect.height / Math.max(1, rows)
+  const col = cw > 0 ? Math.floor((clientX - rect.left) / cw) + 1 : 1
+  const row = ch > 0 ? Math.floor((clientY - rect.top) / ch) + 1 : 1
+  return [
+    Math.min(Math.max(1, col), Math.max(1, cols)),
+    Math.min(Math.max(1, row), Math.max(1, rows)),
+  ]
+}

--- a/website/src/test/touchScroll.test.ts
+++ b/website/src/test/touchScroll.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { touchScrollAction, scrollSequence, touchCellFromRect } from '../state/touchScroll'
+
+const b = (s: string): number[] => Array.from(new TextEncoder().encode(s))
+const seq = (
+  a: 'arrows' | 'wheel',
+  d: 'up' | 'down',
+  n: number,
+  appCursor = false,
+): number[] => Array.from(scrollSequence(a, d, n, appCursor))
+const seqAt = (
+  a: 'arrows' | 'wheel',
+  d: 'up' | 'down',
+  n: number,
+  col: number,
+  row: number,
+): number[] => Array.from(scrollSequence(a, d, n, false, col, row))
+
+describe('touchScrollAction', () => {
+  it('normal screen, no mouse tracking → native (browser pans xterm scrollback)', () => {
+    expect(touchScrollAction(false, false)).toBe('native')
+  })
+  it('mouse tracking on → wheel, even if the buffer still reads normal', () => {
+    // Mouse tracking wins over buffer type: xterm will not native-pan while the
+    // app owns the pointer, and after a reconnect the mode can be re-emitted
+    // before the alt-screen enter, so isAlt can read false for a real TUI.
+    expect(touchScrollAction(false, true)).toBe('wheel')
+    expect(touchScrollAction(true, true)).toBe('wheel')
+  })
+  it('alt screen, no mouse tracking → arrows (less/man/git log)', () => {
+    expect(touchScrollAction(true, false)).toBe('arrows')
+  })
+})
+
+describe('scrollSequence — arrows', () => {
+  it('emits N up/down arrow keys (normal cursor mode → CSI)', () => {
+    expect(seq('arrows', 'up', 1)).toEqual(b('\x1b[A'))
+    expect(seq('arrows', 'down', 1)).toEqual(b('\x1b[B'))
+    expect(seq('arrows', 'up', 3)).toEqual(b('\x1b[A\x1b[A\x1b[A'))
+  })
+  it('uses SS3 (ESC O) arrows in application-cursor mode (DECCKM)', () => {
+    expect(seq('arrows', 'up', 1, true)).toEqual(b('\x1bOA'))
+    expect(seq('arrows', 'down', 2, true)).toEqual(b('\x1bOB\x1bOB'))
+  })
+})
+
+describe('scrollSequence — SGR mouse wheel reports', () => {
+  it('emits wheel-up (64) / wheel-down (65) at the given cell', () => {
+    expect(seqAt('wheel', 'up', 1, 10, 5)).toEqual(b('\x1b[<64;10;5M'))
+    expect(seqAt('wheel', 'down', 1, 10, 5)).toEqual(b('\x1b[<65;10;5M'))
+  })
+  it('defaults the cell to 1;1 and repeats per step', () => {
+    expect(seq('wheel', 'down', 2)).toEqual(b('\x1b[<65;1;1M\x1b[<65;1;1M'))
+  })
+})
+
+describe('scrollSequence — clamping', () => {
+  it('yields no bytes for a non-positive count', () => {
+    expect(seq('arrows', 'up', 0)).toEqual([])
+    expect(seq('wheel', 'down', -3)).toEqual([])
+  })
+  it('caps a fling at 6 steps', () => {
+    expect(seq('arrows', 'down', 999)).toEqual(b('\x1b[B'.repeat(6)))
+  })
+})
+
+describe('touchCellFromRect', () => {
+  const rect = { left: 0, top: 0, width: 800, height: 400 } // 80x24 grid → 10x~16.7 px cells
+  it('maps a point to its 1-based cell', () => {
+    expect(touchCellFromRect(rect, 80, 24, 15, 20)).toEqual([2, 2])
+  })
+  it('clamps to [1,cols] / [1,rows] outside the box', () => {
+    expect(touchCellFromRect(rect, 80, 24, -50, -50)).toEqual([1, 1])
+    expect(touchCellFromRect(rect, 80, 24, 9999, 9999)).toEqual([80, 24])
+  })
+})

--- a/website/src/utils/terminalRegistry.ts
+++ b/website/src/utils/terminalRegistry.ts
@@ -153,6 +153,22 @@ export function sendRawToTerminalSession(sessionId: string, data: string): boole
   }
 }
 
+/**
+ * Send raw bytes to a terminal session — used by touch swipe-to-scroll to write
+ * synthesized arrow-key or SGR mouse-wheel sequences straight to the PTY.
+ * Returns false if that session has no open socket.
+ */
+export function sendRawBytesToTerminalSession(sessionId: string, data: Uint8Array): boolean {
+  const ws = getTerminalWs(sessionId)
+  if (!ws || data.length === 0) return false
+  try {
+    ws.send(data)
+    return true
+  } catch {
+    return false
+  }
+}
+
 /* ── Persistent per-session connection manager ──
  * The WebSocket lives here (module scope), NOT in the TerminalView component,
  * so unmounting the terminal tab (activity-bar close, tab switch, chat switch,


### PR DESCRIPTION
## Problem

On a touch device, a one-finger drag cannot scroll the terminal while a
full-screen app is running. xterm's built-in touch scroll only pans its own
scrollback, so an alt-screen app — `claude`, `vim`, `less` — has nothing for it
to pan, and while the app holds mouse tracking xterm refuses to pan at all. The
result on a phone: the plain shell scrolls, but the app's output is stranded
off-screen with no gesture to reach it.

## Change

`useTerminalTouchScroll` (wired into `CliPanel`) turns a one-finger vertical
drag into the scroll input the active app actually responds to — the same thing
a mouse wheel does on desktop:

| Context | Transport |
|---|---|
| normal screen, no mouse tracking | `native` — left to xterm's scrollback pan |
| alt screen, no mouse tracking (`less`, `man`, `git log`) | arrow keys — CSI, or SS3 under DECCKM |
| mouse tracking on, any screen (`claude`, `vim mouse=a`, `htop`, `tmux`) | SGR 1006 wheel reports |

Mouse tracking is checked before the buffer type: xterm will not native-pan
while the app owns the pointer, and after a reconnect the mode can be re-emitted
before the alt-screen enter, so the buffer type alone is not a reliable signal.

The synthesized wheel report carries the **cell under the finger**, exactly as
xterm's native desktop wheel forwarding does — a position-sensitive TUI (claude's
Ink transcript) only scrolls when the report lands inside its scroll box, so a
fixed top-left `1;1` scrolls nothing.

Listeners are attached natively (not via React props) so `preventDefault` on
`touchmove` is honored, and `touch-action: none` is toggled on the container
whenever we intend to intercept, so the browser does not claim the vertical pan
first and start delivering non-cancelable moves.

## Files

- `website/src/state/touchScroll.ts` — pure routing + sequence encoding + cell mapping
- `website/src/hooks/useTerminalTouchScroll.ts` — the touch handler + intercept toggle
- `website/src/components/CliPanel.tsx` — wires the hook
- `website/src/utils/terminalRegistry.ts` — `sendRawBytesToTerminalSession`
- `website/src/index.css` — `.term-scroll-intercept { touch-action: none }`
- `website/src/test/touchScroll.test.ts` — unit tests for the pure core

## Testing

- `npm run typecheck`, `npm run lint`, and the new `touchScroll.test.ts` (11 cases) pass.
- The pure routing/encoding is unit-tested; the end-to-end gesture needs a real
  touch device and has not yet been verified on-device.
