### PR TITLE
fix: wait on the zombie watchdog's stop signal in the sharing-violation test (#9478)

### DIFF
--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -2112,10 +2112,34 @@ class TestZombieDiagnostic:
             return real_open(self, *args, **kwargs)
 
         monkeypatch.setattr(Path, "open", sharing_violation_open)
-        await asyncio.wait_for(
-            gw._zombie_diagnostic(cast(Any, server), BackendPool(max_backends=1), set(), stop),
-            timeout=5,
+        # Wait on the watchdog's own completion signal, not the coroutine: the
+        # watchdog swallows CancelledError, so on Python 3.11+ a timed-out
+        # ``asyncio.wait_for(coro, ...)`` cannot raise TimeoutError -- the
+        # cancellation never propagates, wait_for returns None, and the later
+        # assertions fail in misleading ways (FileNotFoundError on diag.jsonl
+        # or an unset stop event, depending on where the cancel landed). A
+        # genuinely slow runner now fails legibly at the bounded wait below.
+        task = asyncio.create_task(
+            gw._zombie_diagnostic(cast(Any, server), BackendPool(max_backends=1), set(), stop)
         )
+        stop_wait = asyncio.create_task(stop.wait())
+        try:
+            # Waiting on BOTH means a watchdog that raises before setting stop
+            # surfaces its exception immediately instead of hiding behind the
+            # full 30s budget.
+            done, _ = await asyncio.wait(
+                {task, stop_wait}, timeout=30, return_when=asyncio.FIRST_COMPLETED
+            )
+            assert done, "watchdog neither set stop nor finished within 30s"
+            if task in done:
+                await task  # surface any exception the watchdog raised
+        finally:
+            # Never leak the watchdog past monkeypatch teardown: cancel and
+            # drain whatever is still pending (the watchdog swallows
+            # CancelledError, so the drain terminates promptly).
+            task.cancel()
+            stop_wait.cancel()
+            await asyncio.gather(task, stop_wait, return_exceptions=True)
 
         records = [json.loads(line) for line in diag.read_text().strip().splitlines()]
         tags = [record["tag"] for record in records]


### PR DESCRIPTION
## Problem / Motivation

`test_zombie_dump_survives_a_windows_sharing_violation` fails non-deterministically on the `Backend Tests (Windows)` shard, in two confusing forms: a `FileNotFoundError` reading `diag.jsonl`, or `assert stop.is_set()` failing. It has redded unrelated PRs (#9213, #9223).

## Why it matters

A flaky required shard blocks merges that have nothing to do with the gateway watchdog. The two failure forms also point away from the real cause, so each occurrence costs a fresh investigation.

## What changed (motivation → approach → change)

The symptom: on a slow Windows runner the test's 5-second budget expires mid-run. The test drove the watchdog with `asyncio.wait_for(gw._zombie_diagnostic(...), timeout=5)`.

The root cause: the watchdog ends with `except asyncio.CancelledError: pass`. When `wait_for` times out it cancels the coroutine, the coroutine swallows the cancel and returns None, and on Python 3.11+ `wait_for` only raises `TimeoutError` when the cancellation actually propagates. So the timeout is silent. The test falls through to a downstream assertion, and which one fails depends on where the cancel landed: before the dump write gives form 1, between the write and `stop_event.set()` gives form 2. The dump itself is synchronous with respect to the coroutine (`await asyncio.to_thread(...)` then `stop_event.set()` then return), so this is a test-harness defect, not a Windows write defect.

The change: the test now creates the watchdog as a task and waits on the watchdog's own completion signal with `asyncio.wait({task, stop_wait}, timeout=30, return_when=FIRST_COMPLETED)`. Waiting on both means a watchdog that raises before setting `stop` surfaces its exception immediately instead of hiding behind the 30s budget. A `finally` cancels and drains both tasks so nothing leaks past monkeypatch teardown. A genuinely slow runner now fails legibly at the bounded wait with a named assertion instead of a misleading downstream error. Production code in `gatewayd.py` is unchanged; whether the watchdog should re-raise `CancelledError` is a separate design question.

The sibling tests were audited: `test_prefired_stop_event_writes_nothing` returns immediately and keeps its `wait_for` shape; `test_cancellation_is_swallowed` tests the swallow itself and is untouched; the other tests already use task-based shapes.

## Tests

This is a test-only change. It keeps the sharing-violation coverage intact (same `PermissionError`-on-second-open simulation, same assertions on `tags == ["probe", "zombie_detected"]` and `stop.is_set()`), and changes only how the test bounds and observes watchdog completion.

## Manual verification

The flake is Windows-only and non-deterministic, so a local green run proves little. The change removes the two misleading failure forms structurally and turns residual runner slowness into an explicit failure at the bounded wait under a 30s budget. CI (including the Windows shard) is the verification. Local isort/flake8/mypy pass.

## Related Issues

Closes #9478

## Pattern harvest

Rule candidate: review-prompt
Pattern: `asyncio.wait_for` around a coroutine that swallows `CancelledError` cannot report a timeout on Python 3.11+ — it returns None and downstream assertions fail misleadingly; wait on the code's own completion signal instead.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
