### PR TITLE
fix(chat): keep the message when an intermediary answers the send

### DIFF
--- a/website/src/test/sendDelivery.test.ts
+++ b/website/src/test/sendDelivery.test.ts
@@ -118,3 +118,68 @@ describe('readSendReceipt', () => {
     }
   })
 })
+
+/**
+ * A 2xx an INTERMEDIARY wrote is not a receipt the endpoint wrote.
+ *
+ * An SSO/auth proxy whose session has lapsed answers the send POST itself, with a
+ * login page: a 2xx whose body is not JSON. That took `unknown`'s deliberately
+ * silent branch, so the composer — cleared at submit — dropped the user's text
+ * with no error row and nothing on screen saying so.
+ *
+ * The distinguishing evidence is PROVENANCE, never "the body would not parse":
+ * a truncated reply from the endpoint itself still means the turn may have run,
+ * and handing that payload back duplicates it (#4217 / #5672).
+ */
+describe('readSendReceipt provenance', () => {
+  const res = (
+    ok: boolean,
+    json: () => Promise<unknown>,
+    extra: { redirected?: boolean; contentType?: string } = {},
+  ) => ({
+    ok,
+    json,
+    redirected: extra.redirected,
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? extra.contentType ?? null : null) },
+  })
+  const notJson = () => Promise.reject(new Error('unexpected token < in JSON'))
+
+  it('refuses a 2xx the browser was REDIRECTED to, so the payload is handed back', async () => {
+    // `POST /api/chat` never redirects, so a redirected answer came from wherever
+    // the chain ended — a login form, not the gateway.
+    expect((await readSendReceipt(res(true, notJson, { redirected: true }))).outcome).toBe('refused')
+  })
+
+  it('refuses a 2xx that answers in HTML, the proxy shape with no redirect', async () => {
+    // Some proxies serve the login page directly on the original URL.
+    expect((await readSendReceipt(res(true, notJson, { contentType: 'text/html; charset=utf-8' }))).outcome).toBe('refused')
+    // Case and leading whitespace are the intermediary's choice, not a signal.
+    expect((await readSendReceipt(res(true, notJson, { contentType: ' TEXT/HTML' }))).outcome).toBe('refused')
+  })
+
+  it('KEEPS unknown for an unreadable 2xx from the endpoint itself (#5672 must not regress)', async () => {
+    // The truncated-JSON case: not redirected, and the content type is the
+    // endpoint's own. Delivery is plausible, so the payload must NOT come back.
+    expect((await readSendReceipt(res(true, notJson, { contentType: 'application/json' }))).outcome).toBe('unknown')
+    // No provenance information at all is also not evidence of interception.
+    expect((await readSendReceipt(res(true, notJson))).outcome).toBe('unknown')
+  })
+
+  it('leaves a readable receipt alone even when redirected', async () => {
+    // The check guards only the unreadable branch: a body that parsed is the
+    // endpoint's verdict and outranks any guess about who served it.
+    expect((await readSendReceipt(res(true, async () => ({ ok: true }), { redirected: true }))).outcome).toBe('accepted')
+  })
+
+  it('does not warn on the intercepted branch, which the user can now see', async () => {
+    // The console line exists for the branch that shows nothing. This one
+    // reports an error row and refills the composer, so it earns no warning.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      await readSendReceipt(res(true, notJson, { redirected: true }))
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/website/src/utils/sendDelivery.ts
+++ b/website/src/utils/sendDelivery.ts
@@ -21,9 +21,12 @@ export interface SendReceiptBody {
  *
  *  - `accepted` — the server said `ok` or `queued`; the message is its problem now.
  *  - `refused`  — the server said no, either in a readable body or with a non-2xx
- *                 status. Nothing was sent, so the payload is safe to hand back.
- *  - `unknown`  — the request was accepted (2xx) but its body could not be read.
- *                 The message may well have been delivered.
+ *                 status; or an intermediary answered in the endpoint's place, so
+ *                 the request never reached it. Nothing was sent, so the payload
+ *                 is safe to hand back.
+ *  - `unknown`  — the request was accepted (2xx) by the endpoint itself but its
+ *                 body could not be read. The message may well have been
+ *                 delivered, so the payload must NOT be handed back.
  */
 export type SendOutcome = 'accepted' | 'refused' | 'unknown'
 
@@ -34,10 +37,42 @@ export interface SendReceipt {
 }
 
 /** The part of `Response` a receipt is read from — narrowed so a test can stand
- *  one up without constructing a whole `Response`. */
+ *  one up without constructing a whole `Response`.
+ *
+ *  The two provenance members are OPTIONAL so every existing double stays valid;
+ *  a double that omits them reads as "not redirected, no content type", which is
+ *  the pre-existing behaviour. */
 export interface SendResponseLike {
   ok: boolean
   json(): Promise<unknown>
+  /** Whether the browser followed a redirect chain to produce this response. */
+  redirected?: boolean
+  headers?: { get(name: string): string | null }
+}
+
+/**
+ * Positive evidence that a 2xx response was written by an INTERMEDIARY rather
+ * than by the send endpoint — the shape an SSO/auth proxy produces once the
+ * browser's session with it has lapsed.
+ *
+ * Both signals are about PROVENANCE, not about content:
+ *
+ *   - `redirected` — the browser followed a redirect chain, so whatever answered
+ *     sits at the end of that chain. `POST /api/chat` never redirects, so a
+ *     redirected answer did not come from it.
+ *   - an HTML content type — the endpoint answers JSON on every path, refusals
+ *     included, so `text/html` is a page (a login form), not a receipt.
+ *
+ * Deliberately NOT "the body would not parse". That is `unknown`'s case and it
+ * stays exactly as it was: a TRUNCATED gateway reply to a POST that did run must
+ * keep its silence, because handing the payload back there duplicates a
+ * delivered turn (the regression #5672 fixed). Only a response the gateway
+ * demonstrably did not write is reclassified.
+ */
+function answeredByIntermediary(response: SendResponseLike): boolean {
+  if (response.redirected) return true
+  const contentType = response.headers?.get('content-type') ?? ''
+  return /^\s*text\/html\b/i.test(contentType)
 }
 
 /**
@@ -71,6 +106,16 @@ export async function readSendReceipt(response: SendResponseLike): Promise<SendR
   const body = readable ? (parsed as SendReceiptBody) : {}
   if (!response.ok) return { body, outcome: 'refused' }
   if (!readable) {
+    // An intermediary answered in the endpoint's place, so the POST never
+    // reached it. That is a refusal in the one sense every call site acts on —
+    // "nothing was sent, so the payload is safe to hand back" — and it is the
+    // difference between the composer keeping the user's text and dropping it.
+    //
+    // Without this, an auth proxy's login page (a 2xx that will not parse) took
+    // `unknown`'s silent branch: no error row, no banner, and a composer already
+    // cleared at submit, so the message was lost with nothing on screen saying
+    // so. `unknown` still owns the case it was written for, one line below.
+    if (answeredByIntermediary(response)) return { body, outcome: 'refused' }
     // The one outcome with NO user-facing trace, by design — so it needs a
     // diagnostic one, or an intermediary that mangles every receipt degrades
     // sends invisibly and leaves nobody anything to find. Console only: this


### PR DESCRIPTION
## What

A send whose response was written by an intermediary rather than by the send
endpoint now hands the payload back to the composer and reports, instead of
being silently swallowed.

- `readSendReceipt` separates "the endpoint accepted this and its reply is
  mangled" from "something else answered, so the endpoint never saw it".
- The second case is classified `refused`, whose contract already states the
  payload is safe to hand back. No call site changes.
- `unknown` keeps the case it was written for, so #5672 does not regress.

## Why

An SSO/auth proxy whose browser session has lapsed answers `POST /api/chat`
itself, with a login page: a 2xx whose body is not JSON. That took `unknown`'s
branch, and `unknown`'s contract is that callers do nothing, because an
unreadable 2xx from the endpoint may mean the turn already ran.

The composer is cleared at submit, so the result was the worst combination:
no error row, no banner, and the user's text gone. Reported symptom is that a
lapsed session silently eats every message typed until the page is reloaded.

The distinguishing evidence has to be provenance, not whether the body parses:

- `redirected` means the browser followed a chain, so the answer came from
  wherever that chain ended. `POST /api/chat` never redirects.
- an HTML content type means a page, not a receipt. The endpoint answers JSON
  on every path, refusals included.

An unreadable 2xx that is neither redirected nor HTML is still a plausibly
truncated reply from the endpoint itself. It still takes no action.

### Alternative rejected

Adding a distinct receipt status (`auth-intercepted`) and teaching each caller
about it. The six failure sites are if-chains rather than exhaustive switches,
so a status no site matched would fall through to the accepted tail and lose
the message anyway. Reusing `refused` cannot miss a site. Worth revisiting if a
caller ever needs to treat interception differently from a server refusal.

### Deliberately not in this PR

Auth-specific copy, and raising the existing re-auth banner on this path. That
banner's current string tells the reader to mint a fresh dashboard credential
with the CLI, which is correct for this product's own token auth and wrong for
a third-party SSO proxy. New copy means new catalog keys across 13 locales,
which does not belong in a message-loss fix. The user-visible result here is
the existing `send_failed` row plus the restored composer.

## Testing

- `npx vitest run`: 2025 files, 32181 passed, 1 expected fail, 2 skipped.
- `npx tsc -b`: clean.
- `npx eslint src --ext .ts,.tsx`: clean.
- `vite build`: succeeds.
- 5 new tests in `website/src/test/sendDelivery.test.ts`. Reverting only the
  implementation fails exactly the 3 behavioural ones and leaves the two guard
  tests (the #5672 regression guard and the readable-receipt guard) passing,
  which is the intended signature.

No UI recording is attached. The change is a classifier whose observable effect
needs a running gateway, and the OSS Python install fails on this host while
building numpy metadata. The proxy response also has to be simulated in any
case, since a real SSO proxy cannot be stood up locally.

## Unverified premise

The exact response shape a lapsed Midway session returns was not confirmed:
a followed 302 to a 200 login page fits the reported symptoms, and a bare
401/403 would already have handed the text back through the existing `refused`
path. Both observable shapes are covered here. `readSendReceipt` logs
`send receipt unreadable on an accepted response` on the old silent branch, so
seeing that line in devtools at the moment of loss confirms the diagnosis.
