### PR TITLE
fix: format two files with the pinned black so main's ratchet audit is green

### DIFF
--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -540,8 +540,7 @@ class AcpRuntimeProtocol(Protocol):
         """
         ...
 
-    def death_summary(self) -> str | None:
-        ...
+    def death_summary(self) -> str | None: ...
 
 
 class AcpSessionHandle:

--- a/test/test_slot_close_nudge_race.py
+++ b/test/test_slot_close_nudge_race.py
@@ -140,9 +140,11 @@ async def test_loop_is_retired_before_the_persist_begins(tmp_path, monkeypatch) 
     resp = await handlers.api_chat_slot_delete(_Req(state, NAME))
 
     assert resp.status == 200
-    assert order == ["loop:removed", "persist", "session_teardown"], (
-        "the loop must be gone before the closure is persisted, not after"
-    )
+    assert order == [
+        "loop:removed",
+        "persist",
+        "session_teardown",
+    ], "the loop must be gone before the closure is persisted, not after"
     svc.stop()
 
 
@@ -162,9 +164,9 @@ async def test_close_with_no_armed_loop_is_unaffected(tmp_path, monkeypatch) -> 
     saved = state.conversation_log.read_messages(f"dashboard:{NAME}")
     assert [m["role"] for m in saved] == ["user", "assistant"]
     survivor = svc.get_by_slot("chat-2-9999")
-    assert survivor is not None and survivor.id == other.id, (
-        "closing one tab retired another tab's loop"
-    )
+    assert (
+        survivor is not None and survivor.id == other.id
+    ), "closing one tab retired another tab's loop"
     svc.stop()
 
 
@@ -186,9 +188,7 @@ async def test_failed_persist_gives_the_session_its_clock_back(tmp_path, monkeyp
     """A close that cannot persist must not silently retire the babysit loop."""
     state = _state_with_slot(tmp_path)
     svc = await _service(tmp_path, monkeypatch)
-    loop = await svc.add(
-        NAME, "check the PR", idle_secs=300, max_cycles=24, max_runtime_secs=3600
-    )
+    loop = await svc.add(NAME, "check the PR", idle_secs=300, max_cycles=24, max_runtime_secs=3600)
     loop.cycle_count = 3
     loop.created_ts = time.time() - 600
 
@@ -436,9 +436,7 @@ async def test_app_close_waits_for_a_queued_direct_arm(tmp_path, monkeypatch) ->
 
 
 @pytest.mark.asyncio
-async def test_app_close_retires_the_latest_queued_arm_generation(
-    tmp_path, monkeypatch
-) -> None:
+async def test_app_close_retires_the_latest_queued_arm_generation(tmp_path, monkeypatch) -> None:
     state = _state_with_slot(tmp_path)
     state._slots[NAME]._app = "issue-radar"
     svc = await _service(tmp_path, monkeypatch)
@@ -505,9 +503,7 @@ async def test_issue_radar_arm_queued_behind_final_retirement_is_refused(
         return True
 
     monkeypatch.setattr("kiro_crew.apps.teardown.notify_slot_closed", _hook)
-    monkeypatch.setattr(
-        crew_runtime, "ensure_crew_session", AsyncMock(return_value=slot)
-    )
+    monkeypatch.setattr(crew_runtime, "ensure_crew_session", AsyncMock(return_value=slot))
     monkeypatch.setattr(
         crew_runtime,
         "compose_turn_prompt_async",


### PR DESCRIPTION
## Problem / Motivation

The **Main Ratchet Audit** workflow fails on every push to main. Its job
"Backend ratchet & baseline gates" has been red on every main commit for days
(checked runs for `8b58f72a8`, `ea9ada27f`, `97ff065ed`, `cbfd3a6d7`,
`82988b783`, `0c67a7179` — all `failure`).

The red gate is the black one. Two files on main are not formatted the way
black 26.3.1 formats them, and neither is listed in `.github/black-baseline.txt`:

```
::error file=src/kiro_crew/acp/session_handle.py::not black-formatted. Run: black --target-version py310 src/kiro_crew/acp/session_handle.py
::error file=test/test_slot_close_nudge_race.py::not black-formatted. Run: black --target-version py310 test/test_slot_close_nudge_race.py

black gate FAILED: 2 new offender(s), 0 graduated entr(y/ies) to prune.
```

26.3.1 is the version `pyproject.toml` pins and CI installs. Both files were
pruned from the baseline as graduated, so the gate now judges them, and it
disagrees with the style they carry.

## Why it matters

A gate that is always red teaches everyone to skip it. While this one is red,
real drift in the other five ratchet lanes lands on main unnoticed, and the
first person to see it is the author of an unrelated pull request, whose
cheapest way out is to raise the ceiling. That is the exact failure the audit
exists to stop.

## What changed (motivation → approach → change)

The symptom is two files the black gate calls unformatted.

The cause is that the two files were written with a black that formats them a
different way. The pinned black is the one CI runs, so the pinned black is the
one that decides.

The change is `black --target-version py310` run on exactly those two files.
Nothing else. No baseline edit, no suppression, no other file touched.

**No behaviour changes.** The diff is whitespace and line wrapping only: a
protocol stub folded onto one line, three call argument lists joined, two assert
messages rewrapped. Both files parse to the same AST before and after
(`ast.dump` equal on the base commit vs this head).

## Tests

No new tests. This is a formatting fix; the gate it satisfies is
`scripts/check_black_formatting.py`, which is already wired into CI and into the
Main Ratchet Audit.

Ran on this branch:

- `RATCHET_SCOPE_WHOLE_TREE=1 python3 scripts/check_black_formatting.py` — passes
  (the main-push scope, the one the audit uses).
- The audit's other five backend gates in the same scope — all pass.
- `test/test_slot_close_nudge_race.py` — 17 passed.
- Every test file that names `session_handle` or `AcpSessionHandle` (44 files) —
  3682 passed, 1 skipped.
- `flake8` and `isort --check-only` on the two changed files — clean.

## CI note: the one red, and why it is not this diff

`Backend Tests (Windows) (2)` failed once and passed on a rerun of that single
job, same head, nothing pushed between them:

- attempt 1, job `103522662732`, started 08:00:33 — failure at 24m0s on
  `test/test_eager_spawn.py::TestPrewarmAdmission::test_two_concurrent_slot_signals_against_one_allowance_spawn_once`,
  `Expected get_or_create to have been awaited once. Awaited 2 times.`
- attempt 2, job `103528196866`, 08:48:12 to 09:13:23 — success.

That test asserts the outcome of a race: two slots pre-warm at once against an
allowance of one, and exactly one may spawn. It holds only while the first
signal is still mid-handshake, which the test fakes with a 0.01s sleep. If the
runner is slow enough that the first signal registers before the second reaches
admission, the first key stops being a reservation, so it becomes evictable and
the second signal spawns too. Ordering alone, and a whitespace diff cannot move
it — the two changed files are AST-identical and `test/test_eager_spawn.py`
references neither.

## Manual verification

N/A — the gate is the verification, and it is run above in the same scope CI
uses.

## Note: how the baseline prune let this in (recorded, not fixed here)

Worth a separate look, because the same thing will happen again. Both files were
removed from `.github/black-baseline.txt` as graduated —
`src/kiro_crew/acp/session_handle.py` by #10238, `test/test_slot_close_nudge_race.py`
by #5186 — while neither was clean under the pinned black 26.3.1. A prune says
"this file is formatted now", so the file loses its exemption and the gate starts
judging it; if the author's local black formats it differently from the pinned
one, their run agrees the file is clean and only the integrated tree disagrees.
The open question is which black the prune step verifies against: the pinned
version, or whatever the author happens to have. Nothing in this PR addresses
that.

## Related Issues

No linked issue closes on merge: this PR fixes the two files, and the mechanism
that let the bad baseline prune happen is tracked separately in #10329, which
stays open after this merges. The drift itself is visible in the Main Ratchet
Audit runs on main.

## Pattern harvest

Rule candidate: `lint`
Pattern: a baseline prune that graduates a file measured by a different local
formatter version than the pinned one, so the file passes the contributor's
run and fails the gate on the integrated tree.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (no new behaviour to test)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


