### PR TITLE
docs: conductors close child sessions on terminal verdict

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -5787,7 +5787,8 @@ Your tools:
   `accept`, `verdict`, `close`, `goal`); `work_brief` / `work_report` for your
   OWN item when a parent conductor dispatched you.
 - Child sessions — `session_create`, `session_send`, `session_read_message`,
-  `session_stop`, `list_sessions`.
+  `session_stop`, `session_close` (close a child once its item is terminal),
+  `list_sessions`.
 - Keeping the goal's sessions together — `chat_folder_tree`,
   `chat_folder_create`.
 - Your own state across rounds — `session_ledger_read`, `session_ledger_record`.
@@ -6725,7 +6726,8 @@ with `wait`. A quiet cycle is one line, then end the turn.
 Your tools:
 
 - Child sessions — `session_create`, `session_send`, `session_read_message`,
-  `session_stop`, `list_sessions`.
+  `session_stop`, `session_close` (close a child once its item is terminal),
+  `list_sessions`.
 - Keeping the audit's sessions together — `chat_folder_tree`,
   `chat_folder_create`.
 - State that outlives a round — `session_ledger_read`, `session_ledger_record`.

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -264,7 +264,13 @@ Each cycle:
 
    If the user says the card is gone, re-issue it. A report that the card vanished is not an answer.
 4. `work_ledger_record` `action=close` with the item's `state` when an item is
-   finally done with — that is what ends it. `action=decide` records an
+   finally done with — that is what ends it. **Closing the item and closing
+   its session happen together.** When a work item reaches a terminal verdict
+   (accepted, rejected, abandoned/void) and its loop is stopped,
+   `session_close` that child session in the same cycle — a finished worker
+   has nothing left to re-arm. `session_close` archives (reopenable); it never
+   deletes. Never close a child that still has a pending human question or an
+   unmerged PR it is actively driving. `action=decide` records an
    instruction you want the worker to read out of `work_brief`; it is the ONE
    field the worker treats as an instruction, so keep it to a decision.
 5. `session_read_message` for detail the record does not carry — a question's
@@ -342,8 +348,12 @@ Stop and report when ANY of these fire. Do not push past one.
 4. **A decision is needed that no acceptance condition can settle.** Stopping to
    ask is correct here. Guessing is the failure.
 
-Call `autonudge_stop` when you stop. Reaching `max_cycles` is a runaway
-backstop, not a finish.
+Call `autonudge_stop` when you stop, and close out the children you created
+before your final report: `session_close` each one whose item is terminal, and
+**leave open any child still holding a pending human question or driving an
+unmerged PR**. Stop condition 4 fires precisely because a person is about to
+re-engage with such a child, and a close cancels its turn and discards that
+work. Reaching `max_cycles` is a runaway backstop, not a finish.
 
 ## What the ledger holds, and what your own does
 
@@ -455,11 +465,14 @@ what the composer renders:
   runs as the target's own turn, and a stop discards the target's in-flight work.
   You ingest external content by design, so the prompt is the only call-time
   check on both. Expect one approval per item at dispatch (the seed), one per
-  question you answer, and one if you ever stop an item. `execute_bash` also
-  still prompts, so **each patrol cycle that verifies anything blocks on one
-  approval for the `accept_eval.py` invocation**. Size the nudge interval for
-  that, and batch. On a host with a governance ceiling even the granted verbs
-  prompt; if you see approvals where this says you should not, that is why.
+  question you answer, and one if you ever stop an item. `session_close` sits on
+  the same footing — it writes to a session that is not yours, even though it
+  archives rather than deletes — so budget one approval per child you close out.
+  `execute_bash` also still prompts, so **each patrol cycle that verifies
+  anything blocks on one approval for the `accept_eval.py` invocation**. Size
+  the nudge interval for that, and batch. On a host with a governance ceiling
+  even the granted verbs prompt; if you see approvals where this says you
+  should not, that is why.
 - **`session_send` reports delivery, not completion.** `started: true` means the
   target began a turn on your message; `started: false` means it queued. Neither
   says the work succeeded — acceptance is still the evaluator's job.

--- a/src/kiro_crew/builtin_skills/security-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/security-conductor/SKILL.md
@@ -296,7 +296,15 @@ Each cycle, in this order:
    verdict. These are what go missing, because nothing fires to remind you. An
    entry clears when the obligation is discharged, not when you decide about it.
 4. **Record verdicts and state back** in one write.
