### PR TITLE
feat(security-conductor): policy-block-sourced lessons

### DIFF
--- a/src/kiro_crew/builtin_skills/security-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/security-conductor/SKILL.md
@@ -209,10 +209,12 @@ One retrospective per round, after every finding carries a verifier verdict.
 > the outside, what the confirmed findings shared, what a `needs-human` verdict
 > was actually missing.
 > PROPOSE lessons with `scripts/ledger.py propose-lesson`, one per pattern, each
-> carrying its source finding id and one of `true-positive` / `false-positive` /
-> `missed` / `out-of-scope`. A proposed lesson is INACTIVE until a human approves
-> it — never write guidance as though it is already in force, and never inject an
-> unapproved lesson into a seed message.
+> naming EXACTLY ONE source — `--source-finding ID` for a finding, or
+> `--source-policy-block REF` for a `policy_block` event — and one of
+> `true-positive` / `false-positive` / `missed` / `out-of-scope`. Passing neither or
+> both exits 2. A proposed lesson is INACTIVE until a human approves it — never
+> write guidance as though it is already in force, and never inject an unapproved
+> lesson into a seed message.
 > RULE ON EVERY `policy_block` EVENT recorded this round, one at a time: was it a
 > FALSE POSITIVE (the fence refused a legitimate operation) or a CORRECT BLOCK
 > (the worker was reaching past the boundary)? A correct block is recorded as
@@ -220,16 +222,18 @@ One retrospective per round, after every finding carries a verifier verdict.
 > For each false positive propose the GOLDEN-PATH ROW FIRST, always: the wrongly
 > refused operation with `scripts/ledger.py propose-golden-path` (`active=0`). Its
 > `--source-finding` is optional, so a block with no finding still gets its row.
-> THEN the `false-positive` lesson with `scripts/ledger.py propose-lesson` — but
-> only when the block HAS a finding to cite. That command requires
-> `--source-finding` and exits 2 on an id that resolves to no finding, so cite the
-> finding the verifier was verifying, or the candidate the auditor was proving. A
-> block tied to no finding at all gets its golden-path row plus ONE LINE in your
-> report naming the lesson you would have written. Never invent a finding id to
-> carry a lesson, and never report a lesson you could not persist.
+> THEN the `false-positive` lesson with `scripts/ledger.py propose-lesson`, and
+> propose it for EVERY false positive — a block with no finding cites the block
+> itself with `--source-policy-block`, naming the event as you recorded it
+> (`{round_id}/policy_block-N`). Where the block does have a finding, cite it with
+> `--source-finding`: the finding the verifier was verifying, or the candidate the
+> auditor was proving. Never invent a finding id to carry a lesson; there is no
+> longer any reason to, and a fabricated id is the one thing that would make the
+> ledger's attribution a lie.
 > The two halves do different jobs — the lesson stops a future auditor re-filing
-> it, the golden path stops a future fix re-breaking it — so a round that could
-> only record the corpus half says which half is missing.
+> it, the golden path stops a future fix re-breaking it — so both are recorded for
+> every false positive, and a round that could record only one says which is
+> missing and why.
 > A HUMAN APPROVES ROWS, not you: `scripts/ledger.py approve-lesson` and
 > `approve-golden-path` are the human's commands, and nothing is injected into a
 > seed message or gates a fix before that. A proposed row is inert.
@@ -351,12 +355,15 @@ discards that work.
   circumvention is a stop condition rather than a note.
 - A lesson only changes behaviour on the NEXT round, and only after a human
   approves it. Nothing here learns inside a round.
-- **A policy block with no finding can be recorded as a golden path but not as a
-  lesson.** `ledger.py propose-lesson` requires `--source-finding` and refuses an
-  id that resolves to no finding, while a `policy_block` is deliberately an event
-  rather than a finding. So the corpus half of the retrospective's ruling survives
-  that case and the guidance half is reported to the human instead of being
-  silently dropped. Letting a lesson cite an event is a ledger change, not a
-  procedure change, and it is not made here.
+- **A policy block with no finding is recorded as both a golden path and a
+  lesson.** A `policy_block` is deliberately an event rather than a finding, so it
+  has no id for `--source-finding` to resolve; `propose-lesson` therefore takes
+  `--source-policy-block` instead, and a lesson names exactly one of the two. Both
+  halves of the retrospective's ruling survive a block that filed nothing — the
+  golden path that stops a future fix re-breaking the operation, and the guidance
+  that stops the next auditor walking into the same refusal. A policy-block
+  reference is not a foreign key and cannot be, since the events are the round's
+  own record rather than a table in the ledger, so this source is attributable but
+  not referentially checked.
 - One set of rules of engagement = one target. A second target is a second set,
   reviewed on its own.

--- a/src/kiro_crew/builtin_skills/security-conductor/scripts/ledger.py
+++ b/src/kiro_crew/builtin_skills/security-conductor/scripts/ledger.py
@@ -16,7 +16,8 @@ Usage. ``--db PATH`` goes BEFORE the subcommand and defaults to
     python3 ledger.py record-verdict --finding ID --role ROLE --verdict V
                                      [--reason WHY]
     python3 ledger.py propose-lesson --kind K --surface S --pattern P
-                                     --guidance G --source-finding ID
+                                     --guidance G
+                                     (--source-finding ID | --source-policy-block REF)
     python3 ledger.py approve-lesson --id ID --approved-by WHO
     python3 ledger.py add-rule --field F --value V --reason WHY --approved-by WHO
     python3 ledger.py export-roe
@@ -63,10 +64,21 @@ Four properties this script exists to hold, none of which a prompt can:
 3. **The seed is bounded.** ``seed-lessons`` emits at most ``--budget-bytes``
    bytes, because an unbounded lesson list becomes the seed and crowds out the
    brief.
-4. **Every lesson is attributable, in both directions.**
-   ``source_finding_id`` is NOT NULL and a real foreign key, enforced with
-   ``PRAGMA foreign_keys=ON``, so guidance traces back to the finding that earned
-   it; and ``approved_by`` cannot be overwritten once set -- not by a second
+4. **Every lesson is attributable, in both directions.** A lesson names
+   EXACTLY ONE source, and a table CHECK -- not only the argument parser -- is what
+   makes that a property of the row: either ``source_finding_id``, a real foreign
+   key enforced with ``PRAGMA foreign_keys=ON``, or ``source_policy_block``, the
+   free text naming a ``policy_block`` event. Two sources is as much a defect as
+   none, because a reader that trusts the first field it finds would attribute the
+   guidance to whichever one it happened to check. The second kind exists because a
+   ``policy_block`` is deliberately an EVENT and not a finding, so a fence that
+   wrongly refused a legitimate operation had no id to cite and its lesson could
+   not be stored at all -- the round recorded the golden path that stops a future
+   fix re-breaking the operation, and lost the guidance that stops the next auditor
+   walking into the same refusal. A policy-block reference is NOT a foreign key and
+   cannot be: the events it names are the round's own record, not a table here. So
+   this source is attributable but not referentially checked, which is the honest
+   description of it. And ``approved_by`` cannot be overwritten once set -- not by a second
    approval, and not by deactivating the lesson and approving it again, since the
    write requires ``approved_by IS NULL`` and not merely ``active = 0``. Every
    required text
@@ -125,7 +137,7 @@ except Exception:  # pragma: no cover - exercised when the package is not import
     # exists to secure. Nothing else about the shim's behaviour is relied on.
     import sqlite3  # type: ignore[no-redef]
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 ROLES = ("auditor", "verifier", "human")
 # Fold precedence, weakest first: a human overrules a verifier, who overrules an
@@ -157,6 +169,64 @@ LIST_QUERIES = {
 }
 LIST_TABLES = tuple(LIST_QUERIES)
 
