### PR TITLE
feat: doctor flags configs naming deprecated agent specs (#10268)

### DIFF
--- a/docs/request-for-change/rfc-conductor-work-ledger.md
+++ b/docs/request-for-change/rfc-conductor-work-ledger.md
@@ -974,15 +974,19 @@ describes patrol, so a conductor sizes its interval against the real cost. Phase
 remains worth doing and is now an optimisation of the shipped conductor rather than of a
 variant of it.
 
-**Still owed before the alias is deleted.** The retirement spec above requires a
+**The doctor notice -- shipped.** The retirement spec above requires a
 `kirocrew doctor` notice for any config that still names `kirocrew-ledger-conductor`,
-and no doctor change ships with the swap. Nothing tells a cron owner or a crew binding
-that its agent name is going away — the deprecated `description` is read by an operator
-looking at the roster, not by a config file — so without the notice the one-release
-window warns nobody and the name's deletion is a `Mode not found` at the far end. The
-notice is a **precondition for deleting the alias**, not for the swap: while the alias
-exists, an unmigrated config keeps working. Tracked as
-[#10268](https://github.com/kirodotdev/KiroCrew/issues/10268).
+and that notice now ships ([#10268](https://github.com/kirodotdev/KiroCrew/issues/10268)):
+doctor scans every config surface that persists an agent name -- cron jobs
+(`agent_id`, and `agent_sequence` entries when the sequence actually dispatches),
+crew bindings (`agents.<name>.kiro_agent`), the config's own selectors
+(`agent.default_agent`, `session.pool_agent`, per-channel `agent` overrides), and
+open chat slots -- and reports any that names a deprecated spec, naming the
+replacement. The check is data-driven off `DEPRECATED_AGENT_SPECS` in `agent.py`,
+defined beside the alias installer so a future rename adds a row instead of a new
+check, and a row is deleted together with its alias. The notice is a
+**precondition for deleting the alias**, not for the swap: while the alias
+exists, an unmigrated config keeps working.
 
 **Mid-goal behaviour.** A `kirocrew-conductor` session that was mid-goal under the old
 procedure wakes into the ledger prompt with its item state still in `session_ledger`

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -6300,6 +6300,21 @@ def _install_conductor_agent() -> None:
     logger.info("Installed conductor agent config: %s", path)
 
 
+#: Deprecated agent-spec name -> the current spec that replaced it.
+#:
+#: One row per installed alias. ``kirocrew doctor`` reads this table to warn
+#: any config surface that persists an agent name -- a cron job, a crew
+#: binding, a chat slot -- while the old name still resolves, so deleting the
+#: alias later breaks nobody silently with ``Mode not found`` at dispatch
+#: time. A row is deleted together with its alias installer, never before:
+#: the doctor notice is the precondition for the deletion (see
+#: ``docs/request-for-change/rfc-conductor-work-ledger.md``, "What retired
+#: means for the name").
+DEPRECATED_AGENT_SPECS: dict[str, str] = {
+    "kirocrew-ledger-conductor": "kirocrew-conductor",
+}
+
+
 def _install_ledger_conductor_agent() -> None:
     """Install the deprecated ``kirocrew-ledger-conductor`` alias spec.
 

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -1091,6 +1091,127 @@ def _doctor_cron_script_sources(issues: list[str]) -> None:
         )
 
 
+def _open_slot_agent_names() -> list[tuple[str, str]]:
+    """``(slot key, agent name)`` for every open dashboard tab persisting one.
+
+    Read-only + best-effort: reads ``open_slots.json`` and each open slot's
+    transcript metadata line off disk (no running gateway needed), returning an
+    empty list on any error. Slot keys pass through the restore path's own
+    sanitizer before they reach path construction -- the file is
+    attacker-writable, and doctor must not accept a key the restore path would
+    reject.
+    """
+    try:
+        from kiro_crew.dashboard.chat_persistence import (
+            _read_open_slots_keys,
+            _sanitize_open_slot_key,
+        )
+        from kiro_crew.dashboard.chat_utils import slot_transcript_key
+        from kiro_crew.history import ConversationLog
+
+        log = ConversationLog()
+        out: list[tuple[str, str]] = []
+        for raw in _read_open_slots_keys():
+            key = _sanitize_open_slot_key(raw)
+            if not key:
+                continue
+            # slot_transcript_key, not _history_key_for: a channel-born tab's
+            # slot key (e.g. slack_<ts>) already addresses its transcript, and
+            # an unconditional dashboard: prefix would read a nonexistent file
+            # and silently skip that tab.
+            agent = log.get_metadata(slot_transcript_key(key)).get("agent")
+            if isinstance(agent, str) and agent:
+                out.append((key, agent))
+        return out
+    except Exception:
+        logger.debug("doctor: open-slot agent scan failed", exc_info=True)
+        return []
+
+
+def _doctor_deprecated_agent_specs(cfg: KiroCrewConfig, issues: list[str]) -> None:
+    """Report configs that still name a deprecated agent spec.
+
+    A deprecated spec (``DEPRECATED_AGENT_SPECS`` in ``agent.py``) still
+    resolves for one release, so a config surface naming it -- a cron job, a
+    crew binding, an open chat slot, or one of the config's own agent
+    selectors -- keeps working today and breaks with ``Mode not found`` at
+    dispatch time once the alias is deleted. Each finding names the replacement so the owner
+    can migrate inside the window.
+
+    Silent when nothing names one: the installed alias spec by itself is
+    expected (the gateway installs it every boot), not a finding.
+    """
+    from kiro_crew.agent import DEPRECATED_AGENT_SPECS
+    from kiro_crew.cron import job_agent_names_from_disk
+
+    # (holder description, deprecated name, replacement). Holder text is
+    # user/LLM-writeable (crew names, job names, slot keys) so it goes through
+    # _safe_display; the matched name and its replacement are keys and values
+    # of our own table, so they print as-is.
+    findings: list[tuple[str, str, str]] = []
+
+    # A cron job, chat slot, or config selector may name a CREW rather than a
+    # kiro agent spec; the crew row owns that report, so those names are
+    # skipped on the leaf surfaces rather than double-flagged through the
+    # crew's binding.
+    crew_names = set(cfg.agents)
+
+    def _add(holder: str, name: object) -> None:
+        # config.json is hand-editable and agent-writable, and the loader
+        # preserves some of these values verbatim (e.g. kiro_agent), so a
+        # non-string can arrive here. dict.get on an unhashable value raises
+        # TypeError, and doctor must diagnose a malformed config, not crash
+        # on it -- a non-string never names a deprecated spec, so skip it.
+        if not isinstance(name, str) or not name or name in crew_names:
+            return
+        replacement = DEPRECATED_AGENT_SPECS.get(name)
+        if replacement:
+            findings.append((holder, name, replacement))
+
+    # Crew bindings: config.json agents.<name>.kiro_agent. A crew name is not
+    # skipped here -- crew_names shields only the LEAF surfaces that resolve
+    # through a crew, and a kiro_agent that happens to equal a crew name is
+    # not resolved again.
+    for crew_name, crew in cfg.agents.items():
+        name = crew.kiro_agent
+        if not isinstance(name, str) or not name:
+            continue
+        replacement = DEPRECATED_AGENT_SPECS.get(name)
+        if replacement:
+            findings.append((f"crew {_safe_display(crew_name)}", name, replacement))
+
+    # The config's own persisted agent selectors.
+    _add("agent.default_agent", cfg.agent.default_agent)
+    _add("session.pool_agent", cfg.session.pool_agent)
+    for channel_id, channel in cfg.slack_channels.items():
+        _add(f"slack channel {_safe_display(channel_id)}", channel.agent)
+
+    # Cron jobs: the agent names dispatch actually runs, read off crons.json
+    # (agent_id, or the agent_sequence entries when the sequence dispatches).
+    for holder, name in job_agent_names_from_disk():
+        _add(f"cron job {_safe_display(holder)}", name)
+
+    # Chat slots: each open tab's persisted agent from its transcript metadata.
+    for slot_key, name in _open_slot_agent_names():
+        _add(f"chat slot {_safe_display(slot_key)}", name)
+
+    if not findings:
+        return
+
+    print("\nDeprecated Agent Specs")
+    for holder, name, replacement in findings:
+        print(
+            f"  {holder}:  \u26a0\ufe0f  names deprecated agent spec "
+            f"'{name}' -- rename it to '{replacement}'"
+        )
+    print(
+        "               A deprecated spec still resolves this release and is "
+        "deleted next release; a config still naming it then fails with "
+        "'Mode not found' at dispatch time."
+    )
+    issues.append("a config names a deprecated agent spec")
+
+
 def _doctor_managed_service_policy(issues: list[str]) -> None:
     """Surface installed service definitions that predate launch-class policy."""
     state = service_controller.installed_service_has_managed_marker()
@@ -3557,6 +3678,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     # ── Data Home (+ leftover legacy home) ──
     _doctor_data_home()
     _doctor_cron_script_sources(issues)
+    _doctor_deprecated_agent_specs(cfg, issues)
     _doctor_path_launcher()
     _doctor_trust_root()
     _doctor_strict_identity(cfg)

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -311,6 +311,59 @@ def referenced_skill_names() -> set[str]:
     return out
 
 
+def agent_sequence_dispatches(seq: list[str]) -> bool:
+    """Whether a job's ``agent_sequence`` is what dispatch actually runs.
+
+    A sequence of more than one agent takes precedence over ``agent_id``; a
+    shorter one is dormant and dispatch falls through to ``agent_id``. This is
+    the ONE spelling of that gate -- the Slack dispatch path, session-key
+    stability, and the doctor's disk reader all call it, so a change to the
+    dispatch semantics cannot silently leave a consumer reporting (or keying)
+    against the old rule.
+    """
+    return len(seq) > 1
+
+
+def job_agent_names_from_disk() -> list[tuple[str, str]]:
+    """``(job name, agent name)`` for every agent a stored cron job dispatches.
+
+    Read-only + best-effort like :func:`referenced_skill_names`: reads
+    ``crons.json`` directly (so it needs no running scheduler) and returns an
+    empty list on any error. ``kirocrew doctor`` uses this to warn when a job
+    still names a deprecated agent spec.
+
+    Mirrors dispatch, not storage: a ``script`` or ``command`` job bypasses
+    agent dispatch entirely, so its agent fields are dormant and the record is
+    skipped whole; otherwise, when :func:`agent_sequence_dispatches` the
+    sequence entries are reported and ``agent_id`` is dormant, else
+    ``agent_id`` is reported and the sequence (if any) is dormant. A record
+    whose fields the scheduler's own loader rejects (a non-list sequence, a
+    non-string entry or ``agent_id``) dispatches nothing, so it contributes
+    nothing here rather than failing doctor over a job that never runs.
+    """
+    out: list[tuple[str, str]] = []
+    try:
+        for j in _read_job_records(config_dir() / _CRONS_FILE)[0]:
+            if j.get("script") or j.get("command"):
+                continue  # runs with no LLM; agent fields are dormant
+            label = j.get("name") or j.get("id")
+            holder = label if isinstance(label, str) and label else "<unnamed job>"
+            seq = j.get("agent_sequence", [])
+            if not isinstance(seq, list) or any(not isinstance(s, str) for s in seq):
+                continue  # the scheduler's loader rejects this record whole
+            agent_id = j.get("agent_id", "")
+            if agent_id is not None and not isinstance(agent_id, str):
+                continue  # same rejection class
+            if agent_sequence_dispatches(seq):
+                names = [s for s in seq if s]
+            else:
+                names = [agent_id] if agent_id else []
+            out.extend((holder, name) for name in names)
+    except Exception:
+        return []
+    return out
+
+
 _STORE_VERSION = 2
 _MIN_INTERVAL_SECS = 60
 _JOB_TIMEOUT_SECS = 1800  # 30 min per job
@@ -959,7 +1012,7 @@ def cron_session_key_is_stable(job: CronJob) -> bool:
     record separates them. The sequential path ignores ``persistent_session``
     entirely, which is why it is checked second rather than combined.
     """
-    if len(job.agent_sequence) > 1:
+    if agent_sequence_dispatches(job.agent_sequence):
         return True
     return job.persistent_session
 

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -38,6 +38,7 @@ from kiro_crew.cron import (
     CronService,
     CronStoreBusy,
     CronStoreUnreadable,
+    agent_sequence_dispatches,
     compute_next_run_ts,
     cron_job_id_from_session_key,
     cron_session_key_is_stable,
@@ -2310,7 +2311,9 @@ def _owner_unusable_caveat(svc: "CronService", session_key: str, job_id: str) ->
     )
 
 
-def _ephemeral_authority_caveat(persistent: bool, is_agent_job: bool, sequence_len: int) -> str:
+def _ephemeral_authority_caveat(
+    persistent: bool, is_agent_job: bool, agent_sequence: list[str]
+) -> str:
     """Warn when the job BEING created or updated is the one that loses authority.
 
     Distinct from :func:`_owner_unusable_caveat`, which is about the caller. Here
@@ -2325,7 +2328,8 @@ def _ephemeral_authority_caveat(persistent: bool, is_agent_job: bool, sequence_l
     * NOT an agent job. A script cron is launched with
       ``KIROCREW_SESSION_KEY=cron:<job_id>`` unconditionally and a command cron
       issues no MCP call at all.
-    * ``agent_sequence`` longer than one. That path mints a stable
+    * a dispatching ``agent_sequence`` (:func:`cron.agent_sequence_dispatches`,
+      the one spelling of that gate). That path mints a stable
       ``cron:<job_id>:<agent>`` key and ignores ``persistent_session``, so the
       warning would be false -- the same conflation
       :func:`cron.cron_session_key_is_stable` exists to prevent.
@@ -2339,7 +2343,7 @@ def _ephemeral_authority_caveat(persistent: bool, is_agent_job: bool, sequence_l
     revokes the job's authority over the scheduler. That gap is why this is worth
     a sentence rather than a docs line.
     """
-    if persistent or not is_agent_job or sequence_len > 1:
+    if persistent or not is_agent_job or agent_sequence_dispatches(agent_sequence):
         return ""
     return (
         " Note: persistent_session is false, so every run of this job gets a fresh "
@@ -2584,7 +2588,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         caveats = _owner_unusable_caveat(svc, session_key, job.id) + _ephemeral_authority_caveat(
             persistent_session if isinstance(persistent_session, bool) else True,
             not (command or script),
-            len(args.get("agent_sequence") or []),
+            list(args.get("agent_sequence") or []),
         )
         return (
             f"Added job: {job.id} ({job.name}) [{sched_str}]. "
@@ -2701,7 +2705,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         caveat = _ephemeral_authority_caveat(
             updated.persistent_session,
             not (updated.command or updated.script),
-            len(updated.agent_sequence),
+            updated.agent_sequence,
         )
         note = _sub_floor_timeout_note(args["timeout_secs"]) if "timeout_secs" in args else ""
         return f"Updated job: {updated.id} ({updated.name}) [{sched_str}]{caveat}{note}"

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -102,6 +102,7 @@ from kiro_crew.cron import (
     CronService,
     CronStoreBusy,
     CronStoreUnreadable,
+    agent_sequence_dispatches,
     build_cron_session_context,
     effective_wake_budget,
 )
@@ -4777,7 +4778,7 @@ class GatewayOrchestrator:
             # When agent_sequence has multiple agents, run them sequentially
             # with per-agent session keys and per-job env vars.
             agents = job.agent_sequence if job.agent_sequence else []
-            if len(agents) > 1:
+            if agent_sequence_dispatches(agents):
                 assert self.sessions is not None
                 assert self.ctx_builder is not None
                 result_text = "_No response._"

--- a/test/test_cron_owner_caveats.py
+++ b/test/test_cron_owner_caveats.py
@@ -167,17 +167,22 @@ class TestEphemeralAuthorityCaveat:
     """Whether the job BEING written can manage crons on a later run."""
 
     def test_an_ephemeral_agent_job_is_warned(self):
-        out = _ephemeral_authority_caveat(persistent=False, is_agent_job=True, sequence_len=0)
+        out = _ephemeral_authority_caveat(persistent=False, is_agent_job=True, agent_sequence=[])
         assert "persistent_session is false" in out
         assert "including ones it creates itself" in out
 
     def test_a_persistent_agent_job_is_not_warned(self):
-        assert _ephemeral_authority_caveat(persistent=True, is_agent_job=True, sequence_len=0) == ""
+        assert (
+            _ephemeral_authority_caveat(persistent=True, is_agent_job=True, agent_sequence=[]) == ""
+        )
 
     def test_a_multi_agent_job_is_not_warned(self):
         """That path mints a stable per-agent key and ignores the flag."""
         assert (
-            _ephemeral_authority_caveat(persistent=False, is_agent_job=True, sequence_len=2) == ""
+            _ephemeral_authority_caveat(
+                persistent=False, is_agent_job=True, agent_sequence=["a", "b"]
+            )
+            == ""
         )
 
     @pytest.mark.parametrize("persistent", [True, False])
@@ -188,7 +193,9 @@ class TestEphemeralAuthorityCaveat:
         unconditionally and a command cron issues no MCP call at all.
         """
         assert (
-            _ephemeral_authority_caveat(persistent=persistent, is_agent_job=False, sequence_len=0)
+            _ephemeral_authority_caveat(
+                persistent=persistent, is_agent_job=False, agent_sequence=[]
+            )
             == ""
         )
 

--- a/test/test_doctor_deprecated_agents.py
+++ b/test/test_doctor_deprecated_agents.py
@@ -1,0 +1,310 @@
+"""Tests for the `kirocrew doctor` deprecated-agent-spec check.
+
+Guards the retirement contract from rfc-conductor-work-ledger.md ("What
+retired means for the name"): a config surface that persists an agent name --
+a cron job, a crew binding, a chat slot -- and still names a deprecated spec
+is reported with its replacement, while a config naming only current specs
+stays silent. The check is what makes deleting a deprecated alias safe: the
+one-release window warns the owners instead of ending in a silent
+"Mode not found" at dispatch time.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew import cli_doctor, cron
+from kiro_crew.agent import DEPRECATED_AGENT_SPECS
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.paths import config_dir
+from kiro_crew.config.sections import KiroCrewAgentConfig
+
+DEPRECATED = "kirocrew-ledger-conductor"
+REPLACEMENT = "kirocrew-conductor"
+
+
+@pytest.fixture()
+def no_other_surfaces(monkeypatch):
+    """Silence the cron and slot surfaces so a test exercises one at a time."""
+    monkeypatch.setattr(cron, "job_agent_names_from_disk", lambda: [])
+    monkeypatch.setattr(cli_doctor, "_open_slot_agent_names", lambda: [])
+
+
+class TestDeprecatedTable:
+    def test_ledger_conductor_row_present(self) -> None:
+        # The alias installer and this row retire together; the doctor notice
+        # is the precondition for deleting the alias.
+        assert DEPRECATED_AGENT_SPECS[DEPRECATED] == REPLACEMENT
+
+    def test_values_are_not_themselves_deprecated(self) -> None:
+        # A replacement that is itself a key would send a migrating user to a
+        # name that is also going away.
+        for replacement in DEPRECATED_AGENT_SPECS.values():
+            assert replacement not in DEPRECATED_AGENT_SPECS
+
+
+class TestJobAgentNamesFromDisk:
+    def _write_store(self, jobs: list[dict]) -> None:
+        path = config_dir() / "crons.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"version": 2, "jobs": jobs}), encoding="utf-8")
+
+    def test_reads_agent_id_and_sequence(self) -> None:
+        self._write_store(
+            [
+                {"id": "a1", "name": "nightly", "message": "x", "agent_id": DEPRECATED},
+                {"id": "b2", "name": "relay", "message": "x", "agent_sequence": ["one", "two"]},
+                {"id": "c3", "name": "plain", "message": "x"},
+            ]
+        )
+        assert cron.job_agent_names_from_disk() == [
+            ("nightly", DEPRECATED),
+            ("relay", "one"),
+            ("relay", "two"),
+        ]
+
+    def test_unnamed_job_uses_placeholder_holder(self) -> None:
+        self._write_store([{"id": "", "message": "x", "agent_id": "spec"}])
+        assert cron.job_agent_names_from_disk() == [("<unnamed job>", "spec")]
+
+    def test_dispatching_sequence_makes_agent_id_dormant(self) -> None:
+        # A sequence of more than one agent is what dispatch runs; agent_id is
+        # dormant and must not fail doctor.
+        self._write_store(
+            [
+                {
+                    "id": "m1",
+                    "name": "multi",
+                    "message": "x",
+                    "agent_id": DEPRECATED,
+                    "agent_sequence": ["one", "two"],
+                }
+            ]
+        )
+        assert cron.job_agent_names_from_disk() == [("multi", "one"), ("multi", "two")]
+
+    def test_one_entry_sequence_is_dormant(self) -> None:
+        # Dispatch runs a sequence only when it holds more than one agent; a
+        # one-entry sequence never dispatches, so its name must not fail
+        # doctor.
+        self._write_store(
+            [{"id": "a1", "name": "solo", "message": "x", "agent_sequence": ["dormant"]}]
+        )
+        assert cron.job_agent_names_from_disk() == []
+
+    def test_loader_rejected_record_contributes_nothing(self) -> None:
+        # The scheduler's own loader rejects a record whose agent_sequence
+        # holds a non-string; a job that never loads dispatches nothing.
+        self._write_store(
+            [
+                {"id": "", "message": "x", "agent_id": "spec", "agent_sequence": [1, "ok", "x"]},
+                {"id": "b", "name": "bad-id", "message": "x", "agent_id": ["list"]},
+            ]
+        )
+        assert cron.job_agent_names_from_disk() == []
+
+    def test_script_and_command_jobs_are_skipped(self) -> None:
+        # A script or command cron bypasses agent dispatch entirely
+        # (gateway runs it with no LLM), so its agent fields are dormant.
+        self._write_store(
+            [
+                {
+                    "id": "s1",
+                    "name": "scripted",
+                    "message": "x",
+                    "agent_id": DEPRECATED,
+                    "script": "~/.kiro/crew/crons/x.py:run",
+                },
+                {
+                    "id": "c1",
+                    "name": "cmd",
+                    "message": "x",
+                    "agent_id": DEPRECATED,
+                    "command": "echo hi",
+                },
+            ]
+        )
+        assert cron.job_agent_names_from_disk() == []
+
+    def test_gate_predicate_is_shared_with_dispatch(self) -> None:
+        # The reader, session-key stability, and the Slack dispatch path must
+        # all read the same gate.
+        from kiro_crew.slack import gateway
+
+        assert gateway.agent_sequence_dispatches is cron.agent_sequence_dispatches
+        assert not cron.agent_sequence_dispatches(["one"])
+        assert cron.agent_sequence_dispatches(["one", "two"])
+
+    def test_missing_store_is_empty(self) -> None:
+        assert cron.job_agent_names_from_disk() == []
+
+    def test_malformed_store_is_empty(self) -> None:
+        path = config_dir() / "crons.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert cron.job_agent_names_from_disk() == []
+
+
+class TestOpenSlotAgentNames:
+    def _write_slot(self, slot_key: str, agent: str) -> None:
+        from kiro_crew.dashboard.chat_utils import slot_transcript_key
+        from kiro_crew.history import _safe_key, _sessions_dir
+
+        sessions = _sessions_dir()
+        sessions.mkdir(parents=True, exist_ok=True)
+        meta = {"_type": "metadata", "agent": agent}
+        name = _safe_key(slot_transcript_key(slot_key))
+        (sessions / f"{name}.jsonl").write_text(json.dumps(meta) + "\n", encoding="utf-8")
+
+    def _write_open_slots(self, keys: list[str]) -> None:
+        path = config_dir() / "open_slots.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"keys": keys}), encoding="utf-8")
+
+    def test_reads_open_slot_agent(self) -> None:
+        self._write_open_slots(["chat-1"])
+        self._write_slot("chat-1", DEPRECATED)
+        assert cli_doctor._open_slot_agent_names() == [("chat-1", DEPRECATED)]
+
+    def test_channel_born_slot_is_read_from_its_own_transcript(self) -> None:
+        # A channel-born tab's slot key (slack_<ts>) already addresses its
+        # transcript; a dashboard: prefix would read a nonexistent file and
+        # silently skip the tab.
+        self._write_open_slots(["slack_1785370133.085469"])
+        self._write_slot("slack_1785370133.085469", DEPRECATED)
+        assert cli_doctor._open_slot_agent_names() == [("slack_1785370133.085469", DEPRECATED)]
+
+    def test_slot_without_agent_metadata_is_skipped(self) -> None:
+        self._write_open_slots(["chat-1"])
+        self._write_slot("chat-1", "")
+        assert cli_doctor._open_slot_agent_names() == []
+
+    def test_path_separator_key_is_rejected(self) -> None:
+        # open_slots.json is attacker-writable; a smuggled key must not reach
+        # path construction.
+        self._write_open_slots(["../../etc/passwd"])
+        assert cli_doctor._open_slot_agent_names() == []
+
+    def test_missing_file_is_empty(self) -> None:
+        assert cli_doctor._open_slot_agent_names() == []
+
+
+class TestDoctorDeprecatedAgentSpecs:
+    def test_crew_binding_naming_deprecated_is_flagged(self, no_other_surfaces, capsys) -> None:
+        cfg = KiroCrewConfig()
+        cfg.agents = {"myteam": KiroCrewAgentConfig(kiro_agent=DEPRECATED)}
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(cfg, issues)
+        out = capsys.readouterr().out
+        assert "Deprecated Agent Specs" in out
+        assert "'myteam'" in out
+        assert DEPRECATED in out
+        assert REPLACEMENT in out
+        assert issues == ["a config names a deprecated agent spec"]
+
+    def test_cron_job_naming_deprecated_is_flagged(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(cron, "job_agent_names_from_disk", lambda: [("nightly", DEPRECATED)])
+        monkeypatch.setattr(cli_doctor, "_open_slot_agent_names", lambda: [])
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(KiroCrewConfig(), issues)
+        out = capsys.readouterr().out
+        assert "cron job 'nightly'" in out
+        assert REPLACEMENT in out
+        assert issues == ["a config names a deprecated agent spec"]
+
+    def test_chat_slot_naming_deprecated_is_flagged(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(cron, "job_agent_names_from_disk", lambda: [])
+        monkeypatch.setattr(cli_doctor, "_open_slot_agent_names", lambda: [("chat-3", DEPRECATED)])
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(KiroCrewConfig(), issues)
+        out = capsys.readouterr().out
+        assert "chat slot 'chat-3'" in out
+        assert REPLACEMENT in out
+        assert issues == ["a config names a deprecated agent spec"]
+
+    def test_job_naming_a_crew_is_reported_once_via_the_crew(self, monkeypatch, capsys) -> None:
+        # The job names the CREW; the crew binds the deprecated spec. One
+        # finding (the crew's), not two -- fixing the binding fixes the job.
+        cfg = KiroCrewConfig()
+        cfg.agents = {"myteam": KiroCrewAgentConfig(kiro_agent=DEPRECATED)}
+        monkeypatch.setattr(cron, "job_agent_names_from_disk", lambda: [("nightly", "myteam")])
+        monkeypatch.setattr(cli_doctor, "_open_slot_agent_names", lambda: [])
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(cfg, issues)
+        out = capsys.readouterr().out
+        assert out.count("names deprecated agent spec") == 1
+        assert "crew 'myteam'" in out
+        assert "nightly" not in out
+
+    def test_config_selectors_naming_deprecated_are_flagged(
+        self, no_other_surfaces, capsys
+    ) -> None:
+        from kiro_crew.config.sections import ChannelConfig
+
+        cfg = KiroCrewConfig()
+        cfg.agent.default_agent = DEPRECATED
+        cfg.session.pool_agent = DEPRECATED
+        cfg.slack_channels = {"C123": ChannelConfig(agent=DEPRECATED)}
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(cfg, issues)
+        out = capsys.readouterr().out
+        assert "agent.default_agent" in out
+        assert "session.pool_agent" in out
+        assert "slack channel 'C123'" in out
+        assert out.count("names deprecated agent spec") == 3
+        assert issues == ["a config names a deprecated agent spec"]
+
+    def test_default_agent_naming_a_crew_is_reported_once_via_the_crew(
+        self, no_other_surfaces, capsys
+    ) -> None:
+        cfg = KiroCrewConfig()
+        cfg.agents = {"myteam": KiroCrewAgentConfig(kiro_agent=DEPRECATED)}
+        cfg.agent.default_agent = "myteam"
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(cfg, issues)
+        out = capsys.readouterr().out
+        assert out.count("names deprecated agent spec") == 1
+        assert "crew 'myteam'" in out
+
+    def test_malformed_selector_values_do_not_crash_doctor(self, no_other_surfaces, capsys) -> None:
+        # config.json is hand-editable and the loader preserves kiro_agent
+        # verbatim, so a list can arrive here; dict.get on an unhashable value
+        # would raise TypeError. Doctor must diagnose a malformed config, not
+        # crash on it.
+        from kiro_crew.config.sections import ChannelConfig
+
+        cfg = KiroCrewConfig()
+        cfg.agents = {"broken": KiroCrewAgentConfig(kiro_agent=[DEPRECATED])}  # type: ignore[arg-type]
+        cfg.agent.default_agent = [DEPRECATED]  # type: ignore[assignment]
+        cfg.session.pool_agent = {"agent": DEPRECATED}  # type: ignore[assignment]
+        channel = ChannelConfig()
+        channel.agent = [DEPRECATED]  # type: ignore[assignment]
+        cfg.slack_channels = {"C123": channel}
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(cfg, issues)
+        assert capsys.readouterr().out == ""
+        assert issues == []
+
+    def test_current_names_are_silent(self, monkeypatch, capsys) -> None:
+        cfg = KiroCrewConfig()
+        cfg.agents = {"myteam": KiroCrewAgentConfig(kiro_agent=REPLACEMENT)}
+        monkeypatch.setattr(cron, "job_agent_names_from_disk", lambda: [("nightly", REPLACEMENT)])
+        monkeypatch.setattr(cli_doctor, "_open_slot_agent_names", lambda: [("chat-1", "kirocrew")])
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(cfg, issues)
+        assert capsys.readouterr().out == ""
+        assert issues == []
+
+    def test_holder_text_is_rendered_inert(self, monkeypatch, capsys) -> None:
+        # Crew names, job names and slot keys are read off disk; a control
+        # sequence in one must print escaped, not drive the terminal.
+        hostile = "evil\x1b]0;pwned\x07"
+        monkeypatch.setattr(cron, "job_agent_names_from_disk", lambda: [(hostile, DEPRECATED)])
+        monkeypatch.setattr(cli_doctor, "_open_slot_agent_names", lambda: [])
+        issues: list[str] = []
+        cli_doctor._doctor_deprecated_agent_specs(KiroCrewConfig(), issues)
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "\\x1b" in out


### PR DESCRIPTION
## Problem / Motivation

Nothing warns a user whose config still names `kirocrew-ledger-conductor`. The name is a deprecated alias of `kirocrew-conductor` that is deleted next release. A cron job, a crew binding, an open chat tab, or a config selector naming it works today and warns nobody, then fails with `Mode not found` at dispatch time once the alias is gone. The work-ledger RFC makes a `kirocrew doctor` notice the precondition for deleting the alias, and that notice did not ship with the swap.

## Why it matters

The one-release deprecation window only protects users if something tells them inside it. Without the notice, the alias deletion breaks every unmigrated config silently, at the moment a session dispatches -- the worst possible time to learn about a rename. With the notice, `kirocrew doctor` names each offending config and the exact replacement while everything still works.

## What changed (motivation → approach → change)

`kirocrew doctor` now reports every config surface that persists an agent name and still names a deprecated spec. It scans cron jobs, crew bindings (`agents.<name>.kiro_agent`), the config's own selectors (`agent.default_agent`, `session.pool_agent`, per-channel `agent` overrides), and every open chat tab's persisted agent. The cron scan mirrors dispatch exactly: a `script` or `command` job runs with no LLM so its agent fields are dormant and skipped; otherwise `agent_sequence` entries are reported when the sequence is what runs, `agent_id` when it is, and the dormant one never fails doctor. The gate is one shared predicate, `agent_sequence_dispatches` in `cron.py`, called by the Slack dispatch path, session-key stability, the `cron_add`/`cron_update` authority caveat, and this reader, so the spellings cannot drift. A channel-born tab (`slack_<ts>`) is read through `slot_transcript_key`, which addresses its real transcript file. Each finding prints the replacement name; doctor exits nonzero so the report is actionable.

The check is data-driven: `DEPRECATED_AGENT_SPECS` in `agent.py` maps each deprecated name to its replacement and lives beside the alias installer, so a future rename adds one row instead of a new check, and a row is deleted together with its alias. A name that resolves to a configured crew is skipped on the leaf surfaces and reported once, at the crew binding that owns it. Every scanned value is guarded as untrusted: a non-string selector (config.json is hand-editable, and the loader preserves `kiro_agent` verbatim) is skipped instead of crashing doctor on an unhashable `dict.get`, a cron record the scheduler's own loader rejects contributes nothing, and holder names read off disk print through the existing `_safe_display` escape so a hostile name cannot drive the terminal. The RFC rollout note now records the notice as shipped.

```mermaid
flowchart LR
  subgraph Before
    A1[config names kirocrew-ledger-conductor]:::ctx --> B1[alias deleted next release]:::ctx --> C1[Mode not found at dispatch]:::removed
  end
  subgraph After
    A2[config names kirocrew-ledger-conductor]:::ctx --> B2[kirocrew doctor names it + the replacement]:::added --> C2[owner migrates inside the window]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

Legend: green = added, red = removed, blue = unchanged.

*Doctor now warns while the old name still works, instead of the user finding out when it stops.*

## Tests

`test/test_doctor_deprecated_agents.py` (25 tests) locks in: the `kirocrew-ledger-conductor -> kirocrew-conductor` row exists and no replacement is itself deprecated; the cron reader reports exactly what dispatch runs (sequence when it dispatches, `agent_id` otherwise; script/command jobs and loader-rejected records contribute nothing) and degrades to empty on a missing or malformed store; the dispatch gate predicate is the same object in the Slack gateway and the reader; the slot reader resolves dashboard and channel-born tabs to their real transcripts, skips tabs without an agent, and rejects a path-separator key from the attacker-writable `open_slots.json`; the doctor check flags each surface with the replacement named, reports a crew-resolved name once at the crew binding, survives malformed non-string selector values, stays silent for current names, and escapes hostile holder text.

## Manual verification

N/A -- unit coverage sufficient: the check is a pure read of on-disk stores that the tests recreate byte-for-byte (crons.json, open_slots.json, transcript metadata lines).

## Related Issues

Closes #10268

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a deprecation window with no detector -- any alias kept 'for one release' needs the notice that tells its users, shipped before the deletion, or the window protects nobody"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
