### PR TITLE
ci: pilot the CloudFormation Lint job on a CodeBuild-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1648,7 +1648,13 @@ jobs:
     # The templates it lints live under src/kiro_crew/deploy/, which the
     # paths-filter counts as backend, so a frontend-only diff cannot touch one.
     if: needs.changes.outputs.only_frontend != 'true'
-    runs-on: ubuntu-latest
+    # PILOT: this one job runs on a CodeBuild-hosted runner (project
+    # `kirocrew-gha-linux`, Ubuntu 22.04) instead of ubuntu-latest. Only runs
+    # inside kirodotdev/KiroCrew that are not fork PRs get the codebuild label;
+    # a fork's own CI and fork PRs stay on ubuntu-latest, because the runner
+    # never serves them. Rollback: `ubuntu-latest`. Policy, image caveat and
+    # exit condition: docs/ci/ci-and-reviews.md, "CodeBuild-hosted runner (pilot)".
+    runs-on: ${{ (github.repository != 'kirodotdev/KiroCrew' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)) && 'ubuntu-latest' || format('codebuild-kirocrew-gha-linux-{0}-{1}', github.run_id, github.run_attempt) }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -278,13 +278,68 @@ Every job here is blocking. Every job that costs real runner time also `needs:`
 | `electron-test` | The Electron shell's own node:test suite (`website/electron`) |
 | `frontend-test` | `vitest run --coverage` |
 | `frontend-coverage-merge` | Merges the frontend coverage shards so the gate reads one report |
-| `cfn-lint` | Lints the artifact-deploy templates with a pinned `cfn-lint` |
+| `cfn-lint` | Lints the artifact-deploy templates with a pinned `cfn-lint`. **Runs on the CodeBuild-hosted runner** (pilot, below) except for fork PRs |
 | `linux-packaging` | "Linux Packaging (build + smoke-install)". Builds all three Linux desktop formats from one backend tree through `packaging/build-desktop.sh`, then installs them in their target distros with `scripts/smoke-linux-packages.sh`. Path-filtered on the packaging surface |
 | `lockfile-engines-floor` | "Lockfile Installs On Declared Node Floor". Runs a real `npm ci` in `website/` on the LOWEST Node version `engines.node` declares, so a lockfile that only resolves under the newer npm major cannot land. The version is a literal pinned to that floor by `test_the_engines_floor_job_pins_the_declared_floor` rather than a range, because resolving a range picks the newest match and makes the job vacuous |
 | `bundle-size` | "Bundle Size Gate". Builds the frontend with `--mode analyze` (which is the only build that emits `dist/bundle-report.json`) and then runs TWO checks over that one build: per-chunk ceilings from `website/scripts/check-bundle-size.mjs`, with a 500 KB default for any chunk not named there, and an acyclic-graph check from `website/scripts/check-chunk-cycles.mjs`. The job name is narrower than its scope on purpose — it is a required check, so renaming it would silently stop satisfying branch protection. **An acyclic chunk graph is a deliberate invariant and the cycle check has no allowlist**, unlike the size ceilings: a chunk cycle has no valid initialization order, so a body can run against a binding that is still uninitialized and blank the page before React mounts, and whether a given cycle does that is not decidable from the chunk graph. Fix the chunking rather than waiving it. Skipped on a backend-only diff, which cannot change the bundle |
 | `e2e` | The i18n render-time gate, then `python setup.py test_e2e` |
 
 Details worth knowing:
