### PR TITLE
fix: key the session peer pin on the signed payload, not the cookie string

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -259,9 +259,12 @@ class TokenStateManager:
         self._nonces: OrderedDict[str, float] = OrderedDict()
         # Observation latches for the Security Posture surface only — never read
         # by an auth decision. See bind_peer() / proxied_pin_observed().
-        # token → (peer key, exp, proxied). The peer key is "ip:<addr>" for the
-        # default address pin and "ts:node:<login>@<node>" / "ts:login:<login>" for a
-        # daemon-verified tailnet peer (RFC §3) — in-memory only, regenerated on restart.
+        # _token_pin_key(token) → (peer key, exp, proxied). The key comes from
+        # the signed payload rather than the token string, so every string that
+        # authenticates as a session finds that session's pin. The peer key is
+        # "ip:<addr>" for the default address pin and "ts:node:<login>@<node>" /
+        # "ts:login:<login>" for a daemon-verified tailnet peer (RFC §3) —
+        # in-memory only, regenerated on restart.
         self._peer_bindings: dict[str, tuple[str, float, bool]] = {}
         self._consumed: dict[str, float] = {}  # token → exp
 
@@ -303,8 +306,9 @@ class TokenStateManager:
         Security Posture surface only — it does not change the binding or how
         :meth:`check_peer` compares it.
         """
+        key = _token_pin_key(token)
         with self._lock:
-            self._peer_bindings[token] = (peer_key, session_exp, proxied)
+            self._peer_bindings[key] = (peer_key, session_exp, proxied)
 
     def proxied_pin_observed(self, now: float) -> bool | None:
         """Report the pin scope of the sessions that are LIVE at *now*.
