### PR TITLE
fix(security): log and pin the uncharged queue-wait refusal (#9482)

### DIFF
--- a/src/kiro_crew/executors.py
+++ b/src/kiro_crew/executors.py
@@ -252,8 +252,12 @@ _MAX_STT_WORKERS = 2
 # the wait does NOT free the worker, so this is its OWN tiny pool: a wedged
 # resolution can only ever starve other path resolution, never the sweeps or
 # the default executor's DNS.  Two workers is deliberate -- healthy resolution is
-# microseconds, so the cap only bites when the filesystem is wedged, which is
-# exactly when queueing behind a wedged sibling is the correct outcome.
+# microseconds, so sustained queueing means the filesystem is wedged, and
+# queueing behind a wedged sibling can only time out.  The cap also bites under
+# plain concurrency (simultaneous cron fires submitting at once); a queued
+# resolution that never starts is cancelled on timeout and refused for that
+# call alone, charging no prefix cooldown (see
+# ``security.paths._run_resolution_bounded``).
 _MAX_PATH_RESOLVE_WORKERS = 2
 
 _lock = threading.Lock()

--- a/src/kiro_crew/security/paths.py
+++ b/src/kiro_crew/security/paths.py
@@ -1290,13 +1290,15 @@ def _load_arm_budget_spent(prefix: str) -> bool:
 def _mark_stalled(prefix: str, budget: float) -> None:
     """Record an OBSERVED stall under *prefix*: back off exponentially on repeats.
 
-    Only a resolution that actually timed out is recorded.  A refusal issued
-    because every worker was already pinned costs nothing (nothing is
-    submitted) and must not charge the refused prefix -- often the local
-    workspace -- a backoff it never earned, or a transient dual-mount outage
-    would keep refusing healthy paths for the accrued window after the mounts
-    recover.  The log line deliberately omits the path: the token is
-    agent-supplied and is what the gates exist to keep out of clear-text logs.
+    Only a resolution that actually RAN and timed out is recorded.  A refusal
+    issued because every worker was already pinned (nothing is submitted), or
+    because a submitted resolution never left the queue (its future cancelled
+    on timeout), says nothing about the filesystem and must not charge the
+    refused prefix -- often the local workspace -- a backoff it never earned,
+    or a transient dual-mount outage would keep refusing healthy paths for the
+    accrued window after the mounts recover.  The log line deliberately omits
+    the path: the token is agent-supplied and is what the gates exist to keep
+    out of clear-text logs.
     """
     now = _path_resolve_clock()
     with _path_resolve_lock:
@@ -1369,6 +1371,15 @@ def _run_resolution_bounded(
     rarely and can never pin the whole pool.  Never blocks the caller for longer
     than ``_PATH_RESOLVE_TIMEOUT_SECS``.
 
+    A stall is charged only to a resolution that RAN.  A future that times out
+    still QUEUED (the pool saturated by concurrent callers, e.g. simultaneous
+    cron fires) is cancelled and refuses this call alone: queue wait is
+    evidence about load, not about the mount, so it opens no cooldown and pins
+    no worker in :func:`_wedged_workers`.  A future claimed by a freeing worker
+    in the very instant the deadline fires is abandoned by handshake -- the
+    worker returns without entering the resolution -- so the never-ran
+    classification is binding, not a race.
+
     The UNC shortcut is NOT here: skipping a ``\\\\server\\share`` token is a
     stance about agent-supplied CANDIDATES (:func:`_resolved_forms_bounded`),
     whose fence targets a UNC realpath never produces.  The anchors are the
@@ -1400,12 +1411,21 @@ def _run_resolution_bounded(
         raise PathResolutionStalled(expanded, prefix)
     try:
         started = threading.Event()
+        abandoned = threading.Event()
+        handoff = threading.Lock()
         worker_tid: list[int] = []
 
         @functools.wraps(worker)
-        def _tracked(arg: str) -> _ResolvedT:
+        def _tracked(arg: str) -> _ResolvedT | None:
             worker_tid.append(threading.get_native_id())
-            started.set()
+            with handoff:
+                if abandoned.is_set():
+                    # The caller classified this future as never-run at its
+                    # deadline: return without touching the filesystem, so a
+                    # late claim can neither probe a wedged mount nor pin a
+                    # worker _wedged_workers() is not tracking.
+                    return None
+                started.set()
             return worker(arg)
 
         future = path_resolve_executor().submit(_tracked, expanded)
@@ -1415,9 +1435,28 @@ def _run_resolution_bounded(
     try:
         value = future.result(timeout=budget)
     except FutureTimeoutError:
-        if not started.is_set() and future.cancel():
-            # Only a future proven dead by cancel() may go untracked: one that refuses
-            # cancellation is running, and would pin a worker _wedged_workers() cannot see.
+        if future.cancel():
+            # Never claimed by a worker: the pool was saturated and the
+            # resolution never started -- evidence about load, not the mount.
+            logger.debug(
+                "sensitive-path symlink resolution refused: the resolver pool was "
+                "saturated and the resolution never started; prefix not charged"
+            )
+            raise PathResolutionStalled(expanded, prefix) from None
+        with handoff:
+            ran = started.is_set()
+            if not ran:
+                abandoned.set()
+        if not ran:
+            # Claimed by a freeing worker in the instant the deadline fired,
+            # before entering the resolution.  The handshake makes the
+            # classification binding: the worker sees ``abandoned`` and returns
+            # without probing, so it pins nothing and there is nothing to
+            # charge -- the same conclusion as the queued arm above.
+            logger.debug(
+                "sensitive-path symlink resolution refused: the resolver pool was "
+                "saturated and the resolution never started; prefix not charged"
+            )
             raise PathResolutionStalled(expanded, prefix) from None
         with _path_resolve_lock:
             _path_resolve_wedged.append(future)

--- a/test/test_security_path_resolve_bounded.py
+++ b/test/test_security_path_resolve_bounded.py
@@ -22,6 +22,7 @@ which must fence a symlinked ``$HOME`` by its logical spelling.
 from __future__ import annotations
 
 import errno
+import logging
 import os
 import re
 import threading
@@ -711,11 +712,25 @@ def test_the_discriminator_reads_a_running_thread_as_not_blocked() -> None:
     assert _REAL_BLOCKED_IN_FILESYSTEM(2**31 - 1) is True
 
 
-def test_an_uncancellable_queued_future_is_still_tracked_as_wedged(monkeypatch) -> None:
-    # An uncancellable queued future is already running, so an untracked pinned worker makes
-    # the pool-exhaustion guard undercount -- surfacing later as unrelated exhaustion.
-    class _QueuedNeverCancels:
-        """Times out having never run, and refuses to be cancelled."""
+def test_a_future_claimed_at_the_deadline_aborts_instead_of_probing(monkeypatch) -> None:
+    # A queued future can be claimed by a freeing worker in the same instant the
+    # budget fires: cancel() fails, yet the resolution has not begun.  The
+    # timeout arm classifies it never-run, and the handshake makes that binding:
+    # the late worker sees the abandonment and returns WITHOUT touching the
+    # filesystem -- so it cannot probe a wedged mount while untracked, and there
+    # is nothing to charge or to count as wedged.
+    probes: list[str] = []
+
+    def _resolver(expanded: str) -> set[str]:
+        probes.append(expanded)
+        return {expanded}
+
+    monkeypatch.setattr(security, "_resolved_spellings", _resolver)
+
+    captured: list = []
+
+    class _ClaimedAtDeadline:
+        """Times out, and refuses cancellation as a just-claimed future does."""
 
         def result(self, timeout=None):  # noqa: ANN001, ANN202, ARG002
             raise FutureTimeoutError
@@ -727,10 +742,11 @@ def test_an_uncancellable_queued_future_is_still_tracked_as_wedged(monkeypatch) 
             return False
 
     class _Pool:
-        def submit(self, fn, arg):  # noqa: ANN001, ANN202, ARG002
-            # The callable is deliberately never invoked, so `started` stays unset and the
-            # queued arm is the one under test.
-            return _QueuedNeverCancels()
+        def submit(self, fn, arg):  # noqa: ANN001, ANN202
+            # Hold the callable instead of running it: the worker has claimed
+            # the future but not yet entered it when the deadline fires.
+            captured.append((fn, arg))
+            return _ClaimedAtDeadline()
 
     tracked: list = []
     monkeypatch.setattr(security.paths, "_path_resolve_wedged", tracked)
@@ -739,9 +755,50 @@ def test_an_uncancellable_queued_future_is_still_tracked_as_wedged(monkeypatch) 
     with pytest.raises(security.PathResolutionStalled):
         security._candidate_forms("/home/someone/ws/file")
 
-    assert (
-        security.paths._wedged_workers() == 1
-    ), "an uncancellable queued future must stay visible to the pool-exhaustion guard"
+    assert security._path_resolve_degraded == {}, "a late claim must not open a cooldown"
+    assert security.paths._wedged_workers() == 0
+    # The worker only now gets around to running the future's callable: the
+    # handshake sends it straight back without a filesystem probe.
+    fn, arg = captured[0]
+    assert fn(arg) is None
+    assert probes == [], "an abandoned resolution must never touch the filesystem"
+
+
+def test_a_saturated_pool_refuses_without_charging_or_tracking(caplog) -> None:
+    # THE QUEUED ARM, end to end on the real pool.  kirodotdev/KiroCrew#9482:
+    # simultaneous cron fires pin both ``mc-pathres`` workers, so a third
+    # resolution times out having never STARTED.  Queue wait is evidence about
+    # load, not the mount: the call is still refused (fail-closed, unchanged),
+    # but no cooldown opens, nothing lands in ``_path_resolve_wedged``, and the
+    # pool-exhaustion guard reads 0 -- otherwise one busy morning refuses every
+    # path under the home prefix without a single slow filesystem operation.
+    gate = threading.Event()
+    pinned = threading.Semaphore(0)
+
+    def _pin_worker() -> None:
+        pinned.release()
+        gate.wait()
+
+    pool = ex.path_resolve_executor()
+    blockers = [pool.submit(_pin_worker) for _ in range(ex._MAX_PATH_RESOLVE_WORKERS)]
+    try:
+        for _ in blockers:
+            assert pinned.acquire(timeout=5.0), "blocker never reached a worker"
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.security.paths"):
+            with pytest.raises(security.PathResolutionStalled):
+                security._candidate_forms("/home/someone/ws/file")
+        assert security._path_resolve_degraded == {}, "queue wait must open no cooldown"
+        assert security._path_resolve_wedged == [], "a never-started future is not wedged"
+        assert security._wedged_workers() == 0
+        assert any("the resolution never started" in r.message for r in caplog.records)
+    finally:
+        gate.set()
+        for blocker in blockers:
+            blocker.result(timeout=5.0)
+    # The pool freed: the very next call under the SAME prefix resolves
+    # normally, with no inherited backoff from the refusal above.
+    forms = security._candidate_forms("/home/someone/ws/file")
+    assert os.path.normpath("/home/someone/ws/file") in forms
 
 
 def test_a_thread_stuck_in_a_monitored_syscall_reads_as_blocked(monkeypatch) -> None:


### PR DESCRIPTION
## Problem / Motivation

Refs #9482. A saturated two-worker path-resolve pool made `is_sensitive_path()` charge a queue-wait timeout as a filesystem stall: the home prefix entered an exponential cooldown and every path under it was refused without probing (the reporter measured 99 cron refusals in one morning with no slow filesystem involved).

The mechanism that resolves the contagion landed in #9711: on timeout, a future that never started is cancelled and refuses that call alone, and a started-but-descheduled worker is separated from a kernel-blocked one via `/proc/<tid>/syscall`. With that in place the prefix poisoning described in the issue no longer occurs on main.

What was still missing, and what this PR adds:

- **A regression test for the cancellable queued arm.** The suite only covered the *uncancellable* queued future (the negative control); deleting the `future.cancel()` handling would have passed every existing test. The new `test_a_saturated_pool_refuses_without_charging_or_tracking` pins the issue's exact reproduction end to end on the real pool: both `mc-pathres` workers pinned, a third resolution raises `PathResolutionStalled`, `_path_resolve_degraded` and `_path_resolve_wedged` stay empty, `_wedged_workers()` reports 0, and the next call after the pool frees succeeds with no inherited cooldown.
- **A closed race in the started arm** (found in pre-push review): a queued future claimed by a freeing worker in the instant the deadline fires makes `cancel()` return False before `_tracked` records its tid; `tid=None` then fell into `_worker_blocked_in_filesystem`'s fail-toward-charging clause and a resolution that did zero filesystem work opened a prefix cooldown. An unrecorded tid at that call site now reads as "never ran" and is not charged; the helper's own `tid is None` stance is unchanged for its other callers.
- **A debug log** in the queued arm (no path in the line, same stance as `_mark_stalled`).
- **Doc corrections**: the `_MAX_PATH_RESOLVE_WORKERS` comment no longer claims the cap only bites when the filesystem is wedged, and the `_run_resolution_bounded` / `_mark_stalled` docstrings state the started/queued split explicitly.

## Invariant

**A stall is charged only to a resolution that ran.** Queue wait is evidence about load, not about the mount: it refuses the individual call (fail-closed semantics are unchanged) and never opens a prefix cooldown, never lands in `_path_resolve_wedged`, and never counts toward the pool-exhaustion guard.

## Out of scope

Item 2 of the issue (memoizing successful resolutions for `_HOME_TARGETS_TTL_SECS`) is **intentionally left open** — it changes how long a sensitivity verdict is trusted and is a maintainer decision; the reporter has since down-weighted it themselves. `_MAX_PATH_RESOLVE_WORKERS` and `_PATH_RESOLVE_TIMEOUT_SECS` are likewise untouched.

## Testing

- New end-to-end test as above; the companion started-and-blocked path (charges the prefix, lands in wedged) was already pinned by the existing tests and is unchanged.
- Local gates: isort, flake8, black, mypy, diff-scoped comment-history and black gates — all green. Test execution is left to CI per repo practice.
- Pre-push review: GPT lane PASS; Opus lane raised 1 HIGH (the tid race above) and 2 LOWs (blocker joins under `finally`, an assertion on the new log line), all addressed.


## Pattern harvest

Rule candidate: a security-state finalizer that distinguishes cause A from cause B by a recorded observation (here: the worker tid) must define what an ABSENT observation means at each call site, not inherit the helper's global fail-toward default — an unrecorded tid at the timeout site means "never ran" (charge nothing), while the same None at other sites correctly means "unreadable /proc" (charge). Greppable shape: a helper with a documented fail-closed None branch called from a site where None has a different provenance. Also harvested: a mechanism merged without a test locking its positive arm (the cancellable queued future) is deletable without any suite failure — when reviewing a fix, check each new branch has a test that fails if the branch is removed.