-5. **Report only real signals.** A quiet cycle is one line, then end the turn.
+5. **Close out what is terminal.** When a work item reaches a terminal verdict
+   (accepted, rejected, abandoned/void) and its loop is stopped,
+   `session_close` that child session in the same cycle — a finished worker
+   has nothing left to re-arm. It holds for auditor, verifier, retrospective
+   and fixer sessions alike, and a VOID fixer is closed after its
+   `session_stop` rather than left open. `session_close` archives
+   (reopenable); it never deletes. Never close a child that still has a
+   pending human question or an unmerged PR it is actively driving.
+6. **Report only real signals.** A quiet cycle is one line, then end the turn.
 
 ## Stop conditions
 
@@ -319,6 +327,13 @@ Stop and report, rather than continuing, on any of these:
 - The false-positive rate for the round is high enough that verifiers are the
   only thing producing signal. Report the rate; a finding stream nobody has
   measured is not a foundation for a fixer lane.
+
+Whichever fires: before the final report, `session_close` each remaining child
+whose item is terminal — auditor, verifier, retrospective and fixer alike. **A
+child still holding a pending human question, or a fixer driving an unmerged PR,
+stays open**: the pending-human-gate stop above fires while a person is
+mid-decision on exactly such a child, and a close cancels its turn and
+discards that work.
 
 ## Known limits (state them, don't hide them)
 

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -491,6 +491,23 @@ class TestConductorInstaller:
         assert "work_ledger_read` first, every cycle" in body
         assert "action=accept" in body
 
+    def test_prompt_and_skill_close_a_child_once_its_item_is_terminal(self, tmp_path, monkeypatch):
+        """A conductor that stops an item's loop and leaves its session open leaves a
+        finished worker parked in the sidebar with nothing to re-arm. The prompt
+        names the verb in the child-session tool line, and the skill ties it to
+        ``action=close`` so ending the item and ending its session are one step.
+        """
+        prompt = " ".join(self._install(tmp_path, monkeypatch)["prompt"].split())
+        assert "`session_close` (close a child once its item is terminal)" in prompt
+        body = " ".join((SKILL_DIR / "SKILL.md").read_text(encoding="utf-8").split())
+        assert "Closing the item and closing its session happen together" in body
+        assert "`session_close` archives (reopenable); it never deletes" in body
+        assert "`session_close` each one whose item is terminal" in body
+        assert (
+            "leave open any child still holding a pending human question or driving an"
+            " unmerged PR" in body
+        )
+
     def test_skill_feeds_the_evaluator_through_a_quoted_heredoc(self):
         """The acceptance document is built from ingested text, and the skill's
         example is what the agent copies. A ``printf '%s' '<json>'`` form ends its

--- a/test/test_ledger_conductor_agent.py
+++ b/test/test_ledger_conductor_agent.py
@@ -105,6 +105,15 @@ def test_the_alias_spec_is_identical_apart_from_name_and_description(tmp_path, m
         assert alias[field] == live[field], field
 
 
+def test_the_alias_prompt_closes_a_child_once_its_item_is_terminal(tmp_path, monkeypatch):
+    """The alias is what an unmigrated session records as its agent, so the
+    session-lifecycle rule has to reach it too. Pinned on the emitted prompt rather
+    than on the shared constant: the identity test above proves the two specs match,
+    and this one proves the clause is in the one the alias ships."""
+    alias = _install(tmp_path, monkeypatch)
+    assert "`session_close` (close a child once its item is terminal)" in alias["prompt"]
+
+
 def test_the_governance_ceiling_reaches_the_alias_the_same_way(tmp_path, monkeypatch):
     """A ceiling is host state, not per-spec state, so it must strip the same ref
     from both. Pinned on a work-ledger ref: the alias is the spec an unmigrated

--- a/test/test_security_conductor_agent.py
+++ b/test/test_security_conductor_agent.py
@@ -90,6 +90,13 @@ class TestSecurityConductorInstaller:
             assert role in prompt, role
         assert "prepare-pr" in prompt  # the fixer's own procedure
 
+    def test_prompt_closes_a_child_once_its_item_is_terminal(self, tmp_path, monkeypatch):
+        """Four child roles reach a terminal verdict and the loop is stopped for each
+        one; without the verb in the tool line the finished session stays open and the
+        operator cleans up by hand."""
+        prompt = " ".join(self._install(tmp_path, monkeypatch)["prompt"].split())
+        assert "`session_close` (close a child once its item is terminal)" in prompt
+
     def test_prompt_delegates_scope_and_acceptance_to_scripts(self, tmp_path, monkeypatch):
         """Both decisions this agent must NOT make by judgment: whether a target
         is in scope, and whether a finding is real. Each names the script whose

--- a/test/test_security_conductor_skill_contract.py
+++ b/test/test_security_conductor_skill_contract.py
@@ -398,6 +398,21 @@ class TestStopConditions:
         body = _flat(_section(skill_text, self.HEADING))
         assert "autonudge_stop" in body
 
+    def test_a_terminal_child_is_closed_in_the_cycle_and_at_the_stop(self, skill_text: str) -> None:
+        """Stopping a child's loop is not the same act as closing its session, so the
+        procedure has to name the second one twice: per item inside the cycle, and for
+        whatever is still open when the conductor itself stops. The VOID fixer is
+        called out because ``session_stop`` reads as the whole close-out for it."""
+        cycle = _flat(_section(skill_text, "## The patrol cycle"))
+        assert "session_close that child session in the same cycle" in cycle
+        assert "a void fixer is closed after its session_stop" in cycle
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "session_close each remaining child whose item is terminal" in body
+        assert (
+            "a child still holding a pending human question, or a fixer driving an"
+            " unmerged pr, stays open" in body
+        )
+
 
 class TestRulesOfEngagementExport:
     """The M0 review surface. Shape is a contract; the values are the human's."""