@@ -340,8 +344,9 @@ class TokenStateManager:
         (Tailscale re-enroll), and reporting it as "IP mismatch" would send
         them chasing the wrong thing.
         """
+        key = _token_pin_key(token)
         with self._lock:
-            entry = self._peer_bindings.get(token)
+            entry = self._peer_bindings.get(key)
         if entry is None or entry[0] == peer_key:
             return True, ""
         stored = entry[0]
@@ -353,8 +358,9 @@ class TokenStateManager:
 
     def has_binding(self, token: str) -> bool:
         """Whether *token* currently has a peer binding (live or not)."""
+        key = _token_pin_key(token)
         with self._lock:
-            return token in self._peer_bindings
+            return key in self._peer_bindings
 
     def mark_consumed(self, token: str, session_exp: float) -> None:
         """Mark a token as consumed (used for one-time token patterns)."""
@@ -749,6 +755,35 @@ def _b64url_encode(data: bytes) -> str:
 def _b64url_decode(s: str) -> bytes:
     padding = 4 - len(s) % 4
     return base64.urlsafe_b64decode(s + "=" * (padding % 4))
+
+
+def _token_pin_key(token: str) -> str:
+    """The identity a token's peer pin is stored under.
+
+    Derived from the signed payload bytes, not from the token string, because
+    the two are not one-to-one: :func:`_b64url_decode` uses the stdlib decoder's
+    default ``validate=False``, which discards characters outside the base64
+    alphabet, so a cosmetically re-encoded copy of a token is a different string
+    carrying byte-identical payload bytes -- and :func:`validate_token` verifies
+    the signature over those bytes, so it accepts both as the same session.
+
+    Keyed on the string, such a copy authenticates as the session while missing
+    its binding, and :meth:`TokenStateManager.check_peer` treats an absent entry
+    as unbound. Keyed on the payload, every string that can authenticate as a
+    session resolves to that session's pin, so the pin cannot be shed by
+    re-spelling the cookie. The signed payload carries a per-mint nonce and
+    ``iat``, so two separate mints never share a key.
+
+    A token whose payload cannot be decoded keeps the raw string as its key. It
+    cannot authenticate at all (:func:`validate_token` rejects it as invalid
+    encoding), and folding every undecodable string into one shared key would
+    alias unrelated tokens onto one another's pins.
+    """
+    try:
+        payload = _b64url_decode(token.split(".", 1)[0])
+    except Exception:
+        return token
+    return hashlib.sha256(payload).hexdigest()
 
 
 def _sign(payload: bytes) -> str:

--- a/test/test_secc_poc_token_session_pin.py
+++ b/test/test_secc_poc_token_session_pin.py
@@ -1,0 +1,183 @@
+"""The session peer/IP pin must hold for every string that authenticates as
+that session, not only for the exact spelling the pin was recorded against.
+
+``_b64url_decode`` uses ``base64.urlsafe_b64decode`` with the stdlib default
+``validate=False``, which silently DISCARDS characters outside the base64
+alphabet. Inserting a multiple-of-four run of such characters into the encoded
+payload therefore produces a DIFFERENT token string that decodes to byte-identical
+payload bytes, so the HMAC still verifies and the string authenticates as the
+same session.
+
+``TokenStateManager`` therefore keys ``_peer_bindings`` on the signed payload, so
+a re-encoded copy of a pinned cookie resolves to that session's entry. Keyed on
+the token string it resolves to no entry at all, and ``check_peer`` reads an
+absent entry as unbound (``entry is None`` -> ``(True, "")``) -- which is what
+would let a stolen access cookie satisfy the pin from any address.
+
+All values here are fabricated fixtures. Nothing reads the real crew home, the
+signing key on disk, or any live session store: the HMAC secret and the
+revocation generation are both monkeypatched.
+"""
+
+import time
+
+import pytest
+
+from kiro_crew.dashboard.token_auth import _state as _token_state
+from kiro_crew.dashboard.token_auth import (
+    bind_token_peer,
+    check_token_peer,
+    generate_token,
+    validate_token,
+)
+
+
+def has_token_binding(token: str) -> bool:
+    """Whether the state manager holds a peer binding for *token*.
+
+    The middleware's first-use re-pin asks this question directly of the state
+    manager, so the tests below ask it the same way rather than through a
+    module-level wrapper that does not exist.
+    """
+    return _token_state.has_binding(token)
+
+
+FIXTURE_SECRET = b"FABRICATED-FIXTURE-HMAC-SECRET-NOT-A-REAL-KEY"
+BOUND_ADDR = "ip:10.0.0.1"
+ATTACKER_ADDR = "ip:203.0.113.9"
+# Four characters outside the base64 alphabet: a multiple of four keeps
+# len(encoded) % 4 stable so _b64url_decode's padding arithmetic is unchanged.
+JUNK_RUN = "!!!!"
+
+
+@pytest.fixture
+def isolated_token_state(tmp_path, monkeypatch):
+    """Sign and validate against fabricated state only -- never the real home."""
+    import kiro_crew.dashboard.revocation_gen as revocation_gen
+    import kiro_crew.dashboard.token_auth as token_auth
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(token_auth, "_get_secret", lambda: FIXTURE_SECRET)
+    monkeypatch.setattr(revocation_gen, "_gen", 0)
+    monkeypatch.setattr(token_auth, "_revoked_store_singleton", None)
+    token_auth._state.clear_all()
+    yield
+    token_auth._state.clear_all()
+    monkeypatch.setattr(revocation_gen, "_gen", 0)
+    monkeypatch.setattr(token_auth, "_revoked_store_singleton", None)
+
+
+def _mutate_encoded_payload(token: str) -> str:
+    """A different token string that decodes to the same payload bytes."""
+    encoded_payload, signature = token.split(".", 1)
+    return f"{encoded_payload[:8]}{JUNK_RUN}{encoded_payload[8:]}.{signature}"
+
+
+def test_peer_pin_holds_against_token_string_mutation(isolated_token_state):
+    session_exp = time.time() + 600
+    token = generate_token("fixture-user", ttl_seconds=600, register_nonce=False)
+    bind_token_peer(token, BOUND_ADDR, session_exp)
+
+    # The pinned session is refused from another address. This is the control.
+    ok_original, _ = check_token_peer(token, ATTACKER_ADDR)
+    assert not ok_original, "precondition: the pin must refuse the original token elsewhere"
+
+    mutant = _mutate_encoded_payload(token)
+    assert mutant != token, "precondition: the mutation must change the token string"
+
+    valid, user_id, reason = validate_token(mutant, use_session_exp=True)
+    assert valid, f"precondition: the mutated string must still validate (reason={reason!r})"
+    assert user_id == "fixture-user"
+
+    # The security property: a string that authenticates as this session must
+    # satisfy the pin that session was bound to.
+    ok_mutant, _mismatch = check_token_peer(mutant, ATTACKER_ADDR)
+    assert not ok_mutant, (
+        "peer pin bypassed: a base64-mutated copy of the pinned token validates "
+        "as the same session but carries no binding, so check_peer fail-opens "
+        "and the session is accepted from an unbound address"
+    )
+
+
+def test_first_use_repin_does_not_see_a_mutated_cookie_as_unbound(isolated_token_state):
+    """``has_binding`` answers for the session, not for the spelling.
+
+    The middleware re-pins a session it believes has no binding yet. Asked about
+    a re-encoded copy of a bound cookie, a string-keyed map answers "unbound",
+    which would re-pin that session to whatever address presented the copy.
+    """
+    session_exp = time.time() + 600
+    token = generate_token("fixture-user", ttl_seconds=600, register_nonce=False)
+    bind_token_peer(token, BOUND_ADDR, session_exp)
+
+    assert has_token_binding(token), "precondition: the original token is bound"
+    assert has_token_binding(_mutate_encoded_payload(token)), (
+        "a re-encoded copy of a bound cookie reads as unbound, so the first-use "
+        "re-pin would rebind this session to the address that presented the copy"
+    )
+
+
+def test_pin_still_admits_the_bound_peer_through_a_re_encoded_cookie(isolated_token_state):
+    """Keying on the payload must not reject the legitimate holder.
+
+    The pin has to keep saying yes from the address it was bound to, whichever
+    spelling of the cookie arrives -- otherwise the fix trades a bypass for a
+    lockout.
+    """
+    session_exp = time.time() + 600
+    token = generate_token("fixture-user", ttl_seconds=600, register_nonce=False)
+    bind_token_peer(token, BOUND_ADDR, session_exp)
+
+    ok, mismatch = check_token_peer(_mutate_encoded_payload(token), BOUND_ADDR)
+    assert ok, f"the bound peer was refused its own session (mismatch={mismatch!r})"
+
+
+def test_trailing_junk_run_is_the_same_session_as_the_original(isolated_token_state):
+    """A second mutation shape: the junk run appended rather than inserted.
+
+    Any run of ignored characters whose length is a multiple of four decodes to
+    the same payload, so the property cannot depend on where the run sits.
+    """
+    session_exp = time.time() + 600
+    token = generate_token("fixture-user", ttl_seconds=600, register_nonce=False)
+    bind_token_peer(token, BOUND_ADDR, session_exp)
+
+    encoded_payload, signature = token.split(".", 1)
+    mutant = f"{encoded_payload}{JUNK_RUN}.{signature}"
+    valid, _user_id, reason = validate_token(mutant, use_session_exp=True)
+    assert valid, f"precondition: the mutated string must still validate (reason={reason!r})"
+
+    ok, _mismatch = check_token_peer(mutant, ATTACKER_ADDR)
+    assert not ok, "a trailing junk run sheds the pin"
+
+
+def test_two_mints_do_not_share_one_pin(isolated_token_state):
+    """Distinct sessions must stay distinct.
+
+    A key derived from the payload would be worthless if two mints collided:
+    binding one session would silently pin the other. The signed payload carries
+    a per-mint nonce and ``iat``, so they do not.
+    """
+    session_exp = time.time() + 600
+    first = generate_token("fixture-user", ttl_seconds=600, register_nonce=False)
+    second = generate_token("fixture-user", ttl_seconds=600, register_nonce=False)
+    assert first != second
+
+    bind_token_peer(first, BOUND_ADDR, session_exp)
+    assert not has_token_binding(second), "a second mint inherited the first one's pin"
+    ok, _mismatch = check_token_peer(second, ATTACKER_ADDR)
+    assert ok, "an unbound session must stay unbound"
+
+
+def test_undecodable_tokens_are_not_folded_together(isolated_token_state):
+    """A token whose payload cannot be decoded keeps its own key.
+
+    Such a string cannot authenticate at all, but it must not act as a wildcard:
+    if every undecodable string shared one key, binding one would answer for all
+    of them.
+    """
+    session_exp = time.time() + 600
+    bind_token_peer("A.signature", BOUND_ADDR, session_exp)
+
+    assert has_token_binding("A.signature")
+    assert not has_token_binding("B.signature"), "two undecodable strings share one pin entry"

--- a/test/test_tailnet_peer.py
+++ b/test/test_tailnet_peer.py
@@ -515,7 +515,7 @@ class TestRefreshRotationRebind:
             app={"tailnet_trust": TRUST},
         )
         await _rebind_rotated_token_to_peer(req, "new-token", 9999999999.0)
-        key, _exp, proxied = _ta._state._peer_bindings["new-token"]
+        key, _exp, proxied = _ta._state._peer_bindings[_ta._token_pin_key("new-token")]
         assert key == "ts:node:you@example.com|phone.tail.ts.net"
         assert proxied is False
         _ta._state.clear_all()
@@ -535,10 +535,10 @@ class TestRefreshRotationRebind:
             app={"tailnet_trust": TRUST},
         )
         await _rebind_rotated_token_to_peer(req, "new-token", 9999999999.0)
-        assert "new-token" not in _ta._state._peer_bindings
+        assert not _ta._state.has_binding("new-token")
         req2 = SimpleNamespace(remote="127.0.0.1", headers=CIMultiDict(), app={})
         await _rebind_rotated_token_to_peer(req2, "other-token", 9999999999.0)
-        assert "other-token" not in _ta._state._peer_bindings
+        assert not _ta._state.has_binding("other-token")
 
 
 class TestCliPathTrust:

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -1872,7 +1872,7 @@ def test_signing_secret_incomplete_file_not_deleted_if_replaced(tmp_path, monkey
 
 def test_evict_expired_removes_old_entries() -> None:
     """Verify evict_expired removes expired IP bindings, consumed tokens, and nonces."""
-    from kiro_crew.dashboard.token_auth import _state
+    from kiro_crew.dashboard.token_auth import _state, _token_pin_key
 
     # Generate a token and bind IP / mark consumed
     token = generate_token("evict_user")
@@ -1888,7 +1888,8 @@ def test_evict_expired_removes_old_entries() -> None:
 
     # Verify expired entries were removed
     with _state._lock:
-        assert token not in _state._peer_bindings, "expired IP binding should be evicted"
+        pin_key = _token_pin_key(token)
+        assert pin_key not in _state._peer_bindings, "expired pin should be evicted"
         assert token not in _state._consumed, "expired consumed token should be evicted"
         assert "expired_nonce" not in _state._nonces, "expired nonce should be evicted"
 
@@ -3502,7 +3503,7 @@ async def test_verified_peer_session_pins_to_identity_key(_tailnet_env) -> None:
     assert resp.status == 200
     cookie = resp.cookies.get("mc_token_5476")
     assert cookie is not None
-    key, _exp, proxied = _ta._state._peer_bindings[cookie.value]
+    key, _exp, proxied = _ta._state._peer_bindings[_ta._token_pin_key(cookie.value)]
     assert key == "ts:node:you@example.com|phone.tail.ts.net"
     assert proxied is False
     from kiro_crew.dashboard.token_auth import proxied_pin_observed
@@ -3609,7 +3610,7 @@ async def test_xff_injection_from_non_loopback_peer_gets_ip_pin(_tailnet_env) ->
     resp = await mw(_peer_request(remote="203.0.113.7", query={"token": token}), _ok_handler)
     assert resp.status == 200
     cookie = resp.cookies.get("mc_token_5476")
-    assert _ta._state._peer_bindings[cookie.value][0] == "ip:203.0.113.7"
+    assert _ta._state._peer_bindings[_ta._token_pin_key(cookie.value)][0] == "ip:203.0.113.7"
     whois.assert_not_called()
 
 
@@ -3625,7 +3626,7 @@ async def test_daemon_failure_degrades_to_token_ip_path(_tailnet_env) -> None:
     resp = await mw(_peer_request(query={"token": token}), _ok_handler)
     assert resp.status == 200
     cookie = resp.cookies.get("mc_token_5476")
-    key, _exp, proxied = _ta._state._peer_bindings[cookie.value]
+    key, _exp, proxied = _ta._state._peer_bindings[_ta._token_pin_key(cookie.value)]
     assert key == "ip:127.0.0.1"
     assert proxied is True  # same-host proxy pin — posture reports SHARED
 
@@ -3661,7 +3662,7 @@ async def test_require_peer_link_exchanges_for_verified_allowed_peer(_tailnet_en
     assert _ta.requires_verified_peer_unverified(cookie.value) is True
     expected = "ts:node:you@example.com|phone.tail.ts.net"
     assert required_peer_key_unverified(cookie.value) == expected
-    assert _ta._state._peer_bindings[cookie.value][0] == expected
+    assert _ta._state._peer_bindings[_ta._token_pin_key(cookie.value)][0] == expected
     refresh = resp.cookies.get(refresh_cookie_name("5476"))
     assert refresh is not None
     assert refresh_token_peer_key(refresh.value) == expected
@@ -3680,7 +3681,7 @@ async def test_non_tailscale_tunnel_behaviour_is_unchanged(_tailnet_env) -> None
     resp = await mw(_peer_request(query={"token": token}), _ok_handler)
     assert resp.status == 200
     cookie = resp.cookies.get("mc_token_5476")
-    key, _exp, proxied = _ta._state._peer_bindings[cookie.value]
+    key, _exp, proxied = _ta._state._peer_bindings[_ta._token_pin_key(cookie.value)]
     assert key == "ip:127.0.0.1"
     assert proxied is True
     assert proxied_pin_observed() is True
@@ -3804,7 +3805,7 @@ async def test_restart_first_use_repins_verified_peer_cookie(_tailnet_env) -> No
     # No bind_token_peer call: simulates the post-restart unbound state.
     resp = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
     assert resp.status == 200
-    key, _exp, _proxied = _ta._state._peer_bindings[token]
+    key, _exp, _proxied = _ta._state._peer_bindings[_ta._token_pin_key(token)]
     assert key == "ts:node:you@example.com|phone.tail.ts.net"
     # Same cookie replayed from a different node (different tailnet address,
     # so the whois cache cannot serve the first node's answer) is rejected.
@@ -3832,7 +3833,7 @@ async def test_restart_require_peer_cookie_refuses_unverified_first_use(
     resp = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
     assert resp.status == 403
     assert b"tailnet identity unverified" in resp.body
-    assert token not in _ta._state._peer_bindings
+    assert not _ta._state.has_binding(token)
 
 
 @pytest.mark.asyncio
@@ -3854,14 +3855,14 @@ async def test_restart_signed_require_peer_cookie_rehydrates_only_for_original_d
         register_nonce=False,
     )
 
-    assert token not in _ta._state._peer_bindings
+    assert not _ta._state.has_binding(token)
     response = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
     assert response.status == 200
-    assert _ta._state._peer_bindings[token][0] == expected
+    assert _ta._state._peer_bindings[_ta._token_pin_key(token)][0] == expected
 
     # Simulate another restart, then let a different but still allowlisted node
     # arrive first.  It cannot claim the empty in-memory map.
-    _ta._state._peer_bindings.pop(token, None)
+    _ta._state._peer_bindings.pop(_ta._token_pin_key(token), None)
     set_whois(_whois_payload(node="other-node.tail.ts.net"))
     replay = await mw(
         _peer_request(forwarded="100.64.0.6", cookies={"mc_token_5476": token}),
@@ -3869,7 +3870,7 @@ async def test_restart_signed_require_peer_cookie_rehydrates_only_for_original_d
     )
     assert replay.status == 403
     assert b"device identity mismatch" in replay.body
-    assert token not in _ta._state._peer_bindings
+    assert not _ta._state.has_binding(token)
 
 
 @pytest.mark.asyncio
@@ -3887,7 +3888,7 @@ async def test_restart_legacy_claimless_require_peer_cookie_cannot_claim_device(
     response = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
     assert response.status == 403
     assert b"tailnet session device binding missing" in response.body
-    assert token not in _ta._state._peer_bindings
+    assert not _ta._state.has_binding(token)
 
 
 @pytest.mark.asyncio
@@ -3909,7 +3910,7 @@ async def test_claimless_require_peer_link_cannot_enroll_on_mixed_internal_path(
     assert response.status == 403
     assert b"tailnet session device binding missing" in response.body
     assert not response.cookies
-    assert token not in _ta._state._peer_bindings
+    assert not _ta._state.has_binding(token)
 
 
 @pytest.mark.asyncio
@@ -3931,7 +3932,7 @@ async def test_signed_login_scope_survives_operator_pin_scope_change(_tailnet_en
     )
     response = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
     assert response.status == 200
-    assert _ta._state._peer_bindings[token][0] == expected
+    assert _ta._state._peer_bindings[_ta._token_pin_key(token)][0] == expected
 
 
 @pytest.mark.asyncio
@@ -3952,7 +3953,10 @@ async def test_restart_repin_covers_internal_mixed_paths(_tailnet_env) -> None:
     req.path = "/api/spawn"
     resp = await mw(req, _ok_handler)
     assert resp.status == 200
-    assert _ta._state._peer_bindings[token][0] == "ts:node:you@example.com|phone.tail.ts.net"
+    assert (
+        _ta._state._peer_bindings[_ta._token_pin_key(token)][0]
+        == "ts:node:you@example.com|phone.tail.ts.net"
+    )
     set_whois(_whois_payload(node="other-node.tail.ts.net"))
     req2 = _peer_request(forwarded="100.64.0.6", cookies={"mc_token_5476": token})
     req2.path = "/api/spawn"
@@ -3975,7 +3979,7 @@ async def test_restart_unbound_cookie_without_peer_keeps_todays_semantics(
     mark_consumed(token)
     resp = await mw(_make_request(cookies={"mc_token_5476": token}), _ok_handler)
     assert resp.status == 200
-    assert token not in _ta._state._peer_bindings
+    assert not _ta._state.has_binding(token)
 
 
 def test_app_token_path_allowed_implicit_ws():


### PR DESCRIPTION
## Problem / Motivation

A dashboard access cookie can be re-spelled into a different string that still
authenticates as the same session, and the session's peer/IP pin does not follow
it. Copy a pinned cookie, insert a run of characters the base64 decoder ignores,
and the copy is accepted from any address — the pin is silently gone.

The two halves that produce this:

- `_b64url_decode` in `src/kiro_crew/dashboard/token_auth.py` calls
  `base64.urlsafe_b64decode` with the stdlib default `validate=False`, which
  discards characters outside the base64 alphabet. Inserting a multiple-of-four
  run of such characters into the encoded payload yields a **different token
  string** whose **decoded payload bytes are identical**. `validate_token`
  computes and compares the HMAC over those bytes, so both strings verify.
- `TokenStateManager` stored the peer pin in `_peer_bindings` keyed on the token
  **string**. The re-encoded copy therefore resolved to no entry, and
  `check_peer` treats an absent entry as unbound (`entry is None` →
  `(True, "")`).

## Why it matters

The pin is the control that stops a stolen dashboard cookie from being replayed
from somewhere else. Anyone who can read one cookie value — a shared machine, a
log, a synced browser profile — can shed its address or tailnet-identity pin with
a four-character edit and use it from anywhere, for the life of the session. It
also reaches the first-use re-pin path: asked about a re-encoded copy,
`has_binding` answered "unbound", which would rebind that session to whatever
address presented the copy.

## What changed (motivation → approach → change)

Symptom: a mutated copy of a pinned cookie is accepted from an unbound address.
Root cause: the pin's identity is a **representation** of the session (one
spelling of the token) while authentication's identity is the **signed payload**;
the two are not one-to-one, so a string can authenticate as a session and miss
its pin. Change: key the pin on what the signature already covers.

`_peer_bindings` is now keyed by `_token_pin_key(token)` — the SHA-256 of the
decoded, signed payload bytes. `bind_peer`, `check_peer` and `has_binding` all
resolve through it, so no call site can address the map by string. Consequences
that make it safe:

- The payload carries a per-mint `nonce` and `iat`, so two mints never collide;
  two distinct tokens cannot share one pin.
- A token whose payload cannot be decoded keeps the raw string as its key. It
  cannot authenticate at all (`validate_token` rejects it as invalid encoding),
  and folding every undecodable string into one key would alias unrelated
  strings onto one another's pins.
- The key is computed outside the lock; it is a pure hash.

**Why not the other candidate — rejecting a non-canonical encoding in
`_b64url_decode`.** Two reasons, and either alone decides it. First, blast
radius: `_b64url_decode` is on every token path in this file (twelve-plus call
sites — link validation, cookie validation, refresh, revocation), so a
stricter decoder changes the accept/reject behaviour of all of them to fix one
map, where this change touches only the pin. Second, it treats the encoding as
the defect rather than the identity: anything else keyed on a token string would
still be keyed on a representation, and the next lenient parser reopens it. It
also cannot satisfy the regression test below, which asserts as a precondition
that the mutated string still authenticates — that precondition is the real
property (a string that authenticates as a session must satisfy that session's
pin), not an accident of the test.

**Ruling on `check_peer`'s fail-open.** It stays. `check_peer` still returns
`(True, "")` for a token with no entry, and that is load-bearing rather than
overlooked: the in-memory pin map is cleared on gateway restart, and
restart-persistent cookies are documented to outlive it (`_check_pin` in the
middleware relies on this), so closing it would refuse those sessions outright
and break app tokens and multi-hop paths that were never pinned. What guarantees
a pinned session cannot lose its pin is no longer the fail-open's absence but the
key: every string that can authenticate as that session now resolves to the same
entry, so "no entry" means the session genuinely has no binding rather than
"this spelling has none". For a session that requires a verified peer, the signed
`peer_key` claim in the middleware is the independent check and is unaffected by
this map at all.

Scope: the pin map named by the finding. Nothing else in the file, in the HMAC
construction, or in the token format is touched.

## Tests

`test/test_secc_poc_token_session_pin.py` — six cases, all against fabricated
fixtures (a fabricated HMAC secret, a monkeypatched revocation generation, a
`tmp_path` config dir; nothing reads a real home, key or session store).

- `test_peer_pin_holds_against_token_string_mutation` — the acceptance test. A
  pinned session is refused from another address (the control), the mutated
  string still validates as the same session (the precondition), and the pin
  must refuse it from an unbound address. **Fails on `origin/main`**, passes
  here.
- `test_first_use_repin_does_not_see_a_mutated_cookie_as_unbound` — `has_binding`
  answers for the session, so the middleware's first-use re-pin cannot rebind a
  bound session to the address that presented a copy. Fails on `origin/main`.
- `test_pin_still_admits_the_bound_peer_through_a_re_encoded_cookie` — the
  legitimate holder is still admitted from its own address, so the fix does not
  trade a bypass for a lockout.
- `test_trailing_junk_run_is_the_same_session_as_the_original` — a second
  mutation shape (run appended, not inserted), so the property cannot depend on
  where the ignored characters sit. Fails on `origin/main`.
- `test_two_mints_do_not_share_one_pin` — two mints stay distinct; binding one
  does not pin the other.
- `test_undecodable_tokens_are_not_folded_together` — the raw-string fallback
  gives each undecodable string its own key instead of one shared wildcard.

`test/test_token_auth.py` and `test/test_tailnet_peer.py`: the existing peer-pin
tests reach into `_peer_bindings` directly and were indexing it by token string.
They now address it through the same derivation, or through `has_binding`. This
is not cosmetic — six of them assert that *no* binding was made, and left keyed
on the raw string they would have passed vacuously forever.

The test file name and the nodeid of the first test are fixed identifiers: the
security-conductor ledger uses
`test/test_secc_poc_token_session_pin.py::test_peer_pin_holds_against_token_string_mutation`
as this finding's acceptance key and reads a JUnit report keyed to that name.
Renaming either is a follow-up once the finding is closed, not part of this PR.

## Manual verification

Automated gate, not hand-driven: `verify_fix.py` from the security-conductor
skill re-runs the proof of concept against this worktree and re-classifies every
gating `shell` golden path — the legitimate operations a security fix must not
break — against the fixed code.

```
verify_fix.py --finding-id 1 --worktree <this worktree>   → exit 0
```

```json
{"broken": [], "corpus_problems": [], "corpus_rows": 49, "finding_id": 1,
 "golden_paths_checked": 41, "platform": "posix",
 "poc": {"exit": 10, "reason": "the proof does not reproduce any more",
         "verdict": "holds"},
 "unverifiable": [], "verdict": "holds"}
```

Exit 0 is both halves: the proof no longer reproduces, and all 41 shell golden
paths that apply to this host are still permitted (0 broken, 0 unverifiable).
The six `needs_human` rows it prints are `flow` and `cron` entries the harness
never executes by design; none is affected by a change to an in-memory pin map.

Cross-platform: the diff adds no platform branch and no platform-specific
behaviour — `str.split`, a stdlib base64 decode and a SHA-256 hexdigest, all
identical on Linux, macOS and Windows. The tests touch no path, process or
socket.

`arcc: unavailable` — the `security-assistance` skill is installed but no
`search_arcc` tool exists in this session's tool table, so no ARCC governance
lookup backs this change.

## Related Issues

no linked issue: raised by the security-conductor pilot, round `m2-round-1`,
finding 1 (surface `token-session`, Medium, confirmed by an independent
verifier). There is no public issue to close.

## Pattern harvest

Rule candidate: review-prompt
Pattern: state keyed on a credential's serialized form while its authenticity is
established over the decoded form — a lenient decoder makes the two one-to-many,
so any per-session state keyed on the outer string can be shed by re-spelling it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing behaviour change
- [x] No secrets, credentials, or internal references in the diff
