### PR TITLE
fix(cron): align malformed-owner test with load contract

### DIFF
--- a/test/test_remove_slot_for_history_key.py
+++ b/test/test_remove_slot_for_history_key.py
@@ -840,7 +840,7 @@ class TestAFailedRemovalDoesNotLeakIntoTheNextSave:
     def _boom() -> None:
         raise OSError(28, "No space left on device")
 
-    def test_malformed_persisted_owner_does_not_poison_unrelated_removal(self, tmp_path):
+    def test_unrelated_removal_persists_a_sanitized_malformed_owner(self, tmp_path):
         crons = CronService(base_dir=tmp_path)
         parent = crons.add_job("parent", "ping", every_secs=3600)
         malformed = crons.add_job("malformed", "ping", every_secs=3600)
@@ -853,7 +853,9 @@ class TestAFailedRemovalDoesNotLeakIntoTheNextSave:
 
         reloaded = CronService(base_dir=tmp_path)
         assert reloaded.get_job(parent.id) is None
-        assert reloaded.get_job(malformed.id).session_key == ["not", "a", "string"]
+        # Loading sanitizes non-string metadata before any mutation. The
+        # unrelated removal persists that safe value instead of invalid data.
+        assert reloaded.get_job(malformed.id).session_key == ""
 
     def test_a_failed_removal_is_not_persisted_by_an_unrelated_later_save(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Problem / Motivation

Main is red because one cron integration test expects invalid `session_key` data to survive a store load. The loader contract sanitizes non-string metadata to `""`, so the assertion fails on every platform; the Windows backend shard exposed it first.

## Why it matters

A deterministic assertion failure blocks the backend test matrix on `main`. The test also describes a cron-store guarantee that the product does not make.

## What changed (motivation → approach → change)

The cron loader is the source of truth for persisted record types. It keeps the malformed job, converts its non-string `session_key` to the safe unset value, and logs the coercion.

The integration test is renamed to state that behavior and expects `session_key == ""`. Production code is unchanged.

## Tests

- `pytest -n0 -q test/test_remove_slot_for_history_key.py test/test_cron*.py`: 1,833 passed, 1 skipped.
- Black, isort, Flake8, mypy, sync-I/O, comment-history, docs, vendor, CloudFormation, and repository policy gates pass.
- Frontend build, TypeScript, ESLint, i18n, 6,784 cross-surface tests, Electron tests, bundle size, and chunk-cycle gates pass.
- The profile's full backend run stops on `test_autonudge.py::TestSentinelPathRepair::test_unnormalized_path_escaping_legacy_is_preserved`. The same test fails on pristine `origin/main` because this runtime's required scratch path contains `.kiro/crew`; it does not touch this diff.
- GPT 5.6 and Opus 4.8 local review contracts report no findings at `624ba18fd6e33d585430c348b1d4e175542e7bf2`.

## Manual verification

N/A — this is a test-only correction to an existing serialized-record contract. The focused test and full cron/session sweep exercise the real save, load, remove, and reload path.

## Related Issues

Fixes #10299

## Pattern harvest

Rule candidate: review-prompt
Pattern: An integration test that writes malformed persisted data must assert the store loader's sanitized value, not the raw fixture.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
