### PR TITLE
test(cron): align malformed-owner removal test with the loader's type guard

### DIFF
--- a/test/test_remove_slot_for_history_key.py
+++ b/test/test_remove_slot_for_history_key.py
@@ -853,7 +853,11 @@ class TestAFailedRemovalDoesNotLeakIntoTheNextSave:
 
         reloaded = CronService(base_dir=tmp_path)
         assert reloaded.get_job(parent.id) is None
-        assert reloaded.get_job(malformed.id).session_key == ["not", "a", "string"]
+        # The malformed row survives the unrelated removal. The loader coerces a
+        # non-string owner to unset, so the invariant is "still present, not
+        # poisoned" -- not byte preservation of a value the loader rejects.
+        assert reloaded.get_job(malformed.id) is not None
+        assert reloaded.get_job(malformed.id).session_key == ""
 
     def test_a_failed_removal_is_not_persisted_by_an_unrelated_later_save(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Summary

Unblocker: main has been red on **Backend Tests (3.12, 3)**, **Backend Tests (Windows) (3)** and **Coverage Gate** since 04:12 UTC (first red main run: `8b58f72a8`, run 34675714755). Every PR rebased onto current main inherits the same three reds.

**Cause -- cross-merge.** #9109 (merged 2026-09-12 04:12 UTC) added `test_malformed_persisted_owner_does_not_poison_unrelated_removal`, asserting that a cron job whose persisted `session_key` is a list survives an unrelated removal byte-for-byte. One minute earlier #9888 (04:11 UTC) made `_job_from_json` coerce non-string record fields to unset at deserialization and log `Coercing non-string value(s) in cron job entry ... to unset`. Each landed green against a base without the other.

**Fix.** The test's invariant is that the malformed row is *still present* after the unrelated removal -- the removal did not poison it. Byte preservation of a value the loader is now specified to reject was never the point, so the assertion checks presence and the coerced value (`""`). One test file, +5/-1; no production code.

## Verification

- `TestAFailedRemovalDoesNotLeakIntoTheNextSave` (3 tests) pass locally against current main.
- `black --check` clean.

no linked issue: main-red unblocker for a cross-merge between two already-merged PRs.