### PR DESCRIPTION
## Problem / Motivation

A conductor finishes a work item, stops that child's loop, and the child session
stays open. The operator watched this across three waves of security-conductor
work: every finished auditor, verifier and retrospective was still in the
sidebar afterwards, closed by hand.

Only `pipeline-conductor/SKILL.md` carried the rule. The goal conductor's and
security conductor's procedures said nothing, and neither conductor system
prompt named `session_close` at all.

## Why it matters

A finished worker with an open session looks like live work. The sidebar fills
with sessions that will never move, and the operator has to tell a stalled child
from a done one by reading transcripts. The conductor is the only party that
knows an item is terminal, so nothing else can close it.

## What changed (motivation → approach → change)

The rule is written where the item ends. The goal conductor's
`work_ledger_record` `action=close` step says closing the item and closing its
session are one act. The security conductor's patrol cycle gains a close-out
step for auditor, verifier, retrospective and fixer alike, and a VOID fixer is
closed after its `session_stop` rather than left open.

One condition governs every close, in the cycle and at the stop alike: the
child's item is terminal. A child holding a pending human question, or a fixer
driving an unmerged PR, stays open — `session_close` cancels an in-flight turn
and discards that work, and the stop condition that waits on a person is the one
that produces exactly such a child. `session_close` archives and is reopenable,
so a close is not a delete.

| case | Before | After |
|---|---|---|
| pipeline conductor, worker terminal | 🟦 `session_close` | 🟦 `session_close` |
| goal conductor, item closed | 🟥 session left open | 🟩 `session_close` with `action=close` |
| security conductor, finding verdict in | 🟥 session left open | 🟩 `session_close` in the same cycle |
| security conductor, VOID fixer | 🟥 stopped, left open | 🟩 stopped, then closed |
| child with a pending human question | 🟦 stays open | 🟦 stays open |
| fixer driving an unmerged PR | 🟦 stays open | 🟦 stays open |
| conductor stops, terminal children left | 🟥 left open | 🟩 closed before the report |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*A conductor that ends an item ends its session too; a child still waiting on a
person, or still driving a PR, is left alone.*

Both conductor system prompts name `session_close` in their child-session tool
line, with the phrase "close a child once its item is terminal". The goal
conductor's approval-budget paragraph adds it beside `session_send` and
`session_stop`: the verb writes to a session that is not yours, so it prompts,
and an unattended patrol has to budget one approval per child it closes.

Two files named in the work item are covered by construction rather than by
their own edit. `kirocrew-ledger-conductor` emits the goal conductor's prompt
byte for byte, so it inherits the clause, and a test pins that. Its
`goal-ledger-conductor/SKILL.md` is a 15-line deprecation pointer whose contract
test forbids procedure text in it (`test_the_skill_is_a_pointer_and_not_a_second_procedure`),
so the rule stays in `goal-conductor`, which that file sends the reader to.

## Tests

- `test_conductor_agent.py` — the goal conductor's emitted prompt carries the
  tool-line clause, and its skill body carries the `action=close` tie-in, the
  archive-not-delete guard, and a stop-condition sweep that is terminal-only and
  names the pending-question / unmerged-PR exception.
- `test_ledger_conductor_agent.py` — the alias's emitted prompt carries the
  clause, pinned on the emitted spec so a future edit cannot satisfy both this
  and the identity test by dropping the clause from both.
- `test_security_conductor_agent.py` — the security conductor's emitted prompt
  carries the clause.
- `test_security_conductor_skill_contract.py` — the patrol cycle names the
  same-cycle close and the VOID fixer case, and the stop-conditions section
  names a terminal-only sweep with the same exception. Scoped per section, so a
  sentence in the wrong place does not satisfy it.

## Manual verification

N/A — prompt and procedure text, pinned by the contract tests above.

## Related Issues

no linked issue: operator-observed gap, filed as work item W4b.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
