### PR TITLE
fix: uncap agent-scratch tree-idle walk to reclaim dead trees (#9508)

### DIFF
--- a/src/kiro_crew/agent_scratch.py
+++ b/src/kiro_crew/agent_scratch.py
@@ -141,11 +141,6 @@ def _pgroup_alive(pid: int) -> bool:
     return platform_compat.pgroup_exists(pid)
 
 
-#: Entry cap for the tree-idle walk: a tree too big to scan cheaply reads as
-#: ACTIVE (kept) -- the sweep must stay cheap and err toward keeping.
-_TREE_IDLE_SCAN_CAP = 10_000
-
-
 def _tree_newest_mtime(root: Path, fallback: float) -> float:
     """The newest mtime anywhere in *root*'s tree (lstat, symlinks never followed).
 
@@ -153,20 +148,24 @@ def _tree_newest_mtime(root: Path, fallback: float) -> float:
     touches the top DIRECTORY's mtime, but every write refreshes the FILE's
     own mtime -- so tree-newest is the faithful idle signal on every
     platform, and the only one available on Windows (no process groups).
-    Fail-safe: an unreadable entry or a tree past the scan cap returns
-    *fallback* (reads as active, the sweep keeps the dir).
+    Fail-safe: an unreadable entry returns *fallback* (reads as active, the
+    sweep keeps the dir).
+
+    Deliberately UNCAPPED: an entry cap that bails to *fallback* turns every
+    tree larger than the cap into a permanently active-looking one, so a
+    dead owner that wrote enough entries could never be reclaimed and
+    repeated runs would exhaust storage. The walk runs off the event loop
+    (``asyncio.to_thread``) on an hourly cadence, and its size is bounded
+    by what one runtime wrote into its OWN scratch dir, so a full metadata
+    walk is the right trade (see ``mcp_gateway.backend_tmp``).
     """
     newest = 0.0
-    seen = 0
     try:
         newest = os.lstat(root).st_mtime
         stack = [root]
         while stack:
             current = stack.pop()
             for entry in os.scandir(current):
-                seen += 1
-                if seen > _TREE_IDLE_SCAN_CAP:
-                    return fallback
                 info = os.lstat(entry.path)
                 if info.st_mtime > newest:
                     newest = info.st_mtime

--- a/test/test_agent_scratch.py
+++ b/test/test_agent_scratch.py
@@ -138,3 +138,57 @@ class TestLivenessSweep:
 
         assert removed == 0
         assert victim.exists() and (victim / "keep").exists()
+
+    #: Large enough that a capped walk would misread the tree as active;
+    #: a local constant so the test stands on its own.
+    LARGE_TREE_ENTRIES = 10_001
+
+    @classmethod
+    def _build_large_tree(cls, path: Path) -> Path:
+        """Populate *path* with an over-cap ``target/`` tree; return one deep file."""
+        target = path / "target"
+        deep = target / "debug" / "deps"
+        deep.mkdir(parents=True)
+        for i in range(cls.LARGE_TREE_ENTRIES):
+            (target / f"unit-{i}.o").touch()
+        deep_file = deep / "artifact.rlib"
+        deep_file.touch()
+        return deep_file
+
+    def test_dead_idle_tree_larger_than_former_scan_cap_is_reclaimed(
+        self, scratch_root: Path
+    ) -> None:
+        # A capped walk bails to the sweep-timestamp fallback on a tree this
+        # large and misreads it as permanently active; the uncapped walk must
+        # reclaim a dead owner's cargo-target-sized residue.
+        path = sc.allocate_scratch("bigdead")
+        sc.record_owner(path, 2**22 - 1)  # almost surely dead
+        self._build_large_tree(path)
+        now = time.time() + 2 * sc._UNOWNED_GRACE_SECONDS
+
+        assert sc.sweep_dead_scratch(now=now) == 1
+        assert not path.exists()
+
+    def test_live_owner_large_tree_is_kept(self, scratch_root: Path) -> None:
+        # Size must not cause deletion: a live owner keeps its tree however
+        # large and however idle.
+        path = sc.allocate_scratch("biglive")
+        live_ref = os.getpid() if sys.platform == "win32" else os.getpgrp()
+        sc.record_owner(path, live_ref)
+        self._build_large_tree(path)
+        now = time.time() + 2 * sc._UNOWNED_GRACE_SECONDS
+
+        assert sc.sweep_dead_scratch(now=now) == 0
+        assert path.exists()
+
+    def test_fresh_deep_write_in_large_dead_tree_keeps_it(self, scratch_root: Path) -> None:
+        # The uncapped walk must still see a fresh write deep inside a large
+        # dead-owner tree: one recent file anywhere reads as in-use.
+        path = sc.allocate_scratch("bigfresh")
+        sc.record_owner(path, 2**22 - 1)  # dead owner
+        deep_file = self._build_large_tree(path)
+        now = time.time() + 2 * sc._UNOWNED_GRACE_SECONDS
+        os.utime(deep_file, (now, now))  # the one fresh entry
+
+        assert sc.sweep_dead_scratch(now=now) == 0
+        assert path.exists()


### PR DESCRIPTION
Closes #9508

## What

`agent_scratch._tree_newest_mtime()` bailed to the caller-provided `fallback` once a tree exceeded the 10,000-entry `_TREE_IDLE_SCAN_CAP`. `sweep_dead_scratch()` passes the sweep timestamp as that fallback, so every over-cap tree read as `idle == 0`, the grace-window check `continue`d, and the owner-liveness check was never reached. Cargo `target/` and `node_modules` trees routinely exceed 10,000 entries, so a dead owner's large scratch tree was retained permanently rather than reclaimed — the reporter measured 16.7 GB of a 17 GB scratch root held by seven dead-owner directories idle 26–30 h.

This removes the cap (constant, counter, and bail branch) and updates the docstring, bringing the walk into byte-for-byte parity with the deliberately UNCAPPED sibling `mcp_gateway.backend_tmp._tree_newest_mtime()`, whose docstring documents this exact failure mode as the reason it carries no cap. The same trade applies here: the walk runs off the event loop via `asyncio.to_thread` on an hourly cadence, and its size is bounded by what one runtime wrote into its own scratch dir. Everything else is untouched: `os.lstat` classification, iterative `os.scandir` stack walk, symlinks never descended, `except OSError` fail-open toward keeping, and `sweep_dead_scratch()`'s ordering and deletion containment.

## Tests

Three additions to `test/test_agent_scratch.py` (`TestLivenessSweep`, same fixture style):

- `test_dead_idle_tree_larger_than_former_scan_cap_is_reclaimed` — dead owner, 10,001-entry `target/` tree, `now` two grace windows out: swept (`== 1`, dir gone). Fails on the capped walk.
- `test_live_owner_large_tree_is_kept` — same tree, live owner (`os.getpgrp()` / `os.getpid()` on Windows): kept. Size never causes deletion.
- `test_fresh_deep_write_in_large_dead_tree_keeps_it` — same tree, dead owner, one deep file `os.utime`d to `now`: kept. The uncapped walk still sees a fresh deep write.

All existing sweep tests (live owner kept, deep fresh write kept, ownerless/garbled kept, symlink children never followed, containment) are unchanged.

Local gates: black (diff-scoped), isort, subprocess-encoding, flake8, mypy all green. Test execution is left to CI per repo policy for this pipeline.

## Pattern harvest

- **A safety cap that bails to "active" is a leak generator.** Any idle/staleness walk that answers "fresh" when it gives up (entry cap, depth cap, timeout) converts every tree beyond the bound into a permanently retained one. If a walk must be bounded, the bail answer has to be "unknown → decide by the other signals," never "active." Here the correct resolution was the one `backend_tmp` already chose: no cap, because the walk is off-loop, hourly, and naturally bounded by one runtime's own output.
- **Sibling implementations that diverge on a guard are a defect signal.** The uncapped `backend_tmp._tree_newest_mtime()` docstring already documented this exact failure mode; the capped copy in `agent_scratch.py` regressed the lesson. When two copies of a walk disagree on a safety property, check which one carries the postmortem reasoning.
- **Regression tests must pin both directions of a removed guard:** the over-cap dead tree is now reclaimed, and size alone still never deletes a live or freshly-written tree.

Rule candidate: a bounded idle/staleness walk must bail toward "unknown, decide by the other signals" (or carry no bound), never toward "active" — a give-up answer of "fresh" turns every tree beyond the bound into permanent retention.

## Pre-push review

Two blind model-pinned lanes, both PASS, no blocking findings. Two Low advisories triaged as deliberate:

- Walk-before-liveness ordering in `sweep_dead_scratch()` means a live owner's large tree still gets a full hourly metadata walk. Kept: `backend_tmp.py` has the identical ordering (parity), and the issue's fix scope explicitly leaves `sweep_dead_scratch()` ordering untouched.
- The two companion large-tree tests also pass under the capped walk; they exist to pin that size alone never causes deletion and that a fresh deep write in an over-cap tree still reads as in-use.

## Not changed

`_UNOWNED_GRACE_SECONDS`, the sweep cadence, `sweep_dead_scratch()` ordering/containment, and `mcp_gateway/backend_tmp.py`.
