### PR TITLE
fix(stop): recognise a composed edition's gateway module

### DIFF
--- a/src/kiro_crew/port_resolution.py
+++ b/src/kiro_crew/port_resolution.py
@@ -32,6 +32,7 @@ in a test process it almost always is.
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import shlex
@@ -404,6 +405,45 @@ def _basename_stem(tok: str) -> str:
     return base
 
 
+@functools.lru_cache(maxsize=1)
+def _gateway_module_roots() -> frozenset[str]:
+    """Top-level module names a Kiro Crew gateway can be booted from with ``-m``.
+
+    Always ``kiro_crew``. A **composed edition** additionally boots from its
+    companion's own module: the companion registers a ``kirocrew.plugins`` entry
+    point, and its launcher execs ``-m <that module>`` so the composition root is
+    entered instead of the core CLI (execing ``-m kiro_crew`` skips the
+    companion's own ``cli.main``). Hardcoding ``kiro_crew`` therefore made
+    :func:`_args_look_like_kirocrew` reject the gateway of every composed
+    install, so ``kirocrew stop`` / ``restart`` filtered out the one listening
+    pid and reported "No Kiro Crew gateway currently running on port <p>".
+
+    Derived from the installed entry points rather than a hardcoded list of
+    edition names: core must not know any companion's module name, and a new
+    edition must not have to be added here.
+
+    ``plugin_entry_points`` is imported lazily — this module's leanness contract
+    (see the module docstring) forbids pulling the platform package at import
+    time, and only the ``stop`` / ``restart`` path needs this answer. Cached
+    because the caller asks once per candidate pid, and the entry-point set
+    cannot change inside one CLI process.
+    """
+    roots = {"kiro_crew"}
+    try:
+        from kiro_crew.platform.discovery import plugin_entry_points
+
+        for ep in plugin_entry_points():
+            # "kirocrew_amazon.compose:build_x" -> "kirocrew_amazon". Parsed from
+            # ``value`` rather than ``ep.module`` so a malformed entry cannot
+            # raise here: this only ever widens a best-effort match.
+            root = str(getattr(ep, "value", "")).split(":", 1)[0].split(".", 1)[0].strip()
+            if root:
+                roots.add(root)
+    except Exception:  # noqa: BLE001 -- a best-effort widening, never a hard gate
+        logging.getLogger(__name__).debug("composed gateway module discovery failed", exc_info=True)
+    return frozenset(roots)
+
+
 def _args_look_like_kirocrew(args: str) -> bool:
     """Return ``True`` if a process command-line *args* string is a Kiro Crew server.
 
@@ -422,6 +462,8 @@ def _args_look_like_kirocrew(args: str) -> bool:
       a service install and the launchd/systemd service), plus the legacy dotted
       form ``<python> -m kiro_crew.<subcmd>``. A Python interpreter must precede
       ``-m`` so we don't misread some other tool's ``-m`` flag (e.g. ``grep -m``).
+      A composed edition's own module counts too — see
+      :func:`_gateway_module_roots`.
     * **Console script** — ``/path/to/kirocrew <subcmd>`` (used when the
       ``kirocrew`` wrapper resolves on ``PATH``).
 
@@ -465,7 +507,7 @@ def _args_look_like_kirocrew(args: str) -> bool:
                 # "kiro_crew.gateway" -> ("kiro_crew", "gateway"); a bare
                 # "kiro_crew" -> ("kiro_crew", "").
                 package, _, dotted_subcmd = tokens[index + 1].partition(".")
-                if package == "kiro_crew":
+                if package in _gateway_module_roots():
                     # Dotted submodule form: ``-m kiro_crew.gateway``.
                     if dotted_subcmd in _KIROCREW_SERVER_SUBCOMMANDS:
                         return True

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2111,6 +2111,98 @@ class TestArgsLookLikeKirocrew:
         assert _args_look_like_kirocrew("python -m kiro_crew GATEWAY") is False
 
 
+class TestComposedEditionGatewayModule:
+    """A composed edition's gateway boots from the COMPANION's module.
+
+    Its launcher execs ``-m <companion module>`` so the composition root is
+    entered rather than the core CLI. Keying the classifier on the literal
+    ``kiro_crew`` made ``kirocrew stop`` / ``restart`` drop the one listening pid
+    and report "No Kiro Crew gateway currently running on port <p>" on every such
+    install — the port lookup found the gateway, the classifier rejected it, and
+    the graceful-API / lock-owner fallbacks never ran because they are reached
+    only when the port lookup itself comes back empty.
+    """
+
+    # The real argv observed on a composed install, verbatim.
+    COMPOSED_ARGV = (
+        "/opt/kirocrew/backend-dist/kirocrew-backend-arm64/bin/python3.12 "
+        "-s -m kirocrew_companion gateway --no-open --port 5476"
+    )
+
+    @staticmethod
+    def _entry_point(value):
+        class _EP:
+            def __init__(self, v):
+                self.value = v
+
+        return _EP(value)
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        from kiro_crew.port_resolution import _gateway_module_roots
+
+        _gateway_module_roots.cache_clear()
+        yield
+        _gateway_module_roots.cache_clear()
+
+    def test_composed_module_matches_when_companion_installed(self, monkeypatch):
+        from kiro_crew.cli_server import _args_look_like_kirocrew
+        from kiro_crew.platform import discovery
+
+        monkeypatch.setattr(
+            discovery,
+            "plugin_entry_points",
+            lambda: [self._entry_point("kirocrew_companion.compose:build_context")],
+        )
+        assert _args_look_like_kirocrew(self.COMPOSED_ARGV) is True
+
+    def test_composed_module_rejected_without_the_companion(self, monkeypatch):
+        """Precision is preserved: the widening comes from the INSTALLED entry
+        points, so a standalone host still refuses to signal that process."""
+        from kiro_crew.cli_server import _args_look_like_kirocrew
+        from kiro_crew.platform import discovery
+
+        monkeypatch.setattr(discovery, "plugin_entry_points", lambda: [])
+        assert _args_look_like_kirocrew(self.COMPOSED_ARGV) is False
+
+    def test_core_module_still_matches_with_a_companion_installed(self, monkeypatch):
+        from kiro_crew.cli_server import _args_look_like_kirocrew
+        from kiro_crew.platform import discovery
+
+        monkeypatch.setattr(
+            discovery,
+            "plugin_entry_points",
+            lambda: [self._entry_point("kirocrew_companion.compose:build_context")],
+        )
+        assert _args_look_like_kirocrew("python3 -m kiro_crew gateway") is True
+
+    def test_companion_module_without_a_server_subcommand_is_refused(self, monkeypatch):
+        """The subcommand gate still applies to the widened module set — a
+        companion task-runner process must never be SIGTERMed by ``stop``."""
+        from kiro_crew.cli_server import _args_look_like_kirocrew
+        from kiro_crew.platform import discovery
+
+        monkeypatch.setattr(
+            discovery,
+            "plugin_entry_points",
+            lambda: [self._entry_point("kirocrew_companion.compose:build_context")],
+        )
+        assert _args_look_like_kirocrew("python -m kirocrew_companion run /tmp/spec.md") is False
+
+    def test_discovery_failure_leaves_the_core_module_matching(self, monkeypatch):
+        """Entry-point discovery is best-effort: a raising probe must degrade to
+        the core module rather than making ``stop`` blind everywhere."""
+        from kiro_crew.cli_server import _args_look_like_kirocrew
+        from kiro_crew.platform import discovery
+
+        def _boom():
+            raise RuntimeError("metadata unreadable")
+
+        monkeypatch.setattr(discovery, "plugin_entry_points", _boom)
+        assert _args_look_like_kirocrew("python3 -m kiro_crew gateway") is True
+        assert _args_look_like_kirocrew(self.COMPOSED_ARGV) is False
+
+
 class TestStop:
     """Tests for _stop CLI function."""
 


### PR DESCRIPTION
## Problem / Motivation

On a **composed (non-standalone) install**, the client commands that stop and
restart the gateway say there is no gateway — while it is up, bound to the port,
and serving the dashboard:

```
No Kiro Crew gateway currently running on port 5476.
```

Exit 1. Reproduced on a live install. The port lookup is right; the classifier is
wrong:

```python
>>> platform_compat.find_listening_pids(5476)
[72559]
>>> cli_server._is_kirocrew_process(72559)
False
```

`_args_look_like_kirocrew` accepted one module name for the `-m` form:

```python
package, _, dotted_subcmd = tokens[index + 1].partition(".")
if package == "kiro_crew":
```

A composed edition's launcher runs `-m <companion module>` on purpose, so the
companion's composition root is entered instead of the core CLI. The argv on the
affected host was:

```
.../backend-dist/.../bin/python3.12 -s -m <companion> gateway --no-open --port 5476
```

`<companion>` is not `kiro_crew`, so the filter threw away the only listening pid.

## Why it matters

Two things make this worse than a missed match.

The pid filter runs **after** the graceful-shutdown and lock-owner fallbacks, and
those two are only reached when the port lookup itself finds nothing. Here it
found the gateway. So a classifier miss skips every fallback and lands on
"nothing running".

The restart path shares the same lookup. Its own comment already says a
mis-reported stop makes it start a second gateway.

## What changed (motivation → approach → change)

The symptom: a composed install cannot stop or restart its own gateway from the
CLI.

The cause: one hardcoded module name in a check that has to recognise every way
the gateway can be launched.

The change: read the accepted `-m` module names from the installed
`kirocrew.plugins` entry points. Core stays ignorant of any companion's module
name, and a new edition needs no edit here. That entry-point group is already how
core finds a composed edition at boot, so this reuses the existing seam.

```mermaid
flowchart LR
  subgraph Before
    A1[port lookup finds pid]:::ctx --> B1[package == kiro_crew]:::removed --> C1[pid dropped]:::removed --> D1[nothing running, exit 1]:::removed
  end
  subgraph After
    A2[port lookup finds pid]:::ctx --> B2[package in entry-point module roots]:::added --> C2[pid kept]:::added --> D2[gateway stops]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1,2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 3,4,5 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The check now asks the installed entry points which modules count, so a composed
edition's own gateway is recognised and actually stops.*

Three notes on the shape.

Precision does not drop. The widening comes only from entry points that are
really installed, and the server-subcommand gate still applies. A companion task
runner (`-m <companion> run /tmp/spec.md`) is still refused, and a standalone
host still refuses a `-m <companion>` process. Both are pinned by tests.

Discovery is best-effort. If the entry-point probe raises, the answer falls back
to `kiro_crew` alone rather than making the stop path blind everywhere.

`plugin_entry_points` is imported inside the function, not at module scope. This
module has a leanness contract — the MCP stdio server must not pay for the
platform package at import time, and `TestPortResolutionStaysLeaf` asserts it.
The answer is cached because the caller asks once per candidate pid.

## Tests

New `TestComposedEditionGatewayModule` in `test/test_cli.py`, five cases:

| Case | Expected |
|---|---|
| composed argv, companion entry point installed | matches |
| composed argv, no companion installed | refused |
| core `-m kiro_crew gateway` with a companion installed | still matches |
| `-m <companion> run /tmp/spec.md` | refused (subcommand gate) |
| entry-point discovery raises | core still matches, composed refused |

The first case fails on `main` and passes with this change. The two negatives are
what keep the widening from becoming a licence to signal any process.

```
404 passed, 2 skipped   # test/test_cli.py + test/test_mcp_api_port_resolution.py
```

## Manual verification

Ran the classifier against the real argv from the affected install, with the
companion's real entry point present:

```
roots: ['kiro_crew', '<companion>']
composed-edition argv matches: True
```

Also confirmed the leanness contract is unchanged: importing
`kiro_crew.port_resolution` pulls no `kiro_crew.cli_server`, same as on `main`.

## Screenshots / video

N/A — no user-visible UI change. The diff touches one backend module and its
tests; no watched frontend path is in it.

## Related Issues

no linked issue: found while debugging a live install, filed straight as a fix.

## Pattern harvest

Rule candidate: review-prompt
Pattern: core code hardcoding one package/module name where a composed edition
supplies its own, instead of reading the plugin entry points

The same shape can hide anywhere core has to recognise "our own process" or "our
own module" by name. The tell is a string literal equal to the core package name
in a predicate that must also hold for a companion.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
