### PR TITLE
fix: fail loud when fix-loop harvest cannot read merged PRs (#9611)

### DIFF
--- a/.github/scripts/fix_loop_metrics.py
+++ b/.github/scripts/fix_loop_metrics.py
@@ -270,6 +270,35 @@ def has_harvest_section(body: str) -> bool:
     return bool(HARVEST_HEADING_RE.search(body) and HARVEST_ANSWER_RE.search(body))
 
 
+def _local_pr_evidence(since_iso: str) -> bool | None:
+    """Whether the checkout's own history shows PR-merged commits since *since_iso*.
+
+    Read-only and cheap: a squash merge leaves a '(#N)' subject trailer and a
+    merge commit answers `--merges`; either is proof PRs merged in the window.
+    Returns None when git cannot answer authoritatively (shallow checkout, git
+    unavailable), so the caller falls back to a coarser rule.
+
+    Deliberately scoped to the checked-out branch: the scheduled run checks
+    out the default branch, which is also the harvest's own scope, and
+    scanning every ref would let a feature branch's merge commits manufacture
+    evidence against a legitimately quiet window. Known edge: `--since`
+    filters on committer date, so a backport cherry-picked onto the checked-
+    out branch keeps its '(#N)' subject with a fresh date and reads as
+    evidence -- a dispatch run against a release branch can fail loud on a
+    quiet window, which is the accepted cost of never publishing a false
+    zero on the branch the metric is actually about.
+    """
+    try:
+        if run(["git", "rev-parse", "--is-shallow-repository"]).strip() != "false":
+            return None
+        subjects = run(["git", "log", f"--since={since_iso}", "--format=%s"])
+        if any(PR_TRAILER_RE.search(s) for s in subjects.splitlines()):
+            return True
+        return bool(run(["git", "log", "--merges", f"--since={since_iso}", "--oneline"]).strip())
+    except (OSError, RuntimeError):
+        return None
+
+
 def merged_prs_since(repo: str, since_iso: str) -> list[dict]:
     """Every PR merged at or after since_iso, one search per calendar day.
 
@@ -312,7 +341,32 @@ def merged_prs_since(repo: str, since_iso: str) -> list[dict]:
                 seen.add(key)
                 prs.append(p)
         day += timedelta(days=1)
-    return [p for p in prs if (p.get("mergedAt") or "") >= since_iso]
+    window = [p for p in prs if (p.get("mergedAt") or "") >= since_iso]
+    if not window:
+        # An empty window is legitimate only when the checkout agrees. The
+        # search surface omits nodes the token cannot read instead of
+        # erroring, so a permissions gap looks exactly like a quiet week --
+        # and this metric's whole contract is to never publish that.
+        evidence = _local_pr_evidence(since_iso)
+        if evidence:
+            raise RuntimeError(
+                f"gh pr list returned zero merged PRs since {since_iso}, yet the "
+                "checkout's own history shows commits that merged through PRs. "
+                "The search surface omits nodes the token cannot read instead "
+                "of erroring, so the probable cause is a token without "
+                "`pull-requests: read` -- failing loud rather than publishing "
+                "a false zero."
+            )
+        if evidence is None and (end - start).days >= 1:
+            raise RuntimeError(
+                f"gh pr list returned zero merged PRs since {since_iso} over a "
+                "window of at least one full day, and git cannot confirm the "
+                "window is empty (shallow checkout or git unavailable). Either "
+                "the window is genuinely quiet or the token lacks "
+                "`pull-requests: read`; re-run on a full-depth checkout to tell "
+                "the two apart rather than publishing a possible false zero."
+            )
+    return window
 
 
 def harvest_metrics(repo: str, since_iso: str) -> dict:

--- a/.github/workflows/fix-loop-analysis.yml
+++ b/.github/workflows/fix-loop-analysis.yml
@@ -50,6 +50,11 @@ permissions:
   # because a report that silently drops PRs understates its own denominator and
   # so must fail loudly instead.
   actions: read
+  # The harvest denominator lists merged PRs through the GraphQL search
+  # surface, which silently omits nodes the token cannot read instead of
+  # 403ing -- so a missing grant publishes a clean-looking false zero
+  # rather than failing.
+  pull-requests: read
   # No `id-token` here: the OIDC grant for Bedrock is job-scoped to `analyze`
   # below, so the git-history job never holds a credential it does not use.
 
@@ -155,6 +160,7 @@ jobs:
       contents: read
       issues: write
       actions: read
+      pull-requests: read
       id-token: write
     steps:
       # The model reads staged files only; a shallow checkout gives the action

--- a/test/test_fix_loop_discipline.py
+++ b/test/test_fix_loop_discipline.py
@@ -20,6 +20,7 @@ import os
 import re
 import shutil
 import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterator
 
@@ -256,21 +257,78 @@ class TestTheMetricsTokenCanReachWhatItReads:
     REQUIRED_SCOPES = {
         "/actions/": "actions: read",
         "/check-runs": "checks: read",
+        # The harvest denominator: `gh pr list` reads PRs through the
+        # GraphQL search surface, which omits nodes the token cannot read
+        # instead of 403ing -- the one surface where a missing grant is a
+        # false zero rather than a red run, so the grant must be pinned.
+        '"pr",': "pull-requests: read",
     }
 
     def test_every_api_surface_the_script_reads_is_granted(self) -> None:
         script = METRICS_SCRIPT.read_text(encoding="utf-8")
         doc = yaml.safe_load(ANALYSIS.read_text(encoding="utf-8"))
-        granted = doc.get("permissions") or {}
+        # A job-level `permissions:` block REPLACES the workflow-level one,
+        # so every job that declares its own must restate the reads in full.
+        blocks = {"the workflow": doc.get("permissions") or {}}
+        for job_id, job in (doc.get("jobs") or {}).items():
+            if isinstance(job, dict) and "permissions" in job:
+                blocks[f"job `{job_id}`"] = job.get("permissions") or {}
         for fragment, scope in self.REQUIRED_SCOPES.items():
             if fragment not in script:
                 continue
             key, _, value = scope.partition(": ")
-            assert granted.get(key) == value, (
-                f"the metrics script reads {fragment}, which needs `{scope}`; an "
-                f"explicit permissions block grants nothing it does not list, so "
-                f"the scheduled run 403s and files no report at all"
-            )
+            for where, granted in blocks.items():
+                assert granted.get(key) == value, (
+                    f"the metrics script reads {fragment}, which needs `{scope}`, "
+                    f"but {where} does not grant it; an explicit permissions "
+                    f"block grants nothing it does not list, so the scheduled "
+                    f"run publishes a false zero or 403s and files no report"
+                )
+
+
+class TestFalseZeroFailsLoud:
+    """Zero merged PRs must be proven empty, never assumed.
+
+    The search surface omits nodes the token cannot read instead of erroring,
+    so `gh_json` sees a valid empty list and the harvest publishes a
+    clean-looking zero -- the exact silent failure the script's own contract
+    forbids. When the checkout's own history disagrees with an empty window,
+    the script must raise instead of publishing.
+    """
+
+    # Two days back keeps the per-day search loop at three iterations while
+    # still spanning the full day the coarse fallback requires; a fixed date
+    # would grow the loop by one iteration per real day.
+    _SINCE = (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%dT00:00:00Z")
+
+    def _module(self):
+        return load_skill_script("fix_loop_metrics", METRICS_SCRIPT)
+
+    def test_zero_prs_with_local_merge_evidence_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mod = self._module()
+        monkeypatch.setattr(mod, "gh_json", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "_local_pr_evidence", lambda since_iso: True)
+        with pytest.raises(RuntimeError, match="pull-requests: read"):
+            mod.merged_prs_since("owner/repo", self._SINCE)
+
+    def test_zero_prs_with_an_actually_empty_history_is_legitimate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mod = self._module()
+        monkeypatch.setattr(mod, "gh_json", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "_local_pr_evidence", lambda since_iso: False)
+        assert mod.merged_prs_since("owner/repo", self._SINCE) == []
+
+    def test_unanswerable_git_still_raises_on_a_full_day_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mod = self._module()
+        monkeypatch.setattr(mod, "gh_json", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "_local_pr_evidence", lambda since_iso: None)
+        with pytest.raises(RuntimeError, match="pull-requests: read"):
+            mod.merged_prs_since("owner/repo", self._SINCE)
 
 
 class TestHarvestDenominator:


### PR DESCRIPTION
## Problem / Motivation

The weekly fix-loop-analysis workflow's harvest metric publishes `0/0 (n/a)` on every CI run, while the identical script over the identical window run locally under a user credential publishes a real numerator and denominator in the hundreds. The `Excluded: another base / gate never ran` row is also `0 / 0` in CI, so the PR listing is returning nothing at all — not merely PRs the gate did not apply to.

## Why it matters

The harvest metric exists to make the fix-loop denominator trustworthy, and its own docstring commits to never publishing a false zero. A clean-looking `0/0` in every scheduled report is exactly that false zero: it silently erases the adoption signal the weekly report is built around, and nothing goes red to say so.

## What changed (motivation → approach → change)

Symptom: `merged_prs_since` reads PRs via `gh pr list --search` (the GraphQL search surface), which **omits nodes the token cannot read instead of erroring**. The workflow grants `contents: read`, `issues: write`, `actions: read` — but never `pull-requests: read` — so the scheduled token sees a valid empty list, and `gh_json`'s raise-on-failure contract never triggers.

Three changes, defense in depth:

1. **Grant the scope** — `.github/workflows/fix-loop-analysis.yml` adds `pull-requests: read` at the workflow level (with a comment explaining the silent-omission behavior, in the same voice as the existing `actions: read` comment) and in the `analyze` job's explicit `permissions:` block, since a job-level block replaces the workflow-level one and grants nothing it does not list. The `metrics` job declares no block of its own and inherits the workflow grant.
2. **Pin the grant in the ratchet test** — `TestTheMetricsTokenCanReachWhatItReads.REQUIRED_SCOPES` gains a fragment matching the script's `gh pr list` invocation mapped to `pull-requests: read`, and the test now iterates every job-level `permissions:` block in addition to the workflow-level one. Verified red against the unpatched workflow, green after the grant.
3. **Fail loud on a false zero** — `merged_prs_since` now cross-checks an empty window against the checkout's own history via a new read-only `_local_pr_evidence` helper (squash `(#N)` subject trailers or `--merges` commits since the window start). Evidence of PR-merged commits while the search says zero raises with the probable cause named; when git cannot answer (shallow checkout), a window spanning at least one full day raises with a message that names both possible causes instead of misattributing. The evidence check is deliberately scoped to the checked-out branch — the scheduled run checks out the default branch, which is the harvest's own scope, and scanning all refs would let a feature branch's merge commits redden a legitimately quiet week; the cherry-picked-backport edge is documented in the docstring.

Escape counting is untouched, and the Bedrock/OIDC path of the `analyze` job is untouched beyond the one permissions line.

Local model-pinned pre-push review (GPT lane + Opus lane): no blocking findings; advisory findings applied (split loud-fail diagnosis, dynamic test window date, branch-scope rationale documented). One GPT suggestion to scan `--all` refs was deliberately not taken for the reason in point 3.

## Tests

- `test_every_api_surface_the_script_reads_is_granted` (extended): every API surface the metrics script names must be granted in the workflow-level block **and** every job-level block; fails red on the unpatched workflow.
- `TestFalseZeroFailsLoud::test_zero_prs_with_local_merge_evidence_raises`: `gh_json` returns `[]` while local evidence exists → `RuntimeError` naming `pull-requests: read`.
- `TestFalseZeroFailsLoud::test_zero_prs_with_an_actually_empty_history_is_legitimate`: `[]` with no local evidence → returns `[]`, no raise.
- `TestFalseZeroFailsLoud::test_unanswerable_git_still_raises_on_a_full_day_window`: `[]` with git unable to answer over a ≥1-day window → raises rather than publishing a possible false zero.

All 30 tests in `test/test_fix_loop_discipline.py` pass; isort/flake8/mypy/black green locally.

## Manual verification

N/A — unit coverage sufficient: the permission grant is asserted by the ratchet test against the real workflow file, and both loud-fail branches plus the legit-empty branch are unit-covered. The scheduled run itself is the integration surface and will confirm on its next Monday fire.

## Related Issues

Closes #9611

## Pattern harvest

Rule candidate: review-prompt
Pattern: a GitHub API surface that silently omits unreadable nodes instead of 403ing (GraphQL search) paired with an explicit `permissions:` block that does not grant it — a missing scope becomes a clean-looking zero rather than a red run; every metric consuming such a surface needs a local cross-check or a pinned-scope ratchet test.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