+
+- **CodeBuild-hosted runner (pilot).** `cfn-lint` is the first job whose
+  `runs-on` is not a GitHub-hosted label but
+  `codebuild-kirocrew-gha-linux-${{ github.run_id }}-${{ github.run_attempt }}`:
+  an AWS CodeBuild project subscribed to this repository's `workflow_job` webhook
+  starts one ephemeral self-hosted runner per queued job, runs that single job,
+  and terminates. Why: at peak the repository's `ubuntu-latest` queue holds a
+  30-second job for 13 minutes (measured 2026-09-11 on this job: mean queue 155 s,
+  max 788 s, 6 of 29 runs over five minutes), and the repository is ~99% of the
+  org's Actions consumption, so the wait is a fair-use ceiling no workflow change
+  can lift. The runner infrastructure (project, role, webhook filters) is
+  modelled in the maintainers' internal `KiroCrewPublishCDK` package, not here.
+  Three things to know when touching it:
+  - **Forks never see it.** The `runs-on` value is an expression: a run in any
+    repository other than `kirodotdev/KiroCrew` (a fork's own CI on its `main`),
+    or a `pull_request` whose head repository is not this one, gets
+    `ubuntu-latest`; everything else gets the CodeBuild label. The webhook on the AWS side is
+    additionally filtered to runs triggered by accounts that can push to this
+    repository (plus dependabot), so a fork PR that rewrites its workflow to force
+    the label never starts a build — its job simply never gets a runner. The
+    `workflow_job` payload carries no "from a fork" bit, which is why both layers
+    exist rather than one.
+  - **The image is not `ubuntu-latest`.** It is `aws/codebuild/standard:7.0`
+    (Ubuntu 22.04). Anything a job assumed pre-installed must come from a
+    `setup-*` action; `cfn-lint` already installs its own Python. Moving another
+    job here means checking that first.
+  - **Rollback is one line:** set `runs-on` back to `ubuntu-latest`. A CodeBuild
+    project that receives webhooks for jobs it does not match starts nothing.
+  - **A queued job is not bounded by `timeout-minutes`.** That budget starts when a
+    runner picks the job up. A job whose log shows the `codebuild-…` label and no
+    runner means the webhook did not start a build — the project name in the label
+    does not match, or the triggering account is not on the allowlist (a new
+    maintainer's first push) — and it will sit *queued* until GitHub's own
+    ~24-hour pending limit, blocking that PR's `PR Readiness` the whole time with
+    no in-repo signal. The response is the rollback above, not waiting for the
+    timeout; the allowlist and the project name are fixed on the infrastructure
+    side, not in this file.
+  - **Trust model.** A self-hosted runner exposes its host identity to the job it
+    runs; that is inherent, not something this PR adds. What bounds it: only runs
+    triggered by accounts that can push here reach the runner (forks never do);
+    the runner role can write one log group and mint a GitHub token from one
+    connection, nothing else, in an account holding nothing else; and an alert fires on
+    any token minted through that connection by anything other than CodeBuild's own
+    runner registration. The residual — a job step minting a GitHub App token whose
+    repository permissions may exceed a writer's — is detected, not prevented.
+    Two recommended controls are **not yet in place**: an organization-level
+    ruleset on `main` whose bypass excludes GitHub Apps (drafted; needs an org
+    owner), and a check that the App installation is scoped to this repository
+    alone (needs repository-settings access).
+  - **Pilot exit condition.** The pilot ends on whichever comes first: **50
+    non-fork `CI` runs** on this job or **2026-10-10**. Expand to more Linux jobs
+    only if the median queue-to-start on CodeBuild is under 60 s and no run waited
+    longer than the hosted baseline's mean (155 s) for a runner; otherwise roll it
+    back. Either way the outcome is recorded here so this entry does not become a
+    permanent one-off.
 
 - **The macOS peer-identity canary is asserted by name.** `pytest -q` does not name
   passing tests and a skip exits 0, so a canary that quietly stopped running (a


### PR DESCRIPTION
## Summary

Pilot: route exactly **one** CI job, `cfn-lint` (CloudFormation Lint), off `ubuntu-latest` onto a CodeBuild-hosted GitHub Actions runner. No other job changes. The runner infrastructure (CodeBuild project `kirocrew-gha-linux`, its role, the webhook and its filters) is modelled in the maintainers' internal CDK package, not in this repository.

## Why

GitHub-hosted `ubuntu-latest` queueing on this repository, measured 2026-09-11 on this very job across the 29 completed `CI` runs that day:

| | |
|---|---|
| mean queue (created → started) | **155 s** |
| max queue | **788 s (13 min)** |
| runs waiting > 5 min | 6 of 29 |
| actual job work | ~31 s |

The repository is ~99% of the org's Actions consumption (~48K runs/day); the queue is a fair-use ceiling no workflow change can lift. `cfn-lint` was picked because it is pure Linux, touches no secrets, needs nothing pre-installed (it brings its own Python), and finishes in seconds — so the measurement is clean and the blast radius is one lint job.

## What changed

- `.github/workflows/ci.yml` — `cfn-lint.runs-on` becomes an expression: fork PRs → `ubuntu-latest`, everything else → `codebuild-kirocrew-gha-linux-${{ github.run_id }}-${{ github.run_attempt }}`. Comment block explains why, the fork policy and the rollback.
- `docs/ci/ci-and-reviews.md` — table row + a "CodeBuild-hosted runner (pilot)" entry under *Details worth knowing*: fork policy, the image is Ubuntu 22.04 not `ubuntu-latest`, rollback, how to read a hung job.

## Fork PR policy

The `workflow_job` webhook payload carries no "from a fork" bit, and none of the filters CodeBuild offers for `WORKFLOW_JOB_QUEUED` can express it (`HEAD_REF` is the PR head branch *name*, identical for fork and same-repo branches; repo/org-name filters only apply to org webhooks and always name this repo). So two layers:

1. **Here** — the `runs-on` expression keeps a fork PR's job on `ubuntu-latest`. Outside contributors never notice the runner exists.
2. **AWS side** — the webhook is filtered by `ACTOR_ACCOUNT_ID` to the accounts that can push to this repository (write/maintain/admin collaborators) plus `dependabot[bot]`. A fork PR that rewrites its workflow to force the codebuild label never starts a build; its job just never gets a runner. (`fork-workflow-guard` already holds fork PRs that touch `.github/workflows` for maintainer approval.)

Cost of layer 2: a new maintainer's `cfn-lint` job hangs until their account id is added on the infrastructure side. Deliberate.

## Trust model & mitigations

A self-hosted runner exposes its host identity to the job it runs. That is inherent to CodeBuild-hosted runners (and any self-hosted runner with an instance role), not something this PR adds; what this PR controls is who can get a step there and what the identity can do.

| | |
|---|---|
| Who reaches the runner | Only runs triggered by write/maintain/admin collaborators + `dependabot[bot]` (`ACTOR_ACCOUNT_ID` webhook filter). Forks — a fork's own CI and fork PRs — are routed to `ubuntu-latest` by the `runs-on` expression and are refused on the AWS side even if they rewrite the workflow. A same-repo PR author is an org member who already holds write on this repo |
| What the role can do | Write one CloudWatch log group; `GetConnectionToken` / `GetConnection` on one connection. No S3 / STS / IAM / KMS / Secrets Manager; no managed policies; trust pinned to the project ARN; dedicated AWS account holding nothing else |
| Residual | A step could mint a GitHub App installation token through the connection; the App's repository permissions can exceed a writer's |
| Detected by | **CloudTrail alert** (deployed): any `GetConnectionToken` on this connection whose user agent is not CodeBuild's control plane (`Coral/…`) → SNS → team e-mail, from any principal |
| Recommended, **not done** | **Org ruleset on `main`** (PR + review + `PR Readiness` required, no force-push/deletion, bypass = Organization Admin only, no App, no repo role) so such a token could not land code on `main` nor edit the guard — JSON drafted, needs an org owner · **App installation scope** confirmed single-repository and its Administration permission reviewed — not verified |

The residual is detected, not prevented, until the two recommended controls land.

## How it was verified

This PR's own CI run is the test: on the first head the `CloudFormation Lint` job was picked up by a CodeBuild runner — `Runner name: 72a4dfff-ed67-46e4-bba0-17f91d43ec30` (= the CodeBuild build id), working dir `/codebuild/output/…`, job queued → runner started in **18 s** (vs hosted mean 155 s / max 788 s), execution 40 s, ≈ US$0.01 per run. Full evidence and timings are in the first review-thread comment.

Static gates run locally: `scripts/check_brand_name.py` (clean), `scripts/docs-lint.sh` (all checks passed), YAML parse of the expression.

## Rollback

Set `runs-on` back to `ubuntu-latest`. The CodeBuild project can stay: a project whose webhook sees no matching label starts nothing and costs nothing.

## UX CONCERNS

none (CI-only)
