### PR TITLE
fix: assert guarded reload for malformed cron owner

### DIFF
--- a/test/test_remove_slot_for_history_key.py
+++ b/test/test_remove_slot_for_history_key.py
@@ -841,6 +841,11 @@ class TestAFailedRemovalDoesNotLeakIntoTheNextSave:
         raise OSError(28, "No space left on device")
 
     def test_malformed_persisted_owner_does_not_poison_unrelated_removal(self, tmp_path):
+        # The loader type-guards record fields at deserialization, so a
+        # non-string session_key reads back as the guarded unset value "",
+        # not as the stored list. What this test owns is the removal half:
+        # dropping an unrelated job must leave the malformed record present
+        # (guarded, not deleted) rather than poisoning or dropping it.
         crons = CronService(base_dir=tmp_path)
         parent = crons.add_job("parent", "ping", every_secs=3600)
         malformed = crons.add_job("malformed", "ping", every_secs=3600)
@@ -853,7 +858,8 @@ class TestAFailedRemovalDoesNotLeakIntoTheNextSave:
 
         reloaded = CronService(base_dir=tmp_path)
         assert reloaded.get_job(parent.id) is None
-        assert reloaded.get_job(malformed.id).session_key == ["not", "a", "string"]
+        assert reloaded.get_job(malformed.id) is not None
+        assert reloaded.get_job(malformed.id).session_key == ""
 
     def test_a_failed_removal_is_not_persisted_by_an_unrelated_later_save(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Problem / Motivation

`test_malformed_persisted_owner_does_not_poison_unrelated_removal` is red on main (Linux shard 3 and Windows shard 3): it persists a list as a cron `session_key`, reloads, and asserts the list survives untouched — but the loader type-guards record fields at deserialization (#9888) and coerces a non-string `session_key` to `""`, so the assertion fails with `assert '' == ['not', 'a', 'string']`. Every PR based on current main inherits the red.

## Why it matters

A red main blocks every PR's required checks; the fix unblocks the queue, not just this test.

## What changed (motivation → approach → change)

Test-only change in `test/test_remove_slot_for_history_key.py`: assert the loader's actual contract instead of the raw stored value. After reload the malformed job still exists, its `session_key` is the guarded unset value `""`, and the unrelated `remove_job` dropped only its own target. The test's owned intent — an unrelated removal neither poisons nor drops the malformed record — is preserved; only the contradicted equality is corrected. No production code touched (`_guard_str`'s contract stands as #9888 designed it).

## Tests

- Before: reproduced the exact main failure locally (`assert '' == ['not', 'a', 'string']`).
- After: the test passes; neighboring class tests untouched.
- `black --target-version py310`, `flake8`, `isort`: clean on the touched file.

## Pattern harvest

Not generalizable: one-off test/contract collision between two independently correct changes; no new pattern.

## Related Issues

Fixes #10295. Fixes #10299 (same test, Windows report — same root cause, not a file-lock interaction).

## Checklist

- [x] Single commit with Conventional Commits title
- [x] Failure reproduced pre-fix, green post-fix
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
