### PR TITLE
ci(dmg): detach by device node and treat an already-ejected volume as success

### DIFF
--- a/packaging/signing/README.md
+++ b/packaging/signing/README.md
@@ -31,9 +31,20 @@ trigger macOS Gatekeeper warnings).
   the freshly-copied app and can hold the volume against ejection ("Resource
   busy") — the same transient class electron-builder retries on. The script
   layers its defenses: `-nobrowse` keeps the volume out of Finder, and the
-  eject gets bounded retries with a synced force fallback. hdiutil calls run without `-quiet`, because
+  eject gets bounded retries with a synced force fallback (see
+  `hdiutil-detach.sh`). hdiutil calls run without `-quiet`, because
   that flag suppresses stderr too and previously reduced failures of this
   script to bare exit codes.
+- `hdiutil-detach.sh` — the detach retry loop `build-dmg.sh` sources. It
+  addresses the device node (`/dev/diskN`, read from `hdiutil attach -plist`)
+  rather than the mount path, and after every failed attempt asks `hdiutil info`
+  whether the device is still attached instead of trusting the exit status.
+  `hdiutil detach` unmounts and then ejects, and reports "Resource busy" when
+  only the eject is held — at which point the mount path is already gone, so a
+  path-addressed retry can only ever answer "No such file or directory". A
+  device that is no longer attached counts as detached however that came about;
+  a device that survives `-force` is still a hard failure. `test/test_hdiutil_detach.py`
+  drills the loop against a scripted fake `hdiutil`.
 
   The branded background is a **volume-bound alias recorded inside `.DS_Store`**,
   which is why the image is reused rather than rebuilt from a folder: recreating

--- a/packaging/signing/build-dmg.sh
+++ b/packaging/signing/build-dmg.sh
@@ -25,12 +25,23 @@ if [ ! -d "$app_path" ] || [[ "$app_path" != *.app ]]; then
   exit 1
 fi
 
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=hdiutil-detach.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hdiutil-detach.sh"
+
 scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kirocrew-dmg.XXXXXX")"
 mount_dir="$scratch_dir/mount"
 read_write_image="$scratch_dir/layout-rw.dmg"
-mounted=0
+# Whole-disk device node of the currently attached image (empty when none).
+# Detach is always addressed to this node, never to $mount_dir: the mount path
+# disappears as soon as the volume is unmounted, while the device stays attached
+# until the eject completes -- see hdiutil-detach.sh.
+device=""
 cleanup() {
-  if [ "$mounted" -eq 1 ]; then
+  if [ -n "$device" ]; then
+    hdiutil detach "$device" -force >/dev/null 2>&1 || true
+  else
+    # Covers the window between a successful attach and reading its device.
     hdiutil detach "$mount_dir" -force >/dev/null 2>&1 || true
   fi
   rm -rf -- "$scratch_dir"
@@ -45,25 +56,24 @@ trap cleanup EXIT
 # is layered rather than absolute: keep the volume out of Finder (-nobrowse
 # at both attach sites) and give the eject bounded retries with a force
 # fallback. electron-builder classifies hdiutil's "Resource busy" as
-# transient-retry for the same reason.
+# transient-retry for the same reason. The retry loop itself lives in
+# hdiutil-detach.sh; it addresses the device node and treats "no longer
+# attached" as success, because a busy verdict can come from an eject that
+# still completes on its own.
+attach_image() {
+  local plist
+  plist="$(hdiutil attach "$@" -plist)"
+  device="$(dmg_device_from_attach_plist "$plist")"
+}
+
 detach_mount() {
   # Flush first so a force-detach on the final attempt cannot lose writes.
   # Force is acceptable here because every write we issued has completed and
   # synced, and the resize/convert/verification stages that follow re-read the
   # image and fail loudly on a damaged filesystem.
   sync
-  local attempt
-  for attempt in 1 2 3 4 5; do
-    if hdiutil detach "$mount_dir"; then
-      mounted=0
-      return 0
-    fi
-    echo "WARN: detach of $mount_dir failed (attempt ${attempt}/5); retrying" >&2
-    sleep $((attempt * 3))
-  done
-  echo "WARN: detach still busy after 5 attempts; forcing" >&2
-  hdiutil detach "$mount_dir" -force
-  mounted=0
+  dmg_detach_device "$device"
+  device=""
 }
 
 mkdir -p "$mount_dir" "$(dirname "$output_path")"
@@ -100,9 +110,8 @@ if [ "$expanded_sectors" -gt "$maximum_sectors" ]; then
 fi
 hdiutil resize -sectors "$expanded_sectors" "$read_write_image" >/dev/null
 
-hdiutil attach -readwrite -noverify -noautoopen -nobrowse \
-  -mountpoint "$mount_dir" "$read_write_image" >/dev/null
-mounted=1
+attach_image -readwrite -noverify -noautoopen -nobrowse \
+  -mountpoint "$mount_dir" "$read_write_image"
 
 # The background is a volume-bound alias recorded INSIDE .DS_Store, so that file
 # is the layout. Fingerprint the template's copy now, while it is still the one
@@ -148,9 +157,8 @@ hdiutil convert "$read_write_image" -format UDZO -o "$output_path" -ov >/dev/nul
 # available on a runner re-renders the window, so the definitive check is the
 # first real signing run -- see README.md, which also names the plan-B that
 # removes this question entirely.
-hdiutil attach -readonly -noverify -noautoopen -nobrowse \
-  -mountpoint "$mount_dir" "$output_path" >/dev/null
-mounted=1
+attach_image -readonly -noverify -noautoopen -nobrowse \
+  -mountpoint "$mount_dir" "$output_path"
 missing=()
 [ -f "$mount_dir/.DS_Store" ] || missing+=(".DS_Store (Finder icon placement)")
 if [ ! -e "$mount_dir/.background.tiff" ] && [ ! -d "$mount_dir/.background" ]; then

--- a/packaging/signing/hdiutil-detach.sh
+++ b/packaging/signing/hdiutil-detach.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Detach helpers for disk images mounted by hdiutil. Sourced by build-dmg.sh.
+#
+# The helpers address the device node (/dev/diskN) that `hdiutil attach`
+# reports, never the mount path. `hdiutil detach` is two operations -- unmount
+# the volume, then eject the device -- and it exits non-zero if EITHER fails.
+# When Spotlight or XProtect hold the volume, the unmount can succeed while the
+# eject reports "Resource busy": the mount path is gone, the device is still
+# attached. A retry addressed by mount path then fails with "No such file or
+# directory" on every attempt, force included, and the caller reads a volume
+# that is already unmounted as a failure. Addressing the device keeps every
+# retry meaningful, and asking hdiutil whether the device is still attached
+# (rather than trusting the exit status alone) recognises the eject that
+# completed asynchronously after a busy verdict.
+#
+# Tuning knobs (defaults are production values; drills shorten them):
+#   DMG_DETACH_ATTEMPTS         plain detach attempts before -force (5)
+#   DMG_DETACH_RETRY_BASE_SECS  sleep after attempt N is N * this many seconds (3)
+
+# Print the whole-disk device node from `hdiutil attach -plist` output.
+# Every attached image reports its whole disk plus one dev-entry per slice;
+# the whole disk is the node without a slice suffix. Fails loudly rather than
+# returning an empty string, because an empty device would turn every detach
+# below into a no-op that reports success.
+dmg_device_from_attach_plist() {
+  local plist="$1" device
+  # Newlines are dropped first so the key/value pair matches whether hdiutil
+  # prints it on one line or, as it does, indented across two.
+  device="$(printf '%s' "$plist" | tr -d '\n' | awk '
+    {
+      rest = $0
+      while (match(rest, /<key>dev-entry<\/key>[[:space:]]*<string>[^<]*<\/string>/)) {
+        entry = substr(rest, RSTART, RLENGTH)
+        sub(/.*<string>/, "", entry); sub(/<\/string>.*/, "", entry)
+        if (entry ~ /^\/dev\/disk[0-9]+$/) { print entry; exit }
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+    }
+  ')"
+  if [ -z "$device" ]; then
+    echo "ERROR: could not find the whole-disk dev-entry in hdiutil attach output" >&2
+    printf 'hdiutil said: %s\n' "$plist" >&2
+    return 1
+  fi
+  printf '%s\n' "$device"
+}
+
+# Succeed while the device (or any of its slices) is still listed by hdiutil.
+# If hdiutil itself cannot answer, assume the device IS still attached: the
+# only consequence is another detach attempt, whereas the opposite guess would
+# report success over a volume that is still held.
+dmg_device_attached() {
+  local device="$1" info
+  if ! info="$(hdiutil info -plist 2>/dev/null)"; then
+    return 0
+  fi
+  printf '%s\n' "$info" | grep -Eq "<string>${device}(s[0-9]+)?</string>"
+}
+
+# Detach the device with bounded retries and a force fallback. Returns 0 as
+# soon as the device is no longer attached, however that came about.
+#
+# Callers flush their writes first (`sync`), so a force on the final attempt
+# cannot lose data; the resize/convert/verification stages that follow re-read
+# the image and fail loudly on a damaged filesystem.
+dmg_detach_device() {
+  local device="$1"
+  local attempts="${DMG_DETACH_ATTEMPTS:-5}"
+  local retry_base="${DMG_DETACH_RETRY_BASE_SECS:-3}"
+  local attempt
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if hdiutil detach "$device"; then
+      return 0
+    fi
+    if ! dmg_device_attached "$device"; then
+      echo "NOTE: $device is no longer attached after a failed detach (attempt ${attempt}/${attempts}); treating as detached" >&2
+      return 0
+    fi
+    echo "WARN: detach of $device failed (attempt ${attempt}/${attempts}); retrying" >&2
+    sleep $((attempt * retry_base))
+  done
+  echo "WARN: detach still busy after ${attempts} attempts; forcing" >&2
+  if hdiutil detach "$device" -force; then
+    return 0
+  fi
+  if ! dmg_device_attached "$device"; then
+    echo "NOTE: $device is no longer attached after a failed forced detach; treating as detached" >&2
+    return 0
+  fi
+  echo "ERROR: $device is still attached after a forced detach" >&2
+  return 1
+}

--- a/test/test_hdiutil_detach.py
+++ b/test/test_hdiutil_detach.py
@@ -1,0 +1,226 @@
+"""Detach drills for ``packaging/signing/hdiutil-detach.sh``.
+
+``hdiutil detach`` unmounts the volume and then ejects the device, and exits
+non-zero when either half fails.  Under Spotlight/XProtect load the unmount
+can succeed while the eject reports "Resource busy", or the eject can finish
+on its own moments after that verdict.  A retry loop that trusts the exit
+status alone, or that addresses the mount path, then fails every attempt
+against a volume that is already gone.  These drills stand in a fake
+``hdiutil`` whose behaviour is scripted per scenario and assert the helper's
+verdict against the device's real attachment state rather than the last exit
+code.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SIGNING_DIR = Path(__file__).resolve().parents[1] / "packaging" / "signing"
+LIBRARY = SIGNING_DIR / "hdiutil-detach.sh"
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="hdiutil-detach.sh is a Bash library for the macOS signing runner",
+)
+
+DEVICE = "/dev/disk5"
+
+# The fake keeps the device's attachment state in $FAKE_STATE_DIR/attached and
+# counts detach calls in $FAKE_STATE_DIR/calls.  `hdiutil info -plist` reports
+# the device (and its slice) only while the marker file exists.  The detach
+# behaviour is chosen by $FAKE_SCENARIO.
+FAKE_HDIUTIL = r"""#!/usr/bin/env bash
+set -u
+state="$FAKE_STATE_DIR"
+case "$1" in
+  info)
+    echo '<plist><dict><key>images</key><array>'
+    if [ -e "$state/attached" ]; then
+      echo '<dict><key>system-entities</key><array>'
+      echo '<dict><key>dev-entry</key><string>/dev/disk5</string></dict>'
+      echo '<dict><key>dev-entry</key><string>/dev/disk5s1</string>'
+      echo '<key>mount-point</key><string>/tmp/fake-mount</string></dict>'
+      echo '</array></dict>'
+    fi
+    echo '</array></dict></plist>'
+    exit 0
+    ;;
+  detach)
+    target="$2"
+    force=0
+    [ "${3:-}" = "-force" ] && force=1
+    n=$(( $(cat "$state/calls" 2>/dev/null || echo 0) + 1 ))
+    echo "$n" > "$state/calls"
+    echo "$target${3:+ $3}" >> "$state/targets"
+    if [ ! -e "$state/attached" ]; then
+      echo "hdiutil: detach failed - No such file or directory" >&2
+      exit 1
+    fi
+    case "$FAKE_SCENARIO" in
+      clean)
+        rm -f "$state/attached"; exit 0 ;;
+      busy-then-gone)
+        # First verdict is busy, but the eject completes on its own right after.
+        rm -f "$state/attached"
+        echo 'hdiutil: couldn'"'"'t eject "disk5" - Resource busy' >&2
+        exit 1 ;;
+      busy-until-force)
+        if [ "$force" -eq 1 ]; then rm -f "$state/attached"; exit 0; fi
+        echo 'hdiutil: couldn'"'"'t eject "disk5" - Resource busy' >&2
+        exit 1 ;;
+      always-busy)
+        echo 'hdiutil: couldn'"'"'t eject "disk5" - Resource busy' >&2
+        exit 1 ;;
+      *)
+        echo "fake hdiutil: unknown scenario $FAKE_SCENARIO" >&2; exit 99 ;;
+    esac
+    ;;
+  *)
+    echo "fake hdiutil: unexpected verb $1" >&2
+    exit 99
+    ;;
+esac
+"""
+
+
+def _run_detach(tmp_path: Path, scenario: str) -> tuple[subprocess.CompletedProcess[str], Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "hdiutil"
+    fake.write_text(FAKE_HDIUTIL, encoding="utf-8")
+    fake.chmod(0o755)
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "attached").touch()
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env.update(
+        FAKE_STATE_DIR=str(state),
+        FAKE_SCENARIO=scenario,
+        DMG_DETACH_ATTEMPTS="3",
+        DMG_DETACH_RETRY_BASE_SECS="0",
+    )
+    proc = subprocess.run(
+        ["bash", "-c", 'source "$1" && dmg_detach_device "$2"', "drill", str(LIBRARY), DEVICE],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    return proc, state
+
+
+def _targets(state: Path) -> list[str]:
+    return (state / "targets").read_text(encoding="utf-8").splitlines()
+
+
+def test_clean_detach_succeeds_first_try(tmp_path: Path) -> None:
+    proc, state = _run_detach(tmp_path, "clean")
+    assert proc.returncode == 0, proc.stderr
+    assert _targets(state) == [DEVICE]
+    assert not (state / "attached").exists()
+
+
+def test_busy_verdict_over_an_eject_that_completed_is_success(tmp_path: Path) -> None:
+    # The nightly failure shape: attempt 1 says "Resource busy" but the device
+    # is gone by the time we look.  No retry, no force, exit 0.
+    proc, state = _run_detach(tmp_path, "busy-then-gone")
+    assert proc.returncode == 0, proc.stderr
+    assert _targets(state) == [DEVICE]
+    assert "no longer attached after a failed detach (attempt 1/3)" in proc.stderr
+
+
+def test_persistent_busy_falls_through_to_force(tmp_path: Path) -> None:
+    proc, state = _run_detach(tmp_path, "busy-until-force")
+    assert proc.returncode == 0, proc.stderr
+    # Three plain attempts, then exactly one -force, every one on the device node.
+    assert _targets(state) == [DEVICE, DEVICE, DEVICE, f"{DEVICE} -force"]
+    assert "forcing" in proc.stderr
+    assert not (state / "attached").exists()
+
+
+def test_still_attached_after_force_is_a_failure(tmp_path: Path) -> None:
+    # Fail-closed: a device that survives -force is reported, not papered over.
+    proc, state = _run_detach(tmp_path, "always-busy")
+    assert proc.returncode == 1, proc.stderr
+    assert _targets(state) == [DEVICE, DEVICE, DEVICE, f"{DEVICE} -force"]
+    assert "still attached after a forced detach" in proc.stderr
+    assert (state / "attached").exists()
+
+
+@pytest.mark.parametrize(
+    ("plist", "expected"),
+    [
+        (
+            "<plist><dict><key>system-entities</key><array>"
+            "<dict><key>dev-entry</key><string>/dev/disk7</string></dict>"
+            "<dict><key>dev-entry</key><string>/dev/disk7s1</string>"
+            "<key>mount-point</key><string>/tmp/m</string></dict>"
+            "</array></dict></plist>",
+            "/dev/disk7",
+        ),
+        (
+            # The shape hdiutil actually prints: one key/value pair per line, tab-indented.
+            '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n'
+            "\t<key>system-entities</key>\n\t<array>\n\t\t<dict>\n"
+            "\t\t\t<key>content-hint</key>\n\t\t\t<string>GUID_partition_scheme</string>\n"
+            "\t\t\t<key>dev-entry</key>\n\t\t\t<string>/dev/disk5</string>\n\t\t</dict>\n"
+            "\t\t<dict>\n\t\t\t<key>dev-entry</key>\n\t\t\t<string>/dev/disk5s1</string>\n"
+            "\t\t\t<key>mount-point</key>\n\t\t\t<string>/private/tmp/kirocrew-dmg.x/mount</string>\n"
+            "\t\t</dict>\n\t</array>\n</dict>\n</plist>\n",
+            "/dev/disk5",
+        ),
+        (
+            # Slice listed before the whole disk: the whole disk still wins.
+            "<dict><key>dev-entry</key><string>/dev/disk12s2</string></dict>"
+            "<dict><key>dev-entry</key><string>/dev/disk12</string></dict>",
+            "/dev/disk12",
+        ),
+    ],
+)
+def test_device_is_read_from_the_attach_plist(tmp_path: Path, plist: str, expected: str) -> None:
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1" && dmg_device_from_attach_plist "$2"',
+            "drill",
+            str(LIBRARY),
+            plist,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == expected
+
+
+def test_missing_device_in_attach_plist_fails_loudly(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1" && dmg_device_from_attach_plist "$2"',
+            "drill",
+            str(LIBRARY),
+            "<plist/>",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+    assert proc.returncode == 1
+    assert proc.stdout == ""
+    assert "could not find the whole-disk dev-entry" in proc.stderr


### PR DESCRIPTION
## Problem / Motivation

The nightly macOS lane failed in `Build DMG from stapled app` in [run 34660309256](https://github.com/kirodotdev/KiroCrew/actions/runs/34660309256) **after** notarization had Accepted and stapled the app. `build-dmg.sh`'s `detach_mount` loop logged, in order: `couldn't eject "disk5" - Resource busy` (attempt 1), then `detach failed - No such file or directory` on attempts 2-5 **and** on the `-force` fallback, then exit 1. `Publish to distribution` was skipped; every other platform shipped.

## Why it matters

The signed, notarized, stapled build was discarded over a volume that was already unmounted. The busy-eject race is expected and mitigated (`-nobrowse`, bounded retries, force fallback) -- but the retry loop that exists to absorb it misreads the most common outcome of that race as a failure, so the mitigation cannot actually save the run.

## What changed (motivation → approach → change)

Symptom: five failed detaches plus a failed force, all `No such file or directory`.

Root cause: `hdiutil detach` unmounts the volume and then ejects the device, and exits non-zero when **either** half fails. Attempt 1's `couldn't eject ... Resource busy` means the unmount succeeded and only the eject was held. From then on the mount path no longer exists, and every retry -- including `-force` -- was addressed **by mount path**, so none of them could act on the still-attached device, and success was judged by exit status alone, never by asking whether the device was actually still there.

Approach: address the device node, and let the device's real attachment state decide the verdict.

Change:

- New `packaging/signing/hdiutil-detach.sh` (sourced by `build-dmg.sh`; the notarize job's `sparse-checkout: packaging/signing` picks it up):
  - `dmg_device_from_attach_plist`: reads the whole-disk `/dev/diskN` from `hdiutil attach -plist` output. Fails loudly on no match, because an empty device would turn every detach into a no-op that reports success.
  - `dmg_device_attached`: `hdiutil info -plist` lists the device or one of its slices. If `hdiutil info` itself fails, the answer is "attached" (fail-closed: the only cost is another attempt).
  - `dmg_detach_device`: bounded plain attempts on the device node, then `-force`. After **every** failed attempt (force included) it checks attachment; a device that is gone is success however that came about. A device still attached after `-force` is a hard failure (exit 1), unchanged semantics.
  - Knobs `DMG_DETACH_ATTEMPTS` (5) / `DMG_DETACH_RETRY_BASE_SECS` (3) keep production timing identical; the drill shortens them.
- `packaging/signing/build-dmg.sh`: both `hdiutil attach` sites go through `attach_image`, which records the device; `detach_mount` is `sync` + `dmg_detach_device "$device"`; the EXIT-trap cleanup force-detaches by device too (falls back to the mount path only in the window before the device is known). No change to the resize/convert/`.DS_Store` fingerprint logic.
- `packaging/signing/README.md`: entry for the new file.
- `test/test_hdiutil_detach.py`: pytest drills against a scripted fake `hdiutil` (skipped on Windows).

## Tests

`test/test_hdiutil_detach.py` -- 8 tests, all pass locally (`pytest test/test_hdiutil_detach.py`):

```
test_clean_detach_succeeds_first_try PASSED
test_busy_verdict_over_an_eject_that_completed_is_success PASSED
test_persistent_busy_falls_through_to_force PASSED
test_still_attached_after_force_is_a_failure PASSED
test_device_is_read_from_the_attach_plist[single-line plist] PASSED
test_device_is_read_from_the_attach_plist[hdiutil's real tab-indented multi-line shape] PASSED
test_device_is_read_from_the_attach_plist[slice listed before whole disk] PASSED
test_missing_device_in_attach_plist_fails_loudly PASSED
```

The tests assert on the fake's call log (every attempt addressed to `/dev/disk5`, exactly one `-force`), the verdict, and the device's attachment state afterwards -- not only on exit codes.

## Manual verification

A real `hdiutil` cannot be exercised from a PR, so verification is static checks plus a shell drill of the library against the fake:

- `bash -n` on both scripts → OK
- `shellcheck -x -s bash packaging/signing/build-dmg.sh` and `shellcheck -s bash packaging/signing/hdiutil-detach.sh` (ShellCheck 0.11.0) → clean
- `black` / `flake8` / `isort` / `mypy` on the test file → clean
- Drill (`DMG_DETACH_ATTEMPTS=3 DMG_DETACH_RETRY_BASE_SECS=0`), four scenarios; `busy-then-gone` is the nightly's shape:

```
=============== scenario: clean
  [fake hdiutil] detach /dev/disk5
>>> exit 0, device still attached afterwards: no
=============== scenario: busy-then-gone
  [fake hdiutil] detach /dev/disk5
hdiutil: couldn't eject "disk5" - Resource busy
NOTE: /dev/disk5 is no longer attached after a failed detach (attempt 1/3); treating as detached
>>> exit 0, device still attached afterwards: no
=============== scenario: busy-until-force
  [fake hdiutil] detach /dev/disk5
hdiutil: couldn't eject "disk5" - Resource busy
WARN: detach of /dev/disk5 failed (attempt 1/3); retrying
  [fake hdiutil] detach /dev/disk5
hdiutil: couldn't eject "disk5" - Resource busy
WARN: detach of /dev/disk5 failed (attempt 2/3); retrying
  [fake hdiutil] detach /dev/disk5
hdiutil: couldn't eject "disk5" - Resource busy
WARN: detach of /dev/disk5 failed (attempt 3/3); retrying
WARN: detach still busy after 3 attempts; forcing
  [fake hdiutil] detach /dev/disk5 -force
>>> exit 0, device still attached afterwards: no
=============== scenario: always-busy
  ... 3 busy attempts, then:
WARN: detach still busy after 3 attempts; forcing
  [fake hdiutil] detach /dev/disk5 -force
hdiutil: couldn't eject "disk5" - Resource busy
ERROR: /dev/disk5 is still attached after a forced detach
>>> exit 1, device still attached afterwards: yes
```

Still required: watch the first real nightly after merge -- the `-plist` key names (`dev-entry`, `system-entities`) are per `hdiutil(1)`, but this is their first use in this pipeline.

## UX concerns

None (CI-only).

## Related Issues

Fixes #10296

## Pattern harvest

Rule candidate: review-prompt
Pattern: "retry loop judges a two-phase external operation (unmount+eject, delete+confirm, stop+remove) by exit status alone and re-addresses it by a handle the first phase destroys" -- the retry must re-read the resource's real state before deciding, and address the handle that survives the first phase.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