+# The lessons columns, spelled ONCE: :data:`DDL` creates the table with them and
+# :func:`_rebuild_lessons` recreates it with them, and two copies of a column list
+# drift the moment one of them gains a column.
+#
+# ``source_finding_id`` is nullable and ``source_policy_block`` is its alternative,
+# with a CHECK making exactly one of them present. The CHECK is the reason this is
+# a storage guarantee and not merely an argument-parser one: anything that can
+# reach this database can INSERT directly, and a lesson attributable to nothing --
+# or to two different things -- is the one row that would break the seed's claim
+# that guidance traces back to what earned it.
+#
+# PRESENT is not the same as non-blank, and for a text column the difference is the
+# whole guarantee: ``''`` and ``'   '`` both satisfy IS NOT NULL, so a CHECK written
+# only against NULL would let a direct writer store a lesson whose attribution is
+# empty -- exactly the row this constraint exists to refuse, arriving by the exact
+# path that makes a parser-only rule insufficient. So the policy-block branch
+# requires the reference to survive a trim. The trim set is ASCII whitespace, named
+# by codepoint because SQLite's one-argument TRIM removes spaces only; the CLI's
+# ``nonblank`` is strictly stronger (Python's ``str.strip()`` also removes the
+# Unicode spaces), and the two are not required to agree -- the CLI refuses more,
+# and storage refuses the cases a hand-written INSERT actually produces.
+#
+# The explicit ``source_policy_block IS NOT NULL`` in that branch is load-bearing and
+# not implied by the TRIM beside it. A CHECK constraint REJECTS only a FALSE result:
+# an expression evaluating to NULL passes. ``TRIM(NULL, ...)`` is NULL and
+# ``NULL <> ''`` is NULL, so without the explicit test a row with NO source at all
+# made the whole constraint NULL and was stored -- the exact case the first branch
+# exists to catch, readmitted through three-valued logic. Every comparison here is
+# therefore kept on values known to be non-NULL.
+LESSONS_COLUMNS = """
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        kind TEXT NOT NULL CHECK (
+            kind IN ('true-positive', 'false-positive', 'missed', 'out-of-scope')
+        ),
+        surface TEXT NOT NULL,
+        pattern TEXT NOT NULL,
+        guidance TEXT NOT NULL,
+        source_finding_id INTEGER REFERENCES findings(id),
+        source_policy_block TEXT,
+        approved_by TEXT,
+        ts TEXT NOT NULL,
+        active INTEGER NOT NULL DEFAULT 0,
+        CHECK (
+            (source_finding_id IS NOT NULL AND source_policy_block IS NULL)
+            OR (
+                source_finding_id IS NULL
+                AND source_policy_block IS NOT NULL
+                AND TRIM(
+                    source_policy_block,
+                    char(32) || char(9) || char(10) || char(11) || char(12) || char(13)
+                ) <> ''
+            )
+        )
+"""
+# The rebuild's scratch name. Held as a constant so the DROP that clears a previous
+# interrupted attempt and the CREATE that starts this one cannot disagree.
+LESSONS_REBUILD_TABLE = "lessons_rebuild"
+
 DDL = (
     "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)",
     # The version row is a SINGLETON, and this index is what makes that a
@@ -186,19 +256,7 @@ DDL = (
         reason TEXT,
         ts TEXT NOT NULL
     )""",
-    """CREATE TABLE IF NOT EXISTS lessons (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        kind TEXT NOT NULL CHECK (
-            kind IN ('true-positive', 'false-positive', 'missed', 'out-of-scope')
-        ),
-        surface TEXT NOT NULL,
-        pattern TEXT NOT NULL,
-        guidance TEXT NOT NULL,
-        source_finding_id INTEGER NOT NULL REFERENCES findings(id),
-        approved_by TEXT,
-        ts TEXT NOT NULL,
-        active INTEGER NOT NULL DEFAULT 0
-    )""",
+    f"CREATE TABLE IF NOT EXISTS lessons ({LESSONS_COLUMNS})",
     """CREATE TABLE IF NOT EXISTS roe_rules (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         field TEXT NOT NULL,
@@ -276,9 +334,16 @@ def connect(db_path: Path) -> sqlite3.Connection:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
-    # NOT NULL + REFERENCES on lessons.source_finding_id is only a real
-    # constraint with this pragma on; SQLite defaults it OFF per connection.
+    # REFERENCES on lessons.source_finding_id is only a real constraint with this
+    # pragma on; SQLite defaults it OFF per connection. The column is nullable now
+    # that a lesson may cite a policy block instead, so the FK is what still makes a
+    # PRESENT finding id a real one -- and the table's CHECK is what makes exactly
+    # one of the two sources present in the first place.
     conn.execute("PRAGMA foreign_keys=ON")
+    # The schema pass takes the write lock for its whole duration (see
+    # :func:`init_schema`), so a second command starting at the same moment waits
+    # for it. The driver's default busy timeout of five seconds covers rebuilding one
+    # small table, so it is left alone.
     try:
         conn.execute("PRAGMA journal_mode=WAL")
     except sqlite3.Error:  # pragma: no cover - filesystem without WAL support
@@ -288,11 +353,120 @@ def connect(db_path: Path) -> sqlite3.Connection:
     return conn
 
 
+def _lessons_needs_rebuild(conn: sqlite3.Connection) -> bool:
+    """Does this database's ``lessons`` table still predate the second source kind?
+
+    ABSENT is not stale: :data:`DDL` has just created it in the current shape on
+    this same pass, so there is nothing to rebuild. The two stale shapes are a
+    table with no ``source_policy_block`` column at all, and -- for a rebuild
+    interrupted between its own statements -- one that has the column while
+    ``source_finding_id`` is still NOT NULL.
+
+    The probe reads COLUMNS and deliberately not the CHECK expression, which would
+    mean string-comparing stored SQL against this file's own text and rebuilding on
+    every reformatting of it. Every schema version that has shipped is told apart
+    by its columns, so the weaker test is sufficient for the databases that exist.
+    """
+    columns = {row["name"]: row for row in conn.execute("PRAGMA table_info(lessons)").fetchall()}
+    if not columns:
+        return False
+    if "source_policy_block" not in columns:
+        return True
+    return bool(int(columns["source_finding_id"]["notnull"]))
+
+
+def _lessons_id_high_water(conn: sqlite3.Connection) -> int | None:
+    """The largest lesson id AUTOINCREMENT has ever issued, or None if unknown.
+
+    Not ``MAX(id)``: that is the largest id still PRESENT, and the two differ exactly
+    when the top rows were deleted -- which for this table means a human row edit,
+    the RFC's own revert path. AUTOINCREMENT keeps the real mark in the sequence
+    table, and the guarantee it buys is that an id is never REUSED.
+
+    The sequence table exists whenever this runs: SQLite creates it when the first
+    table with an AUTOINCREMENT column is created, and ``lessons`` is one.
+    """
+    row = conn.execute("SELECT seq FROM sqlite_sequence WHERE name = 'lessons'").fetchone()
+    return None if row is None else int(row["seq"])
+
+
+def _restore_lessons_id_high_water(conn: sqlite3.Connection, previous: int | None) -> None:
+    """Put the id counter back where it was before the rebuild.
+
+    The copy carries explicit ids, so the new table's counter lands on the largest id
+    it received -- which is ``MAX(id)``, not the mark. Any id above that and at or
+    below the old mark would then be handed out a SECOND time, so a report or a
+    retrospective citing "lesson 12" would name two different lessons over the
+    ledger's life. Writing the sequence row is SQLite's documented way to set an
+    AUTOINCREMENT counter.
+
+    Two statements because the row may be absent as well as low: a table whose rows
+    were all deleted copies nothing, so the rebuilt table gets no sequence row at all
+    and the counter would restart at 1 -- the worst version of the same defect. The
+    UPDATE is guarded with ``seq <`` so this can only ever move the mark FORWARD.
+    """
+    if previous is None:
+        return
+    conn.execute(
+        "INSERT INTO sqlite_sequence (name, seq) SELECT 'lessons', ?"
+        " WHERE NOT EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = 'lessons')",
+        (previous,),
+    )
+    conn.execute(
+        "UPDATE sqlite_sequence SET seq = ? WHERE name = 'lessons' AND seq < ?",
+        (previous, previous),
+    )
+
+
+def _rebuild_lessons(conn: sqlite3.Connection) -> None:
+    """Copy ``lessons`` into the current shape, preserving every row and its id.
+
+    The standard SQLite table rebuild. It runs inside :func:`init_schema`'s
+    ``BEGIN IMMEDIATE``, which is what makes an interrupted upgrade a no-op rather
+    than a half-migrated table and what keeps a second upgrader out of the shared
+    scratch table -- neither holds without that explicit BEGIN, because every
+    statement here except the copy is DDL. Ids are carried across explicitly: a lesson's id is what
+    :func:`seed_lessons` ranks recency by, so renumbering the rows would silently
+    reorder every seed built from this ledger.
+
+    The id COUNTER is carried too, and separately -- see
+    :func:`_restore_lessons_id_high_water`. Copying the rows only restores the ids
+    that still exist, which leaves the counter free to reissue any id above the
+    surviving maximum.
+
+    ``source_policy_block`` is NULL for every migrated row, which is correct rather
+    than lossy -- those lessons were all proposed when a finding id was the only
+    source there was.
+    """
+    high_water = _lessons_id_high_water(conn)
+    conn.execute(f"DROP TABLE IF EXISTS {LESSONS_REBUILD_TABLE}")
+    conn.execute(f"CREATE TABLE {LESSONS_REBUILD_TABLE} ({LESSONS_COLUMNS})")
+    conn.execute(
+        f"INSERT INTO {LESSONS_REBUILD_TABLE}"
+        " (id, kind, surface, pattern, guidance, source_finding_id, source_policy_block,"
+        " approved_by, ts, active)"
+        " SELECT id, kind, surface, pattern, guidance, source_finding_id, NULL,"
+        " approved_by, ts, active FROM lessons"
+    )
+    conn.execute("DROP TABLE lessons")
+    conn.execute(f"ALTER TABLE {LESSONS_REBUILD_TABLE} RENAME TO lessons")
+    _restore_lessons_id_high_water(conn, high_water)
+    # The old table's indexes went with it, so the one :data:`DDL` declares is
+    # recreated here rather than waiting for the next open.
+    conn.execute("CREATE INDEX IF NOT EXISTS lessons_active ON lessons (active, surface)")
+
+
 def init_schema(conn: sqlite3.Connection) -> int:
     """Create every table and index if absent; return the schema version.
 
     Idempotent and versioned: the version row is written once, so a future
     migration ladder has a value to branch on.
+
+    The whole pass runs in ONE ``BEGIN IMMEDIATE`` transaction, so it is atomic
+    against an interruption AND serialized against another process doing the same
+    thing. Both matter because the pass carries destructive DDL -- the lessons
+    rebuild -- and DDL is exactly what the driver does NOT open a transaction for on
+    its own. A pass built only from ``CREATE ... IF NOT EXISTS`` would need neither.
 
     The insert carries its own precondition (``WHERE NOT EXISTS``) instead of
     being gated by a Python read. A read-then-write here was racy on the ORDINARY
@@ -301,9 +475,39 @@ def init_schema(conn: sqlite3.Connection) -> int:
     cannot interleave with itself, and the unique index in :data:`DDL` is the
     backstop for a row written any other way.
     """
+    # ONE writer at a time, for the WHOLE pass, and this line is what makes the
+    # atomicity claimed below actually hold. Python's sqlite3 driver begins a
+    # transaction implicitly before DML only -- never before DDL -- so without an
+    # explicit BEGIN the rebuild's ``DROP``/``CREATE`` of the scratch table execute in
+    # AUTOCOMMIT, and two commands starting together (which is the ordinary case: every
+    # command calls this first, and a round runs auditors in parallel) would then share
+    # one scratch table. The interleaving is not a lost update but a corruption: the
+    # second upgrader's ``DROP TABLE IF EXISTS`` destroys the first's POPULATED scratch
+    # table, and the first then renames whatever is left over ``lessons``.
+    #
+    # IMMEDIATE rather than DEFERRED because the lock has to be taken NOW: a deferred
+    # transaction acquires it at its first write, which is after the probe below has
+    # already decided what work to do, and two upgraders would both decide to rebuild.
+    # The loser blocks here, then re-probes and finds nothing to do -- which is exactly
+    # what makes :func:`_lessons_needs_rebuild` a shape test rather than a version test.
+    #
+    # No guard on ``conn.in_transaction``: this function owns the connection's
+    # transaction state and is called immediately after :func:`connect`. A caller that
+    # wrapped it in its own transaction would get a loud error, which is better than
+    # silently losing the serialization.
+    conn.execute("BEGIN IMMEDIATE")
     with conn:
         for statement in DDL:
             conn.execute(statement)
+        # The one step the ``CREATE ... IF NOT EXISTS`` ladder above cannot take.
+        # SQLite has no ``ALTER COLUMN``, so relaxing lessons.source_finding_id from
+        # NOT NULL to nullable is a table rebuild, and the DDL loop leaves an
+        # existing table in its old shape. Gated on the table's ACTUAL shape rather
+        # than on the stored version, because the version bump is the last write
+        # below: an upgrade interrupted before it must find the same work still to
+        # do, and one that already ran must find none.
+        if _lessons_needs_rebuild(conn):
+            _rebuild_lessons(conn)
         conn.execute(
             "INSERT INTO schema_version (version)"
             " SELECT ? WHERE NOT EXISTS (SELECT 1 FROM schema_version)",
@@ -831,11 +1035,24 @@ def seed_lessons(
     return chosen, used
 
 
+def lesson_source(row: sqlite3.Row) -> str:
+    """The source half of a seed line: the finding id, or the policy block.
+
+    The finding is checked FIRST and the two are never both rendered, because the
+    table's CHECK already makes exactly one of them present -- so a line that
+    named both would be describing a row that cannot exist.
+    """
+    finding = row["source_finding_id"]
+    if finding is not None:
+        return f"finding #{finding}"
+    return f"policy block {row['source_policy_block']}"
+
+
 def format_lesson(row: sqlite3.Row) -> str:
-    """One lesson as one seed line, carrying the finding that earned it."""
+    """One lesson as one seed line, carrying the source that earned it."""
     return (
         f"- [{row['kind']}] {row['surface']}: {row['pattern']} -> {row['guidance']}"
-        f" (finding #{row['source_finding_id']})"
+        f" ({lesson_source(row)})"
     )
 
 
@@ -929,7 +1146,13 @@ def _build_parser() -> argparse.ArgumentParser:
     propose.add_argument("--surface", required=True, type=nonblank)
     propose.add_argument("--pattern", required=True, type=nonblank)
     propose.add_argument("--guidance", required=True, type=nonblank)
-    propose.add_argument("--source-finding", required=True, type=int)
+    # Neither is ``required``, because the requirement is on the PAIR: exactly one.
+    # A mutually-exclusive group with ``required=True`` would express that, but it
+    # exits through ``parser.error``, and every other refusal in this CLI is a
+    # sentence on stderr and a 2 returned from :func:`_dispatch` -- so the check
+    # lives there, where its message can name both flags and say why.
+    propose.add_argument("--source-finding", default=None, type=int)
+    propose.add_argument("--source-policy-block", default=None, type=nonblank)
 
     approve = command("approve-lesson", "activate a proposed lesson")
     approve.add_argument("--id", required=True, type=int)
@@ -1032,7 +1255,18 @@ def _dispatch(
                 file=sys.stderr,
             )
             return 2
-        if not _require_finding(conn, args.source_finding):
+        if (args.source_finding is None) == (args.source_policy_block is None):
+            # Both spellings of the same defect: a lesson whose guidance traces back
+            # to nothing, and one that claims two different origins. Neither can be
+            # stored -- the table's CHECK refuses both -- and reporting them together
+            # names the rule rather than whichever half the caller tripped.
+            print(
+                "exactly one of --source-finding or --source-policy-block is required;"
+                " a lesson names the finding or the policy block that earned it",
+                file=sys.stderr,
+            )
+            return 2
+        if args.source_finding is not None and not _require_finding(conn, args.source_finding):
             # Checked here as well as by the foreign key so the operator gets a
             # sentence instead of an IntegrityError traceback.
             print(
@@ -1042,14 +1276,15 @@ def _dispatch(
             return 2
         with conn:
             cursor = conn.execute(
-                "INSERT INTO lessons (kind, surface, pattern, guidance, source_finding_id, ts,"
-                " active) VALUES (?, ?, ?, ?, ?, ?, 0)",
+                "INSERT INTO lessons (kind, surface, pattern, guidance, source_finding_id,"
+                " source_policy_block, ts, active) VALUES (?, ?, ?, ?, ?, ?, ?, 0)",
                 (
                     args.kind,
                     args.surface,
                     args.pattern,
                     args.guidance,
                     args.source_finding,
+                    args.source_policy_block,
                     now_iso(),
                 ),
             )

--- a/test/test_security_conductor_ledger.py
+++ b/test/test_security_conductor_ledger.py
@@ -269,6 +269,7 @@ class TestSchemaMatchesTheRfc:
                     "pattern",
                     "guidance",
                     "source_finding_id",
+                    "source_policy_block",
                     "approved_by",
                     "ts",
                     "active",
@@ -1727,7 +1728,7 @@ class TestGoldenPathsMigrateAdditively:
     def test_an_existing_v1_ledger_opens_and_gains_the_table(self, mod, db, capsys):
         self.a_v1_database(db)
         assert run(mod, db, "init") == 0
-        assert out_json(capsys)["schema_version"] == 2
+        assert out_json(capsys)["schema_version"] == mod.SCHEMA_VERSION
         run(mod, db, "list", "golden-paths")
         assert out_json(capsys) == []
 
@@ -2291,3 +2292,542 @@ class TestGoldenPathCorpusImport:
         assert "no finding with id 404" in capsys.readouterr().err
         run(mod, db, "list", "golden-paths")
         assert out_json(capsys) == []
+
+
+class TestALessonMaySourceAPolicyBlock:
+    """A fence that wrongly refused a legitimate operation must still teach.
+
+    A ``policy_block`` is deliberately an EVENT and not a finding, so before this
+    the retrospective could record the golden path that stops a future fix
+    re-breaking the operation but had no id with which to store the guidance that
+    stops the next auditor walking into the same refusal. The round that found this
+    lost exactly that half: ``deny-classifier-fence`` filed no finding, so its
+    lesson existed only as a line in a report.
+    """
+
+    def propose(self, mod, db, *extra: str) -> int:
+        return run(
+            mod,
+            db,
+            "propose-lesson",
+            "--kind",
+            "false-positive",
+            "--surface",
+            "deny-classifier-fence",
+            "--pattern",
+            "argv floor refused a read-only scan of committed source",
+            "--guidance",
+            "read the file with the file tool and hand the block up for a ruling",
+            *extra,
+        )
+
+    def test_a_policy_block_sourced_lesson_reaches_the_seed_once_approved(
+        self, mod, db, capsys
+    ) -> None:
+        """The whole point: no finding anywhere in this ledger, and a seed line."""
+        assert self.propose(mod, db, "--source-policy-block", "m2-round-1/policy_block-1") == 0
+        lesson_id = int(out_json(capsys)["id"])
+        assert run(mod, db, "approve-lesson", "--id", str(lesson_id), "--approved-by", "zj") == 0
+        capsys.readouterr()
+
+        assert (
+            run(
+                mod,
+                db,
+                "seed-lessons",
+                "--surface",
+                "deny-classifier-fence",
+                "--budget-bytes",
+                "4000",
+            )
+            == 0
+        )
+        out = capsys.readouterr().out
+        assert "policy block m2-round-1/policy_block-1" in out
+        # The finding spelling must not leak into a line that has no finding: a seed
+        # reader treating "finding #None" as an id would go looking for row None.
+        assert "finding #" not in out
+
+    def test_the_proposed_lesson_is_still_inert_until_approved(self, mod, db, capsys) -> None:
+        """The second source widens WHAT may be cited, never the approval gate."""
+        assert self.propose(mod, db, "--source-policy-block", "m2-round-1/policy_block-1") == 0
+        assert out_json(capsys)["active"] == 0
+        run(mod, db, "seed-lessons", "--surface", "deny-classifier-fence", "--budget-bytes", "4000")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "no approved lesson to seed" in captured.err
+
+    def test_neither_source_is_refused(self, mod, db, capsys) -> None:
+        """The red-before case. A lesson attributable to nothing is the row that
+        would break the seed's claim that guidance traces back to what earned it."""
+        assert self.propose(mod, db) == 2
+        assert "exactly one of --source-finding or --source-policy-block" in capsys.readouterr().err
+        run(mod, db, "list", "lessons")
+        assert out_json(capsys) == []
+
+    def test_both_sources_are_refused(self, mod, db, capsys) -> None:
+        """Two origins is as much a defect as none: a reader trusting the first
+        field it checks would attribute the guidance to whichever that was."""
+        finding = a_finding(mod, db, capsys)
+        assert (
+            self.propose(
+                mod,
+                db,
+                "--source-finding",
+                str(finding),
+                "--source-policy-block",
+                "m2-round-1/policy_block-1",
+            )
+            == 2
+        )
+        assert "exactly one of --source-finding or --source-policy-block" in capsys.readouterr().err
+        run(mod, db, "list", "lessons")
+        assert out_json(capsys) == []
+
+    def test_a_blank_policy_block_reference_is_refused(self, mod, db, capsys) -> None:
+        """``nonblank`` on the flag, for the same reason ``--approved-by`` carries it:
+        a present-but-empty reference stores no attribution while satisfying the
+        parser.
+
+        The stderr assertion is what makes this test about blankness. Exit 2 alone is
+        also what argparse returns for an option it does not recognise, so on a tree
+        where the flag does not exist at all this would pass while proving nothing.
+        """
+        with pytest.raises(SystemExit) as excinfo:
+            self.propose(mod, db, "--source-policy-block", "   ")
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "must not be blank" in err
+        assert "unrecognized" not in err
+
+    def a_hand_written_lesson(self, conn, source_finding, source_block) -> None:
+        """One lesson inserted the way a human editing rows really does it."""
+        with conn:
+            conn.execute(
+                "INSERT INTO lessons (kind, surface, pattern, guidance,"
+                " source_finding_id, source_policy_block, ts, active)"
+                " VALUES ('missed', 's', 'p', 'g', ?, ?,"
+                " '2026-09-12T00:00:00+00:00', 0)",
+                (source_finding, source_block),
+            )
+
+    @pytest.mark.parametrize(
+        "source_finding, source_block, case",
+        [
+            pytest.param(None, None, "no source at all", id="neither"),
+            pytest.param(1, "pb-1", "two different origins", id="both"),
+            pytest.param(None, "", "an empty reference", id="empty-string"),
+            pytest.param(None, "   ", "a spaces-only reference", id="spaces"),
+            pytest.param(None, "\t\n", "a tabs-and-newlines reference", id="ascii-whitespace"),
+        ],
+    )
+    def test_the_check_refuses_an_unattributable_row_written_by_hand(
+        self, mod, db, capsys, source_finding, source_block, case
+    ) -> None:
+        """The guarantee is the TABLE's, not the parser's.
+
+        Anything that can run this script can open the same file with ``sqlite3``,
+        so a constraint enforced only in :func:`_dispatch` would be advice rather
+        than the storage guarantee the module docstring claims.
+
+        The blank cases are the ones a NULL-only CHECK misses: ``''`` and ``'   '``
+        are both PRESENT, so a row carrying one is attributable to nothing while
+        satisfying IS NOT NULL -- and it arrives by exactly the direct-INSERT path
+        that makes a parser-only rule insufficient in the first place.
+        """
+        run(mod, db, "init")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            with pytest.raises(Exception):
+                self.a_hand_written_lesson(conn, source_finding, source_block)
+        finally:
+            conn.close()
+
+    def test_a_reference_that_only_looks_blank_is_kept(self, mod, db, capsys) -> None:
+        """The trim must not swallow a real reference.
+
+        A guard that refused anything containing whitespace would reject the
+        ``{round_id}/policy_block-N`` spellings a round actually writes, so the
+        boundary is asserted from both sides: blank is refused above, and a
+        reference with interior or surrounding whitespace is stored.
+        """
+        run(mod, db, "init")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            self.a_hand_written_lesson(conn, None, "  m2-round-1/policy_block 1  ")
+        finally:
+            conn.close()
+        run(mod, db, "list", "lessons")
+        rows = out_json(capsys)
+        assert [row["source_policy_block"] for row in rows] == ["  m2-round-1/policy_block 1  "]
+
+    def test_a_finding_sourced_lesson_still_reads_the_same(self, mod, db, capsys) -> None:
+        """The line format for the original source kind is unchanged, because every
+        seed already built from this ledger is that spelling."""
+        finding = a_finding(mod, db, capsys)
+        a_lesson(mod, db, capsys, finding)
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000")
+        out = capsys.readouterr().out
+        assert f"(finding #{finding})" in out
+        assert "policy block" not in out
+
+
+class TestLessonsRebuildKeepsWhatWasThere:
+    """The rebuild is the one migration step the ``IF NOT EXISTS`` ladder cannot take.
+
+    SQLite has no ``ALTER COLUMN``, so relaxing ``source_finding_id`` from NOT NULL
+    is a table recreate -- and a recreate is where rows get lost. These tests are
+    about the FILE: a ledger written by the previous checkout, mid-audit, opened by
+    this one.
+    """
+
+    def a_v2_database(self, path: Path) -> None:
+        """A v2 ledger carrying two lessons, written the way one really exists.
+
+        Raw SQL rather than an older copy of the script, for the same reason the v1
+        fixture does it: what has to migrate is the file, and only spelling out the
+        previous DDL produces one that predates the current shape.
+        """
+        import sqlite3
+
+        conn = sqlite3.connect(str(path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            CREATE UNIQUE INDEX schema_version_single ON schema_version (version);
+            INSERT INTO schema_version (version) VALUES (2);
+            CREATE TABLE findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, surface TEXT NOT NULL,
+                severity TEXT NOT NULL, title TEXT NOT NULL, paths TEXT NOT NULL,
+                poc TEXT, auditor_verdict TEXT, verifier_verdict TEXT,
+                final_verdict TEXT, status TEXT NOT NULL, created TEXT NOT NULL,
+                round_id TEXT
+            );
+            INSERT INTO findings (surface, severity, title, paths, status, created)
+                VALUES ('token-session', 'Medium', 'legacy finding', '[]', 'open',
+                        '2000-01-01T00:00:00+00:00');
+            CREATE TABLE lessons (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                kind TEXT NOT NULL CHECK (
+                    kind IN ('true-positive', 'false-positive', 'missed', 'out-of-scope')
+                ),
+                surface TEXT NOT NULL,
+                pattern TEXT NOT NULL,
+                guidance TEXT NOT NULL,
+                source_finding_id INTEGER NOT NULL REFERENCES findings(id),
+                approved_by TEXT,
+                ts TEXT NOT NULL,
+                active INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE INDEX lessons_active ON lessons (active, surface);
+            INSERT INTO lessons (id, kind, surface, pattern, guidance, source_finding_id,
+                                 approved_by, ts, active)
+                VALUES (7, 'true-positive', 'token-session', 'old pattern', 'old guidance',
+                        1, 'a-human', '2000-01-02T00:00:00+00:00', 1);
+            INSERT INTO lessons (id, kind, surface, pattern, guidance, source_finding_id,
+                                 approved_by, ts, active)
+                VALUES (9, 'missed', 'ingest-validation', 'unapproved pattern',
+                        'unapproved guidance', 1, NULL,
+                        '2000-01-03T00:00:00+00:00', 0);
+            """)
+        conn.commit()
+        conn.close()
+
+    def test_the_ledger_opens_and_reports_the_new_version(self, mod, db, capsys) -> None:
+        self.a_v2_database(db)
+        assert run(mod, db, "init") == 0
+        assert out_json(capsys)["schema_version"] == mod.SCHEMA_VERSION
+
+    def test_every_existing_lesson_survives_with_its_id_and_approver(self, mod, db, capsys) -> None:
+        """Ids are carried across explicitly: :func:`seed_lessons` ranks recency by
+        id, so renumbering the rows would silently reorder every later seed. And
+        ``approved_by`` is the audit trail the human gate exists to leave."""
+        self.a_v2_database(db)
+        run(mod, db, "list", "lessons")
+        rows = {int(row["id"]): row for row in out_json(capsys)}
+
+        assert sorted(rows) == [7, 9]
+        assert rows[7]["pattern"] == "old pattern"
+        assert rows[7]["approved_by"] == "a-human"
+        assert rows[7]["active"] == 1
+        assert rows[7]["source_finding_id"] == 1
+        # NULL rather than a back-filled placeholder: these lessons were proposed
+        # when a finding id was the only source there was, which is a fact about
+        # them and not missing data.
+        assert rows[7]["source_policy_block"] is None
+        # The unapproved one stays unapproved -- a rebuild that activated rows would
+        # walk guidance into a seed no human let in.
+        assert rows[9]["active"] == 0
+        assert rows[9]["approved_by"] is None
+
+    def test_a_migrated_ledger_accepts_a_policy_block_lesson(self, mod, db, capsys) -> None:
+        """The rebuild is only worth anything if the relaxed column really relaxed:
+        the old table's NOT NULL would refuse this insert."""
+        self.a_v2_database(db)
+        assert (
+            run(
+                mod,
+                db,
+                "propose-lesson",
+                "--kind",
+                "false-positive",
+                "--surface",
+                "deny-classifier-fence",
+                "--pattern",
+                "p",
+                "--guidance",
+                "g",
+                "--source-policy-block",
+                "m2-round-1/policy_block-1",
+            )
+            == 0
+        )
+        assert out_json(capsys)["active"] == 0
+
+    def test_the_rebuild_is_idempotent(self, mod, db, capsys) -> None:
+        """Every command calls ``init_schema``, so the second open must find nothing
+        to do -- a rebuild that ran every time would rewrite the table on each
+        invocation and the scratch table would collide with itself."""
+        self.a_v2_database(db)
+        run(mod, db, "init")
+        capsys.readouterr()
+        assert run(mod, db, "init") == 0
+        assert out_json(capsys)["schema_version"] == mod.SCHEMA_VERSION
+        run(mod, db, "list", "lessons")
+        assert [int(row["id"]) for row in out_json(capsys)] == [7, 9]
+
+    def test_the_scratch_table_is_not_left_behind(self, mod, db, capsys) -> None:
+        """A leftover ``lessons_rebuild`` would be a second lessons table that
+        nothing reads and every later rebuild would have to reason about.
+
+        Existence is read with ``PRAGMA table_info``, which returns no rows for a
+        table that is not there -- the same probe :func:`_lessons_needs_rebuild`
+        uses, so the test and the code agree on what "present" means.
+        """
+        self.a_v2_database(db)
+        run(mod, db, "init")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            scratch = conn.execute(f"PRAGMA table_info({mod.LESSONS_REBUILD_TABLE})").fetchall()
+            lessons = conn.execute("PRAGMA table_info(lessons)").fetchall()
+        finally:
+            conn.close()
+        assert scratch == []
+        assert lessons != []
+
+    def test_the_active_index_survives_the_rebuild(self, mod, db, capsys) -> None:
+        """Dropping the table dropped its indexes; the rebuild recreates the one
+        :data:`DDL` declares rather than leaving the seed's query unindexed."""
+        self.a_v2_database(db)
+        run(mod, db, "init")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            names = {row["name"] for row in conn.execute("PRAGMA index_list(lessons)")}
+        finally:
+            conn.close()
+        assert "lessons_active" in names
+
+    def delete_lesson_by_hand(self, mod, db: Path, lesson_id: int) -> None:
+        """Remove one lesson the way the RFC's revert path does: a human row edit.
+
+        There is no delete verb in the CLI, which is why this is spelled out here --
+        and it is what makes the id counter and ``MAX(id)`` disagree.
+        """
+        conn = mod.connect(db)
+        try:
+            with conn:
+                conn.execute("DELETE FROM lessons WHERE id = ?", (lesson_id,))
+        finally:
+            conn.close()
+
+    def propose_policy_block_lesson(self, mod, db: Path) -> int:
+        """One policy-block-sourced proposal, returning the id it was given."""
+        return run(
+            mod,
+            db,
+            "propose-lesson",
+            "--kind",
+            "false-positive",
+            "--surface",
+            "deny-classifier-fence",
+            "--pattern",
+            "p",
+            "--guidance",
+            "g",
+            "--source-policy-block",
+            "m2-round-1/policy_block-1",
+        )
+
+    def test_the_rebuild_does_not_reissue_a_retired_id(self, mod, db, capsys) -> None:
+        """AUTOINCREMENT's promise is that an id is never REUSED, and the rebuild
+        must not quietly withdraw it.
+
+        The copy carries explicit ids, so the rebuilt table's counter lands on
+        ``MAX(id)`` -- the largest id still PRESENT. Delete the top lesson by hand
+        first and the two diverge: without the counter being carried across, the next
+        proposal is handed an id that has already named a different lesson, and a
+        report citing it means two things.
+        """
+        self.a_v2_database(db)
+        self.delete_lesson_by_hand(mod, db, 9)
+
+        run(mod, db, "init")
+        capsys.readouterr()
+        assert self.propose_policy_block_lesson(mod, db) == 0
+        assert int(out_json(capsys)["id"]) > 9
+
+    def test_an_emptied_table_does_not_restart_the_counter_at_one(self, mod, db, capsys) -> None:
+        """The worst version of the same defect.
+
+        A table whose rows were ALL deleted copies nothing, so the rebuilt table gets
+        no sequence row at all and the counter restarts at 1 -- handing out ids that
+        every earlier lesson in this ledger already used.
+        """
+        self.a_v2_database(db)
+        self.delete_lesson_by_hand(mod, db, 7)
+        self.delete_lesson_by_hand(mod, db, 9)
+
+        run(mod, db, "init")
+        capsys.readouterr()
+        run(mod, db, "list", "lessons")
+        assert out_json(capsys) == []
+
+        assert self.propose_policy_block_lesson(mod, db) == 0
+        assert int(out_json(capsys)["id"]) > 9
+
+    def test_the_counter_only_ever_moves_forward(self, mod, db, capsys) -> None:
+        """The restore is guarded so it cannot walk the counter BACKWARDS.
+
+        A ledger written by a newer checkout could carry a mark above anything this
+        rebuild saw; lowering it would be the reissue defect with the roles swapped.
+        """
+        self.a_v2_database(db)
+        conn = mod.connect(db)
+        try:
+            with conn:
+                conn.execute("UPDATE sqlite_sequence SET seq = 500 WHERE name = 'lessons'")
+        finally:
+            conn.close()
+
+        run(mod, db, "init")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            seq = mod._lessons_id_high_water(conn)
+        finally:
+            conn.close()
+        assert seq == 500
+
+    def test_the_foreign_key_still_bites_after_the_rebuild(self, mod, db, capsys) -> None:
+        """Nullable is not unchecked: a PRESENT finding id must still resolve, or the
+        rebuild traded one guarantee for the other."""
+        self.a_v2_database(db)
+        run(mod, db, "init")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            with pytest.raises(Exception):
+                with conn:
+                    conn.execute(
+                        "INSERT INTO lessons (kind, surface, pattern, guidance,"
+                        " source_finding_id, source_policy_block, ts, active)"
+                        " VALUES ('missed', 's', 'p', 'g', 4242, NULL,"
+                        " '2026-09-12T00:00:00+00:00', 0)"
+                    )
+        finally:
+            conn.close()
+
+    def test_a_failed_rebuild_leaves_nothing_behind(self, mod, db, capsys, monkeypatch) -> None:
+        """The rebuild is atomic, and that is a property of the explicit BEGIN.
+
+        Python's sqlite3 driver opens a transaction implicitly before DML only, never
+        before DDL. Every statement in the rebuild except the copy is DDL, so without
+        ``BEGIN IMMEDIATE`` the scratch table's ``DROP`` and ``CREATE`` are
+        autocommitted -- and a rebuild that then fails leaves that table behind, live,
+        for the next upgrader to find and destroy mid-flight.
+
+        The failure is injected at the last step so the interesting statements have all
+        run: if the whole pass is one transaction, the old table comes back untouched
+        and no scratch table survives.
+        """
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("injected failure at the end of the rebuild")
+
+        self.a_v2_database(db)
+        monkeypatch.setattr(mod, "_restore_lessons_id_high_water", boom)
+
+        conn = mod.connect(db)
+        try:
+            with pytest.raises(RuntimeError):
+                mod.init_schema(conn)
+        finally:
+            conn.close()
+
+        conn = mod.connect(db)
+        try:
+            columns = {row["name"] for row in conn.execute("PRAGMA table_info(lessons)")}
+            scratch = conn.execute(f"PRAGMA table_info({mod.LESSONS_REBUILD_TABLE})").fetchall()
+            ids = [int(row["id"]) for row in conn.execute("SELECT id FROM lessons ORDER BY id")]
+        finally:
+            conn.close()
+
+        assert scratch == []
+        # Rolled all the way back: the table is the OLD shape, not a half-migrated one.
+        assert "source_policy_block" not in columns
+        assert ids == [7, 9]
+
+    def test_a_second_upgrader_finds_nothing_to_do(self, mod, db, capsys) -> None:
+        """The loser of the race re-probes rather than rebuilding a second time.
+
+        Two connections, each running the pass to completion in turn -- which is what
+        the serialization reduces concurrent upgraders to. The second must see the
+        finished shape and leave it alone; a version-based gate would be equally happy
+        here, but a shape-based one is what makes the LOSER of a real race safe, since
+        the winner's version bump and its tables land together.
+        """
+        self.a_v2_database(db)
+        first, second = mod.connect(db), mod.connect(db)
+        try:
+            assert mod.init_schema(first) == mod.SCHEMA_VERSION
+            assert mod._lessons_needs_rebuild(second) is False
+            assert mod.init_schema(second) == mod.SCHEMA_VERSION
+        finally:
+            first.close()
+            second.close()
+
+        run(mod, db, "list", "lessons")
+        assert [int(row["id"]) for row in out_json(capsys)] == [7, 9]
+
+    def test_the_pass_takes_the_write_lock_immediately(self, mod) -> None:
+        """Asserted structurally, because the interleaving it prevents cannot be driven
+        from one process without hooks into SQLite's locking.
+
+        Both halves matter. ``BEGIN`` at all is what puts the rebuild's DDL in a
+        transaction, and ``IMMEDIATE`` is what takes the lock BEFORE the probe decides
+        whether to rebuild -- a deferred transaction would acquire it at the first
+        write, by which time both upgraders have already decided to.
+        """
+        source = script_source_with_joined_literals()
+        # The STATEMENT, not the phrase: two docstrings explain the transaction, and one
+        # of them belongs to a function defined earlier in the file, so a bare substring
+        # search finds prose and the position assertions below become meaningless.
+        statement = 'conn.execute("BEGIN IMMEDIATE")'
+        assert statement in source
+        begin = source.index(statement)
+        # Inside init_schema, and before the DDL loop it is supposed to cover.
+        assert source.index("def init_schema") < begin
+        assert begin < source.index("for statement in DDL")
+
+    def test_the_columns_are_spelled_once(self, mod) -> None:
+        """:data:`DDL` and the rebuild both build the table from
+        :data:`LESSONS_COLUMNS`. Two copies of a column list drift the moment one of
+        them gains a column, and the drift is invisible: fresh ledgers would get one
+        shape and migrated ones the other."""
+        source = script_source_with_joined_literals()
+        creates = re.findall(r"CREATE TABLE[^(]*\(\{LESSONS_COLUMNS\}\)", source)
+        assert len(creates) == 2, creates
+        assert "source_policy_block TEXT" in mod.LESSONS_COLUMNS

--- a/test/test_security_conductor_skill_contract.py
+++ b/test/test_security_conductor_skill_contract.py
@@ -301,16 +301,22 @@ class TestRetrospectiveBrief:
     def test_lessons_are_proposed_through_the_ledger_cli(self, skill_text: str) -> None:
         assert "ledger.py propose-lesson" in _flat(_section(skill_text, self.HEADING))
 
-    def test_the_lesson_half_is_gated_on_having_a_finding_to_cite(self, skill_text: str) -> None:
-        """`propose-lesson` requires `--source-finding` and refuses an id that
-        resolves to no finding, and a `policy_block` is an event rather than a
-        finding. An instruction to propose one anyway is an order to run a command
-        that exits 2, so the brief states the constraint and orders the half that
-        always works first."""
+    def test_both_lesson_sources_are_named_and_neither_is_a_dead_end(self, skill_text: str) -> None:
+        """A `policy_block` is an event rather than a finding, so `--source-finding`
+        has no id to resolve for one. `propose-lesson` takes
+        `--source-policy-block` for exactly that case, so the brief must name it:
+        an instruction that only offered the finding flag would send a worker to run
+        a command that exits 2, and the guidance half of the ruling would be lost
+        again.
+        """
         body = _flat(_section(skill_text, self.HEADING))
         assert "golden-path row first" in body
         assert "--source-finding" in body
-        assert "only when the block has a finding to cite" in body
+        assert "--source-policy-block" in body
+        # Every false positive gets both halves now; the old brief made the lesson
+        # conditional, and that condition is the gap this replaces.
+        assert "only when the block has a finding to cite" not in body
+        assert "propose it for every false positive" in body
         assert "never invent a finding id" in body
 
     def test_an_unapproved_lesson_never_reaches_a_seed(self, skill_text: str) -> None:


### PR DESCRIPTION
## Problem / Motivation

The security conductor's retrospective rules on every `policy_block` event a round
recorded: was the fence right, or did it refuse a legitimate operation? A false
positive is supposed to produce two rows — a golden path that stops a future fix
re-breaking the operation, and a lesson that stops the next auditor walking into
the same refusal.

Only the first half could actually be stored. `ledger.py propose-lesson` required
`--source-finding` and refused an id that resolves to no finding, while a
`policy_block` is deliberately an **event** and not a finding — so a block with no
finding to cite had no id, and its lesson could not be written at all.

The M2 pilot's round 1 hit this exactly (report:
`/local/home/zejiangg/.kiro/crew/scratch/secc-pilot/round-1-report.md`). The
`deny-classifier-fence` surface was stopped by the argv floor before it filed
anything, the retrospective ruled the block a false positive, and the round's own
report says what was lost:

> **One lesson could not be persisted.** [...] The consequence of the gap is
> specific — golden-path 50 stops a future fix from re-breaking that operation, but
> nothing stops the next auditor on this surface from walking into the same refusal
> and stopping again. The preventive half is present; the instructive half is
> missing.

## Why it matters

The surface that went unaudited is the deny classifier — the one component whose
rule table can only be read out of its own source. A round silenced there looks
identical to a round that found nothing, and with the lesson unstorable the next
auditor on that surface has nothing telling it to reach for the file-reading tool
and hand the block up rather than ending its surface. The failure repeats per
round, and each repeat costs a whole surface's findings.

## What changed (motivation → approach → change)

**Goal:** a lesson whose source is a policy block rather than a finding.

**Approach considered and rejected:** let `--source-finding` accept an event id.
That would put two different id spaces in one foreign-key column, so the FK would
have to go and every reader would have to guess which space a value came from.

**Approach taken:** a second, separate source column, with exactly one of the two
required.

- `propose-lesson` gains `--source-policy-block REF`. Neither flag is `required`,
  because the requirement is on the pair: passing neither or both prints a sentence
  naming both flags and returns 2.
- The `lessons` table carries `source_policy_block TEXT` and a CHECK admitting
  exactly one source. **The check is the point.** The ledger's own docstring says
  anything that can run the script can open the same file with `sqlite3`, so a rule
  held only by the argument parser would be advice rather than the storage guarantee
  the ledger's fourth property claims. Two sources is as much a defect as none: a
  reader that trusts the first field it finds would attribute guidance to whichever
  it happened to check.
- The CHECK tests **non-blankness, not merely presence**, because for a text column
  that is the whole guarantee — `''` and `'   '` both satisfy `IS NOT NULL`, so a
  NULL-only constraint would let a direct writer store a lesson attributable to
  nothing, by the exact path that makes a parser-only rule insufficient. Two
  details are deliberate: the trim set is named by codepoint, since SQLite's
  one-argument `TRIM` removes spaces only; and the explicit
  `source_policy_block IS NOT NULL` is load-bearing rather than implied by the TRIM
  beside it, because a CHECK rejects only a FALSE result and **passes on NULL** —
  without it `TRIM(NULL, ...)` made the whole constraint NULL and a row with no
  source at all was stored. (Both were caught here, the second by the new
  parametrized case before this branch was pushed with it.)
- `source_finding_id` becomes nullable and keeps its foreign key, so a *present*
  finding id must still resolve.
- A policy-block reference is **not** a foreign key and cannot be — the events it
  names are the round's own record, not a table in this ledger. The docstring says
  so rather than implying the two sources are equally strong.

**Schema 2 → 3, and the migration is a rebuild.** Relaxing `source_finding_id`
from `NOT NULL` is the one step the `CREATE ... IF NOT EXISTS` ladder cannot take,
because SQLite has no `ALTER COLUMN`. So `init_schema` rebuilds the table when it
finds the old shape:

- Gated on `PRAGMA table_info(lessons)` — the table's **actual** columns — not on
  the stored version. The version bump is the last write in `init_schema`, so an
  upgrade interrupted before it must find the same work still to do, and one that
  already ran must find none.
- Runs inside an explicit **`BEGIN IMMEDIATE`** now covering the whole schema pass,
  so an interrupted upgrade is a no-op rather than a half-migrated table *and* a
  second upgrader cannot enter the shared scratch table. The pass used to be nothing
  but `CREATE ... IF NOT EXISTS` plus a precondition-carrying `INSERT`, so it was
  race-safe by construction; the rebuild is destructive DDL, and the driver opens a
  transaction implicitly before **DML only** — never before DDL — so the scratch
  table's `DROP`/`CREATE` would otherwise run in autocommit. `IMMEDIATE` because the
  lock must be held *before* the shape probe decides what work to do. The loser waits
  on the driver's default 5 s busy timeout, then re-probes; a measured v2→v3 rebuild
  holds the lock for 29 ms with 5,000 lessons, so the default has ~170× margin.
- Row **ids are carried across explicitly**: `seed_lessons` ranks recency by id, so
  renumbering would silently reorder every seed built from that ledger afterwards.
- The id **counter** is carried separately from the rows, because copying rows only
  restores the ids that still *exist*. `AUTOINCREMENT`'s mark is the largest id ever
  *issued*, and the two diverge whenever a top row was deleted by hand — the RFC's own
  revert path. A rebuild that let the counter fall back to `MAX(id)` would reissue an
  id that already named a different lesson, and an emptied table would restart it at 1.
  The mark is read before the drop and restored after the rename: an `INSERT` for the
  case where the sequence row is absent, and an `UPDATE` guarded with `seq <` so the
  mark can only ever move forward.
- `approved_by` and `active` survive untouched. A rebuild that activated rows would
  walk guidance into a seed no human let in.
- Migrated rows get a NULL policy-block reference, which is a fact about them
  (they were proposed when a finding id was the only source there was) rather than
  missing data.
- The columns are spelled **once**, in `LESSONS_COLUMNS`, used by both `DDL` and
  the rebuild — two copies of a column list drift the moment one gains a column,
  and the drift would be invisible: fresh ledgers would get one shape and migrated
  ones the other.

**Readers.** `format_lesson` renders `(finding #N)` unchanged for the original
source kind and `(policy block REF)` for the new one, via a `lesson_source` helper;
the two are never both rendered, because the CHECK makes exactly one present.
`seed-lessons`, `approve-lesson` and `list lessons` needed no source-specific
changes — approval never touches the source, and the listing is `SELECT *`.

**SKILL.md.** The retrospective template no longer makes the lesson half
conditional on having a finding to cite: it names both flags, and orders a lesson
for *every* false positive. The standing note that documented the gap now
documents the mechanism, including that a policy-block reference is attributable
but not referentially checked.

## Golden-path row 50 — deferred to the classifier-fix PR

Row 50 (the pilot's approved false-positive row for the `deny-classifier-fence`
surface) was landed in this PR at head `9d13e0e2b6` and **removed again** on the
operator's decision after the review lanes confirmed what the measurements showed.

The corpus is defined as operations the shipped rules **allow** — a regression
tripwire — and two committed gates assert that no shell row is refused at head:

```
test/test_deny_diff.py::test_corpus_rows_are_all_allowed_by_the_shipped_composite
test/test_security_conductor_verify_fix.py::TestTheShippedCorpusIsALiveGate
    ::test_every_shipped_shell_row_is_permitted_by_the_real_deny_composite
```

Row 50's operation is still refused, so with the row present both gates fail
(deterministically, on every platform) and Design Review returns BLOCK on the
grounds that a refused row protects no operation. `deny_diff` itself exits 0 with
the row present (refused at both refs = unchanged), which is why the differential
alone was not enough to catch this.

The refusal mechanism, verified in source: `src/kiro_crew/security/argv_floor.py`
defines `_SELF_IMPORT_RE = re.compile(r"\bkiro_crew\b")`, which matches the
package name inside a **file-path literal** (`open('src/kiro_crew/security/…')`)
and not only inside an import. That is the false positive the pilot recorded.

**Follow-up PR**: fix `_SELF_IMPORT_RE` to distinguish a path literal from an
import, and land row 50 in the same change — at which point both corpus gates hold
it permitted and the row starts doing its job. Row 50 stays approved (`active=0`)
in the pilot ledger until then. Nothing in this PR depends on it.

Also applied from the First Principles review: `PRAGMA busy_timeout = 30000` is
dropped — the driver's 5 s default covers the one-table rebuild.

## Tests

35 added, in two classes in `test/test_security_conductor_ledger.py`:

`TestALessonMaySourceAPolicyBlock`
- a policy-block-sourced lesson proposes, approves, and reaches a seed line — with
  no finding anywhere in the ledger — and that line carries `policy block REF` and
  never the string `finding #`
- the second source widens what may be cited, not the approval gate: a proposed
  policy-block lesson is still `active=0` and absent from the seed
- neither source → exit 2, nothing written
- both sources → exit 2, nothing written
- a blank flag value → exit 2, asserted on the *blankness* message, because exit 2
  alone is also what argparse returns for an unrecognised option and the test would
  otherwise pass on a tree where the flag does not exist
- the CHECK refuses all five unattributable shapes written by hand with `sqlite3` —
  no source, two sources, `''`, `'   '` and `'\t\n'`
- and, from the other side of that boundary, a reference with surrounding and
  interior whitespace is stored unchanged, so the guard cannot be "reject anything
  containing whitespace" and still pass
- a finding-sourced lesson still renders identically

`TestLessonsRebuildKeepsWhatWasThere` — a v2 ledger carrying two lessons (one
approved, one not), written as raw SQL so it genuinely predates the current DDL:
- it opens and reports the new version
- both lessons survive with their ids, patterns, approvers and active flags; the
  unapproved one stays unapproved
- it accepts a policy-block lesson afterwards, which the old `NOT NULL` would have
  refused
- the rebuild is idempotent across a second `init`
- no `lessons_rebuild` scratch table is left behind
- the `lessons_active` index survives
- the foreign key still bites on a present-but-unresolvable finding id
- the column list is spelled once
- a retired id is not reissued, an emptied table does not restart the counter at 1,
  and a mark set higher by hand is not walked backwards — each driving the deletion
  through a hand-written row edit, since the CLI has no delete verb
- a rebuild that fails at its last step rolls all the way back: no scratch table
  survives, `lessons` is in its *old* shape rather than a half-migrated one, and both
  rows are intact
- a second upgrader running the pass afterwards finds nothing to do
- structurally, the `conn.execute("BEGIN IMMEDIATE")` statement sits inside
  `init_schema` and before the DDL loop it must cover — asserted on the statement
  rather than the phrase, since two docstrings also mention the transaction

Updated: the declared `lessons` column list gains `source_policy_block`; the v1
migration test now asserts against `mod.SCHEMA_VERSION` rather than a literal `2`;
and `test_the_lesson_half_is_gated_on_having_a_finding_to_cite` in
`test/test_security_conductor_skill_contract.py` is re-pointed — it pinned the
prose describing the gap, so it becomes
`test_both_lesson_sources_are_named_and_neither_is_a_dead_end` and asserts the old
conditional is gone.

**Red-before proven, four times.** With `ledger.py` reverted to `origin/main` and
the tests kept, 9 fail — including `test_neither_source_is_refused`, which on that tree
raises `SystemExit: 2` from argparse's `required=True` rather than returning 2 from
`_dispatch`. And against the presence-only CHECK this branch's earlier head carried,
the `empty-string`, `spaces` and `ascii-whitespace` cases each report
`DID NOT RAISE`. And against the head before the counter was carried across, the two
id cases report `assert 8 > 9` (an id reissued) and `assert 1 > 9` (the counter
restarted at 1). And against the head before the pass was wrapped in a transaction,
the atomicity case finds a live leftover `lessons_rebuild` table after a failed
rebuild. Each is a review finding reproduced as a failing assertion rather than taken
on description.

**Mutation-checked.** Deleting the index recreation from `_rebuild_lessons` turns
`test_the_active_index_survives_the_rebuild` red, so that guard executes the branch
it claims to cover rather than passing on a path the tests never reach.

## Manual verification

- End-to-end through the CLI on a scratch ledger: `propose-lesson` with
  `--source-policy-block` → `approve-lesson` → `seed-lessons` emits
  `- [false-positive] deny-classifier-fence: ... (policy block m2-round-1/policy_block-1)`;
  neither-source and both-sources each print the sentence and exit 2.
- `deny_diff.py --base origin/main --head HEAD --corpus <the committed corpus> --json`
  → **exit 0**, 49 rows, 41 classified, 0 regressions, 0 loosenings,
  `unchanged_allowed: 41`, `unchanged_denied: 0`.
- Row 50's refusing tier read back through `deny_diff`'s own hermetic child against a
  materialized HEAD checkout (not by importing the product here): `deny-rules`,
  `credential-exfil-kirocrew-token`, argv floor. A `git status --porcelain` control row
  in the same pass is allowed, so the refusal is the rule and not the harness.
- Local gates, exact CI commands: `check_black_formatting.py` pass (4 changed
  files in scope), `isort --check-only` pass, `flake8` pass, `mypy src/kiro_crew/`
  pass (1457 files), `docs_lint.py` and `docs-lint.sh` pass, and all five
  `test/test_security_conductor_*.py` plus `test/test_deny_diff.py` pass
  (479 tests).
- Nothing in the pilot database was approved or modified.

## Related Issues

Follow-up work from the M2 security-conductor pilot, round 1 — see
`round-1-report.md`, section "Proposed rows" and the note "One lesson could not be
persisted".

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

