### PR TITLE
fix(cron): align malformed-owner test with the deserialization type-guard

### DIFF
--- a/test/test_remove_slot_for_history_key.py
+++ b/test/test_remove_slot_for_history_key.py
@@ -853,7 +853,15 @@ class TestAFailedRemovalDoesNotLeakIntoTheNextSave:
 
         reloaded = CronService(base_dir=tmp_path)
         assert reloaded.get_job(parent.id) is None
-        assert reloaded.get_job(malformed.id).session_key == ["not", "a", "string"]
+        # The malformed row SURVIVES the unrelated removal -- that is the
+        # poison this test guards against. Its owner field does not survive
+        # verbatim: deserialization type-guards every string field,
+        # degrading a non-string session_key to "" so no consumer ever
+        # calls string methods on a list. "" is the field's documented
+        # unset value, not corruption.
+        survivor = reloaded.get_job(malformed.id)
+        assert survivor is not None
+        assert survivor.session_key == ""
 
     def test_a_failed_removal_is_not_persisted_by_an_unrelated_later_save(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Summary

Main is red again on Backend Tests — `test_malformed_persisted_owner_does_not_poison_unrelated_removal` fails on all platforms (it first surfaced on a Windows shard, but pristine main fails on Linux too). Second same-night instance of the two-individually-green-PRs collision:

- #9888 (merged 21:11:15 PT) type-guards every cron string field at deserialization: a non-string `session_key` degrades to `""`, by documented policy — the guard's comment names the failure it prevents (the redacting serializer would 500 the listing calling string methods on a list).
- #9109 (merged 21:12:14 PT, **one minute later**) added this test, whose final assertion expects a malformed `["not", "a", "string"]` owner to survive the save/load round trip **verbatim**.

Each PR was green against a main that lacked the other; their union fails.

## Fix

The type-guard is the deliberate, documented behavior; the verbatim assertion is incidental to the test's actual point — that a malformed row does not poison an **unrelated** job's removal. So the test moves, not the guard: the survivor row must still exist after the unrelated removal, and its owner field now reads `""`, the guard's documented unset value. A comment in the test records why, citing #9888.

## Testing

- `test/test_remove_slot_for_history_key.py`: 134/134 pass with this change; the original assertion fails on pristine main (reproduced on Linux locally).
- No product code changed.

## Pattern harvest

Rule candidate: process — same class as this evening's #10248 (two green PRs whose union breaks an invariant; these two merged 59 seconds apart). A merge queue that retests each PR against post-merge main catches the whole class; no code-level rule can, since each tree was correct in isolation. Two instances in one night on the same repo is a measurable signal for enabling one.

First observed on [PR #9969's CI](https://github.com/kirodotdev/KiroCrew/pull/9969); reproduced on pristine main.
