### PR TITLE
fix: read the log in-process when tail is missing

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -2445,6 +2445,32 @@ def _sandbox_cmd(args: argparse.Namespace) -> int:
     return 2
 
 
+def _tail_log_file(path: Path, lines: int, follow: bool) -> None:
+    """Print the last *lines* of *path*, following appends when asked.
+
+    Fallback for hosts without ``tail(1)`` (Windows ships none): the caller
+    already resolved the exact file, so exec'ing an external binary buys
+    nothing over reading it here -- and exec'ing a missing binary fails with
+    a bare FileNotFoundError that reads as a KiroCrew crash (#10291).
+    """
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        sys.stdout.write("".join(fh.readlines()[-lines:] if lines > 0 else []))
+    if not follow:
+        return
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            fh.seek(0, os.SEEK_END)
+            while True:
+                chunk = fh.read()
+                if chunk:
+                    sys.stdout.write(chunk)
+                    sys.stdout.flush()
+                else:
+                    time.sleep(0.5)
+    except KeyboardInterrupt:
+        pass
+
+
 def _logs_cmd(args: argparse.Namespace) -> None:
     """Tail gateway logs from the most appropriate source.
 
@@ -2546,6 +2572,10 @@ def _logs_cmd(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
+    if shutil.which("tail") is None:
+        # No tail(1) on this host (Windows ships none): read the resolved
+        # file in-process instead of exec'ing a missing binary (#10291).
+        _tail_log_file(fallback, lines, follow)
         return
     cmd = ["tail", "-n", str(lines)]
     if follow:

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -18,6 +18,7 @@ not enable pytest-asyncio auto mode).
 import argparse
 import asyncio
 import os
+import shutil
 import subprocess
 import sys
 import types
@@ -769,6 +770,55 @@ class TestLogsCmdOtherSources:
         (tmp_path / "gateway.log").write_text("x\n", encoding="utf-8", newline="\n")
         cli_server._logs_cmd(argparse.Namespace(follow=False, lines=0))
         assert capsys.readouterr().out == "x\n"
+
+    def test_missing_tail_binary_reads_the_log_in_python(
+        self, monkeypatch, tmp_path, sel_rec, capsys
+    ) -> None:
+        """No ``tail(1)`` (Windows ships none): the resolved file is read
+        in-process instead of exec'ing a missing binary (#10291)."""
+        monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.UNSUPPORTED)
+        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(shutil, "which", lambda *a, **k: None)
+        lines = [f"line {i}\n" for i in range(150)]
+        (tmp_path / "gateway.log").write_text("".join(lines), encoding="utf-8", newline="\n")
+
+        def _no_exec(*a, **k):  # pragma: no cover - proves no exec attempted
+            raise AssertionError("must not exec when tail is missing")
+
+        monkeypatch.setattr(os, "execvp", _no_exec)
+        cli_server._logs_cmd(argparse.Namespace(follow=False, lines=10))
+        assert capsys.readouterr().out == "".join(lines[-10:])
+        assert sel_rec.operations == ["logs"]
+
+    def test_missing_tail_follow_streams_until_interrupt(
+        self, monkeypatch, tmp_path, sel_rec, capsys
+    ) -> None:
+        """Follow mode without ``tail(1)`` prints the tail, streams an
+        appended line, then exits cleanly on interrupt (no hang, no traceback)."""
+        monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.UNSUPPORTED)
+        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(shutil, "which", lambda *a, **k: None)
+        log = tmp_path / "gateway.log"
+        log.write_text("one\ntwo\n", encoding="utf-8", newline="\n")
+
+        def _no_exec(*a, **k):  # pragma: no cover - proves no exec attempted
+            raise AssertionError("must not exec when tail is missing")
+
+        monkeypatch.setattr(os, "execvp", _no_exec)
+        calls = []
+
+        def _sleep(_s):
+            calls.append(1)
+            if len(calls) == 1:
+                with open(log, "a", encoding="utf-8", newline="\n") as fh:
+                    fh.write("three\n")
+            else:
+                raise KeyboardInterrupt
+
+        monkeypatch.setattr(cli_server.time, "sleep", _sleep)
+        cli_server._logs_cmd(argparse.Namespace(follow=True, lines=10))
+        out = capsys.readouterr().out
+        assert out == "one\ntwo\nthree\n"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

`kirocrew logs` is unusable on Windows: the fallback arm unconditionally `os.execvp("tail", ...)` after resolving `gateway.log`, and Windows ships no `tail`. The result is a bare `FileNotFoundError` traceback from inside `os._execvpe` that reads as a KiroCrew crash rather than "this command is POSIX-only" (reported that way in #10008).

## Why it matters

The fallback arm is also the one a foreground gateway reaches on every platform, and the failure mode actively misleads: a user running `logs` to diagnose something else is handed what looks like gateway breakage.

## What changed (motivation → approach → change)

When `shutil.which("tail")` finds no `tail`, the fallback arm reads the already-resolved log file in-process via a small `_tail_log_file` helper (last N lines; polling follow until `KeyboardInterrupt`) instead of exec'ing a missing binary. POSIX behavior is byte-identical (exec path untouched); only the previously-crashing shape changes. The launchd/systemd arms are untouched (`tail` always exists where they run).

## Tests

- New `test_missing_tail_binary_reads_the_log_in_python`: no `tail` → last 10 of 150 lines printed, no exec attempted, audit recorded.
- New `test_missing_tail_follow_streams_until_interrupt`: follow prints the tail, streams an appended line, exits cleanly on interrupt.
- `black --target-version py310`, `flake8`, `isort`: clean on both touched files.

## Pattern harvest

Not generalizable: one-off missing-binary crash on a platform-specific path; no new pattern.

## Related Issues

Fixes #10291.

## Checklist

- [x] Single commit with Conventional Commits title
- [x] New tests fail pre-fix (exec raises `FileNotFoundError`) and pass post-fix
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
