### PR TITLE
fix(windows): preserve MCP args and make log diagnostics usable

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -595,6 +595,30 @@ are CONSTRUCTED and cannot be changed afterwards. `socket_path`, `overlay_dir`,
 once at spawn, so they too are marked `restart=True` in the config schema and
 apply to a broker started after the change.
 
+### Stub argument transport
+
+Generated overlays carry backend arguments as a base64url-encoded UTF-8 JSON
+string list in `--target-args-b64`. Pool-identity environment names use the same
+codec in `--pool-identity-env-b64`. The encoded alphabet contains no shell
+metacharacters: a Windows CLI can reparse the launch through `cmd.exe` without
+turning a delimiter into a pipeline. Empty arguments, Unicode and literal pipes
+retain their original boundaries. This is encoding, not encryption; arguments
+remain visible on the command line, and the longer representation still counts
+against the host's command-line length limit. On Windows, generation warns
+with the server name and command length when the base stub command reaches
+cmd.exe's 8,191 UTF-16-unit limit; it never logs the argument payload or rejects
+a launcher that can use a longer command. Per-session additions can grow the
+command further.
+
+The stub decodes before both fallback launch and command hashing. The rewriter's
+daemon target map decodes identically, preserving the hash used to select a
+backend. Encoded flags take precedence when present; malformed payloads fail
+rather than falling back to different arguments. Legacy `--target-args`,
+`--pool-identity-env` and `--target-args-sep` remain readable. Rewriter fingerprint
+schema 4 regenerates cached delimiter-based overlays on upgrade. Upgrades must
+keep the rewriter and stub from the same package; an older stub cannot consume
+the new flags.
+
 ## How app agents reach MCP servers
 
 An app declares MCP servers in its manifest, and

--- a/docs/system-specs/common/platform-compat.md
+++ b/docs/system-specs/common/platform-compat.md
@@ -24,6 +24,7 @@ produces exactly those silent failures, which is why the helper is named per cal
 
 | Need | Use (`platform_compat`) | NOT |
 |------|--------------------------|-----|
+| Tail a rotating log | `open_log_file_for_tail(path)` returns a binary read descriptor (caller closes); Windows permits read/write/delete sharing so the writer can rename during a read. Only for log readers, never security pinning. | plain `open` held while a Windows writer rolls over |
 | File lock | `file_lock(fd, exclusive=)` / `acquire_lock`+`release_lock` / `try_acquire_lock` | `fcntl.flock` |
 | Liveness probe | `pid_exists(pid)` / `pid_liveness(pid)` | `os.kill(pid, 0)` (kills on Windows!) |
 | Kill a process | `kill_pid(pid, sig)` | `os.kill(pid, sig)` |

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -173,7 +173,7 @@ choice blob makes the usage line unreadable.
 | `kirocrew setup --agent-only` | Only install agent config (skip credentials) |
 | `kirocrew setup --slack` | Run the guided Slack credential + slash-command setup (opt-in) |
 | `kirocrew setup --whatsapp` | Run the guided WhatsApp opt-in: report the optional `whatsapp` extra and the pairing state, then enable the channel (opt-in) |
-| `kirocrew doctor` | Verify kiro-cli is installed and config is valid |
+| `kirocrew doctor` | Verify kiro-cli is installed and config is valid. MCP counts are host-probe results, not confirmation of session tool loading; strict-identity routing is reported as configuration, not a verified live channel. |
 | `kirocrew cron add/list/remove` | Manage cron jobs |
 | `kirocrew spawn run/list` | Manage background subagents |
 | `kirocrew app install/list/enable/disable/uninstall` | Manage App Kit apps. Uninstall preserves `apps/<name>/data/` by default. |
@@ -191,8 +191,8 @@ choice blob makes the usage line unreadable.
 | `kirocrew service install` | Install gateway as a system-level systemd service (Linux, requires sudo for `tee` + `systemctl` only) or launchd LaunchAgent (macOS, no sudo). Auto-restarts on crash, auto-starts on boot. |
 | `kirocrew service uninstall` | Stop and remove the systemd unit / launchd plist. |
 | `kirocrew service status` | Show service status (`systemctl status` or `launchctl list`). No sudo required. |
-| `kirocrew logs` | Tail gateway logs from the systemd journal, launchd stdout file, or `~/.kiro/crew/gateway.log`. |
-| `kirocrew logs -f` | Follow logs live (long-running tail). |
+| `kirocrew logs` | Tail gateway logs from the systemd journal, launchd stdout file, or `~/.kiro/crew/gateway.log`. Hosts without systemd/launchd, including Windows, read the UTF-8 fallback file in Python without requiring `tail`. Read failures exit with file-access/retry guidance instead of an exception traceback. |
+| `kirocrew logs -f` | Follow logs live. The Python fallback reopens the log by name on each poll, permits Windows rename-based rotation even during reads, streams appended UTF-8 text, and stops on Ctrl+C. A replacement file or detected truncation resets the read offset; a temporary missing path during rotation is retried on the next poll. Rotated backup files are not replayed. |
 | `kirocrew cloud launch/list/status/connect/stop/start/destroy/iam-policy/doctor` | Provision, connect to, and manage a KiroCrew EC2 instance in the user's AWS account. |
 | `kirocrew security events` | Show recent SEL audit events (`-n N` for count) |
 | `kirocrew security verify` | Verify SEL HMAC chain integrity |

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -798,6 +798,8 @@ def _doctor_mcp_tools(
     if not probe_targets:
         return
 
+    print("  MCP host probe — session tool loading is not verified by this check.")
+
     # Every probe below spawns its server through the sandbox chokepoint, and
     # asyncio.gather releases them together. On a cold cache the first arrivals
     # therefore land on the on-loop deferral path simultaneously and each logs a
@@ -1538,7 +1540,7 @@ def _doctor_mcp_gateway_daemon(issues: list[str]) -> None:
 
 
 def _doctor_strict_identity(cfg: KiroCrewConfig) -> None:
-    """Report whether strict-identity tools have a working identity channel.
+    """Report configured routing, not proof of a live session's identity channel.
 
     On the kiro backend a session's process is an ``AcpRuntime``, which is
     session-UNBOUND by design (one process multiplexes N sessions, so it cannot
@@ -1568,7 +1570,12 @@ def _doctor_strict_identity(cfg: KiroCrewConfig) -> None:
         routed = set()
     unrouted = [s for s in _STRICT_IDENTITY_SERVERS if s not in routed]
     if not unrouted:
-        print("  strict identity: ✅ routed — the gateway injects a per-call caller")
+        print("  strict identity: ⏹ routing configured — live session identity not verified")
+        _print_wrapped(
+            "This checks mcp_gateway.stub_servers, not the running session's "
+            "launch command or per-call caller injection. Confirm a strict-identity "
+            "tool succeeds in the affected dashboard session."
+        )
         return
     names = ", ".join(unrouted)
     print(f"  strict identity: ⏹ no identity channel for {names}")

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import codecs
 import http.client
+import io
 import json
 import logging
 import os
@@ -15,6 +17,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections import deque
 from pathlib import Path
 from typing import NoReturn
 
@@ -2483,8 +2486,60 @@ def _logs_cmd(args: argparse.Namespace) -> None:
             file=sys.stderr,
         )
         sys.exit(1)
+    if plat == Platform.UNSUPPORTED:
+        try:
+            _tail_log_file(fallback, lines, follow)
+        except OSError as exc:
+            print(
+                f"Unable to read gateway log: {exc}. "
+                "Check file access or retry `kirocrew logs` if the log is rotating.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return
     cmd = ["tail", "-n", str(lines)]
     if follow:
         cmd.append("-f")
     cmd.append(str(fallback))
     os.execvp("tail", cmd)
+
+
+def _tail_log_file(path: Path, lines: int, follow: bool) -> None:
+    """Follow the log by name, allowing the writer to rotate it during reads."""
+    identity: tuple[int, int] | None = None
+    offset = 0
+    first = True
+    decoder = io.IncrementalNewlineDecoder(
+        codecs.getincrementaldecoder("utf-8")(errors="replace"), translate=True
+    )
+    try:
+        while True:
+            try:
+                fd = platform_compat.open_log_file_for_tail(path)
+            except FileNotFoundError:
+                if not follow:
+                    raise
+            else:
+                with os.fdopen(fd, "rb") as log:
+                    info = os.fstat(log.fileno())
+                    current_identity = (info.st_dev, info.st_ino)
+                    if current_identity != identity or info.st_size < offset:
+                        offset = 0
+                        decoder.reset()
+                    if first:
+                        data = b"".join(deque(log, maxlen=abs(lines)))
+                        first = False
+                    else:
+                        log.seek(offset)
+                        data = log.read()
+                    offset = log.tell()
+                    identity = current_identity
+                # Close before output or sleep can block. Rotation after open
+                # is picked up by name on the next poll, without a retry loop.
+                sys.stdout.write(decoder.decode(data, final=not follow))
+                sys.stdout.flush()
+            if not follow:
+                return
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        return

--- a/src/kiro_crew/mcp_gateway/hashing.py
+++ b/src/kiro_crew/mcp_gateway/hashing.py
@@ -1,6 +1,6 @@
-"""Stable command-args and effective-env hashing shared across the MCP gateway.
+"""Stable argv encoding and command/env hashing shared across the MCP gateway.
 
-Kept in its own dependency-free leaf module (only ``hashlib``) so every caller
+Kept in its own dependency-free leaf module (standard library only) so every caller
 imports it at module top level. The lightweight ``rewriter`` sits on
 ``config.loader``'s import path, while ``pool`` and ``stub`` are asyncio/socket
 -heavy submodules that must stay unloaded until the gateway is actually enabled
@@ -11,8 +11,33 @@ those heavy submodules into CLI/test/MCP startup.
 
 from __future__ import annotations
 
+import base64
 import hashlib
+import json
 from typing import Collection, Mapping
+
+
+def encode_target_args(args: list[str]) -> str:
+    """Carry argv boundaries in JSON, with a shell-inert base64url alphabet.
+
+    Arguments may contain delimiters or be empty. Encoding also keeps their
+    metacharacters out of cmd.exe's parse when a CLI launches the stub through
+    a shell. This is serialization, not encryption; arguments remain visible.
+    """
+    payload = json.dumps(args, ensure_ascii=False, separators=(",", ":"))
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii")
+
+
+def decode_target_args(raw: str) -> list[str]:
+    """Reject malformed payloads without echoing potentially sensitive arguments."""
+    try:
+        payload = base64.b64decode(raw.encode("ascii"), altchars=b"-_", validate=True)
+        decoded = json.loads(payload.decode("utf-8"))
+    except ValueError:
+        raise ValueError("malformed target-args payload") from None
+    if not isinstance(decoded, list) or not all(isinstance(a, str) for a in decoded):
+        raise ValueError("target-args payload is not a JSON array of strings")
+    return decoded
 
 
 def hash_command(command: str, args: list[str]) -> str:

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -29,6 +29,7 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import threading
@@ -41,12 +42,21 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.env import mcp_search_path, spec_path_key
 from kiro_crew.mcp_gateway import STUB_MODULE
-from kiro_crew.mcp_gateway.hashing import hash_command, is_secret_env_key
+from kiro_crew.mcp_gateway.hashing import (
+    decode_target_args,
+    encode_target_args,
+    hash_command,
+    is_secret_env_key,
+)
 from kiro_crew.mcp_gateway.manager import is_credential_env_key
 from kiro_crew.mcp_utils import mcp_server_alias
 from kiro_crew.sandbox import scrub_agent_denied_env
 
 logger = logging.getLogger(__name__)
+
+# cmd.exe's ceiling is smaller than CreateProcessW's; warn without rejecting
+# launchers that do not pass through cmd.exe.
+_WINDOWS_CMD_LINE_LIMIT = 8191
 
 # Normalized ``KIROCREW_MCP_TARGET_<SERVER>`` keys already warned about as a
 # base-name collision, so the notice fires once per distinct colliding key per
@@ -92,7 +102,7 @@ _FINGERPRINT_NAME = ".rewrite-fingerprint"
 # relock — so an older fingerprint still validates correctly, and bumping would
 # gratuitously defeat the transient-keep gate (which compares stored vs current
 # inputs) on the first upgraded boot.
-_FINGERPRINT_SCHEMA = 3
+_FINGERPRINT_SCHEMA = 4
 
 
 @dataclass
@@ -154,11 +164,10 @@ _WRAPPER_MARKER = "_kirocrew_mcp_gateway_wrapped"
 _WRAPPER_MARKER_LEGACY = "_mc_mcp_gateway_wrapped"
 
 
-# Argument separator for the stub's ``--target-args`` flag. `|` is
-# printable, preserved through argv, and not legal in a kiro MCP command
-# path. If a real MCP arg contains `|`, override via stub's
-# ``--target-args-sep`` flag (not used here; not a problem in practice).
+# Read compatibility for overlays carrying delimiter-separated arguments.
 _TARGET_ARGS_SEP = "|"
+_TARGET_ARGS_FLAG = "--target-args-b64"
+_TARGET_ARGS_FLAG_LEGACY = "--target-args"
 
 #: The stub is launched as a module by the interpreter running KiroCrew.
 #: ``sys.executable`` is baked into the overlay rather than resolved at
@@ -414,9 +423,8 @@ def _build_stub_entry(
         "--server", server_name,
         "--agent", agent_name,
         "--target-command", target_command,
-        # Use ``=`` so argparse treats the `|`-joined value as the flag's
-        # value even when it contains `--` (e.g. `--skill-paths|...`).
-        f"--target-args={_TARGET_ARGS_SEP.join(target_args)}",
+        # Keep both argument boundaries and shell metacharacters inside the payload.
+        f"{_TARGET_ARGS_FLAG}={encode_target_args(target_args)}",
         "--sandbox-mode", sandbox_mode,
         "--work-dir", str(work_dir),
         "--approval-mode", approval_mode,
@@ -434,7 +442,8 @@ def _build_stub_entry(
     # rewrite fingerprint's skip path effective.
     entry_identity_keys = sorted(k for k in frozenset(identity_keys) if k in env_pairs)
     if entry_identity_keys:
-        stub_args.extend(["--pool-identity-env", _TARGET_ARGS_SEP.join(entry_identity_keys)])
+        # A names-only list still needs encoding: its delimiter can be a pipe.
+        stub_args.extend(["--pool-identity-env-b64", encode_target_args(entry_identity_keys)])
     if env_pairs:
         # JSON-encode env so values containing ',' or '=' round-trip
         # intact. A prior CSV serialisation ``K=V,K2=V2`` silently
@@ -561,6 +570,15 @@ def _build_stub_entry(
         # not via kiro-cli's subprocess environment.
         "env": {},
     })
+    if platform_compat.IS_WINDOWS:
+        command_line = subprocess.list2cmdline([wrapped["command"], *wrapped["args"]])
+        command_units = len(command_line.encode("utf-16-le")) // 2
+        if command_units >= _WINDOWS_CMD_LINE_LIMIT:
+            logger.warning(
+                "rewriter: server %r generated command is %d UTF-16 units; "
+                "cmd.exe limit is %d. Shorten server arguments if initialization fails.",
+                server_name, command_units, _WINDOWS_CMD_LINE_LIMIT,
+            )
     return wrapped
 
 
@@ -2068,30 +2086,41 @@ def _collect_target_env(
         env_key = "KIROCREW_MCP_TARGET_" + server_name.replace("-", "_").upper()
         args = entry.get("args", []) or []
         target_cmd: str | None = None
-        target_args_str = ""
+        target_args_b64: str | None = None
+        target_args_legacy = ""
+        target_args_sep = _TARGET_ARGS_SEP
         i = 0
         while i < len(args):
-            a = args[i]
-            if a == "--target-command" and i + 1 < len(args):
-                target_cmd = str(args[i + 1])
-                i += 2
-                continue
-            if isinstance(a, str) and a.startswith("--target-args="):
-                target_args_str = a.split("=", 1)[1]
+            token = str(args[i])
+            flag, equals, value = token.partition("=")
+            if flag in {
+                "--target-command", _TARGET_ARGS_FLAG,
+                _TARGET_ARGS_FLAG_LEGACY, "--target-args-sep",
+            }:
+                if not equals:
+                    if i + 1 >= len(args):
+                        break
+                    i += 1
+                    value = str(args[i])
+                if flag == "--target-command":
+                    target_cmd = value
+                elif flag == _TARGET_ARGS_FLAG:
+                    target_args_b64 = value
+                elif flag == _TARGET_ARGS_FLAG_LEGACY:
+                    target_args_legacy = value
+                else:
+                    target_args_sep = value
             i += 1
         if target_cmd:
-            # Target args arrive separated by ``_TARGET_ARGS_SEP`` (the same
-            # constant _build_stub_entry joins them with). Split on it rather
-            # than a hardcoded literal so this reconstruction — which feeds
-            # hash_command — stays in lock-step with the stub's PoolKey hash if
-            # the separator ever changes. Quote each one (incl. the command)
-            # before space-joining so env_target_resolver's shlex.split
-            # round-trips args containing embedded spaces. The old
-            # ``replace("|"," ")`` split such an arg into multiple tokens,
-            # corrupting the backend command line.
-            raw_target_args = (
-                target_args_str.split(_TARGET_ARGS_SEP) if target_args_str else []
-            )
+            # Same precedence and decode as the stub: both sides must hash
+            # identical argv for daemon target lookup to find the backend.
+            if target_args_b64 is not None:
+                raw_target_args = decode_target_args(target_args_b64)
+            else:
+                raw_target_args = (
+                    target_args_legacy.split(target_args_sep) if target_args_legacy else []
+                )
+            # This is a matched quote/split codec, never a shell command.
             spec = " ".join(shlex.quote(p) for p in [target_cmd, *raw_target_args])
             # Bare server-name key: first-wins fallback. Two DISTINCT server
             # names can normalize to the same key ("my-server" vs "my_server",

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -41,7 +41,7 @@ from kiro_crew.executors import configure_default_executor, subprocess_executor
 from kiro_crew.jsonl_util import bounded_records, rotate_jsonl_at
 from kiro_crew.mcp_caller import CallerContext, _parent_pid
 from kiro_crew.mcp_gateway import transport
-from kiro_crew.mcp_gateway.hashing import hash_command, hash_effective_env
+from kiro_crew.mcp_gateway.hashing import decode_target_args, hash_command, hash_effective_env
 from kiro_crew.mcp_gateway.pool import READ_BUFFER_LIMIT_BYTES, PoolKey
 from kiro_crew.metrics.events import MCP_RECONNECTS, emit_counter
 
@@ -165,7 +165,12 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     p.add_argument("--server", required=True)
     p.add_argument("--agent", required=True)
     p.add_argument("--target-command", required=True, dest="target_command")
-    p.add_argument("--target-args", default="", dest="target_args")
+    p.add_argument(
+        "--target-args-b64",
+        default=None,
+        help="Base64url-encoded JSON argv; takes precedence over --target-args.",
+    )
+    p.add_argument("--target-args", default="", help="Legacy delimiter-separated argv.")
     p.add_argument("--target-args-sep", default="|", dest="target_args_sep")
     p.add_argument("--sandbox-mode", default="standard", dest="sandbox_mode")
     p.add_argument("--work-dir", required=True, dest="work_dir")
@@ -202,18 +207,23 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     )
     p.add_argument("--channel-id", default=None, dest="channel_id")
     p.add_argument(
+        "--pool-identity-env-b64",
+        default=None,
+        help="Base64url-encoded JSON env names; takes precedence over --pool-identity-env.",
+    )
+    p.add_argument(
         "--pool-identity-env",
         default="",
         dest="pool_identity_env",
         help=(
-            "Env variable NAMES (separated by --target-args-sep) whose value the "
-            "operator declared part of backend identity via "
-            "mcp_gateway.pool_identity_env. Folded into effective_env_hash even "
-            "when the name looks like a rotating secret. Names only, never "
-            "values, so this is safe on argv. Carries NO authority: gatewayd "
-            "re-reads the operator's own list at spawn and refuses to forward "
-            "when the hash it recomputes does not match the one registered here, "
-            "so a stub cannot widen what gets applied to a shared backend."
+            "DEPRECATED: env variable NAMES separated by --target-args-sep. "
+            "Read only when --pool-identity-env-b64 is absent. Folded into "
+            "effective_env_hash even when the name looks like a rotating "
+            "secret. Names only, never values, so this is safe on argv. "
+            "Carries NO authority: gatewayd re-reads the operator's own list "
+            "at spawn and refuses to forward when the hash it recomputes does "
+            "not match the one registered here, so a stub cannot widen what "
+            "gets applied to a shared backend."
         ),
     )
     p.add_argument(
@@ -225,7 +235,27 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
 
 
 def _split_target_args(raw: str, sep: str) -> list[str]:
+    """Read delimiter-separated arguments from legacy overlays."""
     return raw.split(sep) if raw else []
+
+
+def _resolve_target_args(args: argparse.Namespace) -> list[str]:
+    """Share one decode between backend launch and the registered command hash."""
+    encoded = getattr(args, "target_args_b64", None)
+    if encoded is not None:
+        return decode_target_args(encoded)
+    return _split_target_args(args.target_args, args.target_args_sep)
+
+
+def _resolve_pool_identity_env(args: argparse.Namespace) -> frozenset[str]:
+    """Decode names only; the daemon independently checks forwarding authority."""
+    encoded = getattr(args, "pool_identity_env_b64", None)
+    names = (
+        decode_target_args(encoded)
+        if encoded is not None
+        else _split_target_args(args.pool_identity_env, args.target_args_sep)
+    )
+    return frozenset(n for n in names if n)
 
 
 def _parse_env_csv(raw: str) -> dict[str, str]:
@@ -445,7 +475,7 @@ def build_register_payload(args: argparse.Namespace) -> dict:
 
     The result is accepted verbatim by :meth:`PoolKey.from_register` —
     callers do not post-process."""
-    target_args = _split_target_args(args.target_args, args.target_args_sep)
+    target_args = _resolve_target_args(args)
     # Prefer --env-json when present (commas/equals round-trip intact);
     # fall back to the legacy --env CSV for overlay files written by a
     # pre-JSON rewriter that may still be on disk during the transition.
@@ -457,12 +487,7 @@ def build_register_payload(args: argparse.Namespace) -> dict:
         env_pairs = _parse_env_csv(args.env)
     auto_approve = _parse_auto_approve(args.auto_approve)
     channel_id = _resolve_channel_id(args.channel_id)
-    # Reuses the target-args separator rather than ',' so a name can never be
-    # split the way the legacy CSV env encoding split values. Empty -> the
-    # default set, which hashes exactly as it did before this flag existed.
-    identity_keys = frozenset(
-        n for n in args.pool_identity_env.split(args.target_args_sep) if n
-    )
+    identity_keys = _resolve_pool_identity_env(args)
 
     try:
         work_dir = str(Path(args.work_dir).resolve())
@@ -1712,7 +1737,7 @@ def fallback_exec(args: argparse.Namespace) -> None:
     diagnostic. Windows has no in-place exec, so there the backend runs as a
     child inheriting this process's stdio -- see :func:`_fallback_spawn_child`
     for why the emulated ``exec*`` would kill the session outright."""
-    target_args = _split_target_args(args.target_args, args.target_args_sep)
+    target_args = _resolve_target_args(args)
     argv = [args.target_command, *target_args]
     # Restore the server's declared env. The rewriter moves declared env
     # (which routinely holds tokens / API keys) into a 0600 sidecar the stub

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -4344,6 +4344,53 @@ def open_file_no_reparse(path: str | os.PathLike, *, nonblocking: bool = False) 
     return fd
 
 
+_WIN_FILE_SHARE_READ_WRITE_DELETE = 0x00000001 | 0x00000002 | 0x00000004
+
+
+def open_log_file_for_tail(path: str | os.PathLike) -> int:
+    """Open a binary read fd without blocking the log writer's rename/rotation.
+
+    Windows CRT opens omit FILE_SHARE_DELETE. This separate log-only helper
+    permits rotation even during a read; security pinning helpers must not.
+    The caller owns the returned descriptor and must close it.
+    """
+    if IS_POSIX:
+        return os.open(os.fspath(path), os.O_RDONLY)
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    handle = kernel32.CreateFileW(
+        os.fspath(path),
+        _WIN_GENERIC_READ,
+        _WIN_FILE_SHARE_READ_WRITE_DELETE,
+        None,
+        _WIN_OPEN_EXISTING,
+        0,
+        None,
+    )
+    if handle is None or handle == wintypes.HANDLE(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())  # type: ignore[attr-defined]
+    try:
+        return msvcrt.open_osfhandle(  # type: ignore[attr-defined]
+            handle, os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        )
+    except BaseException:
+        # Ownership transfers only when the CRT descriptor is created.
+        kernel32.CloseHandle(handle)
+        raise
+
+
 # Well-known SID for the file's *owner* (implicit). Under a self-relative DACL
 # with inheritance stripped, S-1-3-4 grants access to whoever currently owns
 # the file. See:

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -761,15 +761,14 @@ class TestLogsCmdOtherSources:
         assert sel_rec.operations == ["logs"]
 
     def test_zero_lines_argument_falls_back_to_the_default(
-        self, monkeypatch, tmp_path, sel_rec, fake_execvp
+        self, monkeypatch, tmp_path, sel_rec, capsys
     ) -> None:
-        """``lines=0`` is falsy, so the product substitutes 100 rather than tailing nothing."""
+        """``lines=0`` selects the default tail length on an unsupported service host."""
         monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.UNSUPPORTED)
         monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
         (tmp_path / "gateway.log").write_text("x\n", encoding="utf-8", newline="\n")
-        with pytest.raises(_ExecCalled) as exc:
-            cli_server._logs_cmd(argparse.Namespace(follow=False, lines=0))
-        assert exc.value.argv[:3] == ["tail", "-n", "100"]
+        cli_server._logs_cmd(argparse.Namespace(follow=False, lines=0))
+        assert capsys.readouterr().out == "x\n"
 
 
 # --------------------------------------------------------------------------

--- a/test/test_mcp_gateway_target_args_codec.py
+++ b/test/test_mcp_gateway_target_args_codec.py
@@ -1,0 +1,287 @@
+"""Generated stub argv survives cmd.exe and preserves backend argument boundaries."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.mcp_gateway import hashing, rewriter, stub
+
+CASES = [
+    [],
+    [""],
+    ["-P", "-s"],
+    ["-P", "-s", "space value"],
+    ["value|with|pipes", ""],
+    ["~", "trailing\\", '"quoted"', "unicode-éß中"],
+    ["a&b", "c^d", "e%PATH%f", "g>h", "i<j", "k;l", "!bang!"],
+]
+
+
+def _entry(
+    tmp_path: Path,
+    args: list[str],
+    identity: bool = False,
+    auto_approve: list[str] | None = None,
+    target_command: str = sys.executable,
+) -> dict:
+    return rewriter._build_stub_entry(
+        stubs_dir=tmp_path / "stubs",
+        server_name="probe",
+        agent_name="probe-agent",
+        original={"command": target_command, "args": args, "autoApprove": auto_approve or []},
+        env_pairs={"ALPHA": "a", "BETA": "b"} if identity else {},
+        target_command=target_command,
+        socket_path=tmp_path / "absent.sock",
+        work_dir=tmp_path,
+        sandbox_mode="standard",
+        approval_mode="interactive",
+        identity_keys=("ALPHA", "BETA") if identity else (),
+    )
+
+
+def _parsed(entry: dict):
+    return stub._parse_args(entry["args"][2:])
+
+
+@pytest.mark.parametrize("args", CASES)
+def test_codec_roundtrip(args):
+    encoded = hashing.encode_target_args(args)
+    assert set(encoded) <= set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=")
+    assert hashing.decode_target_args(encoded) == args
+
+
+@pytest.mark.parametrize("payload", ["", "W10=!", "!!!!", "é", "e30=", "WzFd", "//8="])
+def test_bad_payload_rejected_without_echo(payload):
+    with pytest.raises(ValueError) as error:
+        hashing.decode_target_args(payload)
+    assert str(error.value) in {
+        "malformed target-args payload",
+        "target-args payload is not a JSON array of strings",
+    }
+
+
+@pytest.mark.parametrize("args", CASES)
+def test_emitted_stub_and_daemon_hash_same_argv(tmp_path, args):
+    entry = _entry(tmp_path, args)
+    parsed = _parsed(entry)
+    payload = stub.build_register_payload(parsed)
+    env: dict[str, str] = {}
+    rewriter._collect_target_env({"probe": entry}, env)
+    expected_hash = hashing.hash_command(sys.executable, args)
+    assert payload["command_args_hash"] == expected_hash
+    assert shlex.split(env["KIROCREW_MCP_TARGET_PROBE__" + expected_hash]) == [
+        sys.executable,
+        *args,
+    ]
+    assert stub._resolve_target_args(parsed) == args
+
+
+@pytest.mark.parametrize("sep", ["|", "~"])
+@pytest.mark.parametrize("equals", [True, False])
+def test_legacy_separator_and_flag_spelling(tmp_path, sep, equals):
+    entry = _entry(tmp_path, [])
+    entry["args"] = [
+        "-m",
+        rewriter._STUB_MODULE,
+        "--server",
+        "probe",
+        "--agent",
+        "probe-agent",
+        "--target-command",
+        sys.executable,
+        "--work-dir",
+        str(tmp_path),
+        "--target-args-sep",
+        sep,
+        "--pool-identity-env",
+        sep.join(["ALPHA", "BETA"]),
+    ]
+    argv = ["value", "with spaces", ""]
+    joined = sep.join(argv)
+    entry["args"].extend([f"--target-args={joined}"] if equals else ["--target-args", joined])
+    parsed = _parsed(entry)
+    assert stub._resolve_target_args(parsed) == argv
+    assert stub._resolve_pool_identity_env(parsed) == frozenset({"ALPHA", "BETA"})
+    env: dict[str, str] = {}
+    rewriter._collect_target_env({"probe": entry}, env)
+    assert shlex.split(env["KIROCREW_MCP_TARGET_PROBE"]) == [sys.executable, *argv]
+
+
+@pytest.mark.parametrize("equals", [True, False])
+def test_encoded_precedence_matches_daemon(tmp_path, equals):
+    entry = _entry(tmp_path, [])
+    entry["args"] = [a for a in entry["args"] if not a.startswith("--target-args-b64=")]
+    encoded = hashing.encode_target_args([""])
+    entry["args"].extend(
+        [f"--target-args-b64={encoded}"] if equals else ["--target-args-b64", encoded]
+    )
+    entry["args"].append("--target-args=must-not-be-used")
+    assert stub._resolve_target_args(_parsed(entry)) == [""]
+    env: dict[str, str] = {}
+    rewriter._collect_target_env({"probe": entry}, env)
+    assert shlex.split(env["KIROCREW_MCP_TARGET_PROBE"]) == [sys.executable, ""]
+
+
+def test_empty_encoded_flag_never_falls_back(tmp_path):
+    entry = _entry(tmp_path, [])
+    entry["args"] = [a for a in entry["args"] if not a.startswith("--target-args-b64=")]
+    entry["args"].extend(["--target-args-b64=", "--target-args=wrong"])
+    with pytest.raises(ValueError):
+        stub._resolve_target_args(_parsed(entry))
+    with pytest.raises(ValueError):
+        rewriter._collect_target_env({"probe": entry}, {})
+
+
+def test_pool_identity_names_and_hash(tmp_path):
+    entry = _entry(tmp_path, [], identity=True)
+    parsed = _parsed(entry)
+    assert stub._resolve_pool_identity_env(parsed) == frozenset({"ALPHA", "BETA"})
+    assert "|" not in entry["args"][entry["args"].index("--pool-identity-env-b64") + 1]
+    encoded = stub.build_register_payload(parsed)
+    parsed.pool_identity_env_b64 = None
+    parsed.pool_identity_env = "ALPHA|BETA"
+    assert (
+        stub.build_register_payload(parsed)["effective_env_hash"] == encoded["effective_env_hash"]
+    )
+
+
+def test_fallback_uses_decoded_argv(tmp_path, monkeypatch):
+    parsed = _parsed(_entry(tmp_path, ["value|pipe", ""]))
+    seen = []
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+    def child(argv, env):
+        seen.append(argv)
+        raise SystemExit(0)
+
+    monkeypatch.setattr(stub, "_fallback_spawn_child", child)
+    with pytest.raises(SystemExit):
+        stub.fallback_exec(parsed)
+    assert seen == [[sys.executable, "value|pipe", ""]]
+
+
+def _through_cmd(tmp_path: Path, entry: dict) -> dict:
+    # Resolve from the OS system-directory API, not a mutable SystemRoot env var.
+    cmd = platform_compat.trusted_system_bin("cmd")
+    assert cmd is not None, "native Windows regression requires the system cmd.exe"
+    receiver = tmp_path / "receiver.py"
+    receiver.write_text(
+        "import json\nfrom kiro_crew.mcp_gateway.stub import _parse_args, build_register_payload\n"
+        "ns = _parse_args()\n"
+        "print(json.dumps({'payload': build_register_payload(ns), 'args': vars(ns)}))\n",
+        encoding="utf-8",
+    )
+    inner = subprocess.list2cmdline([sys.executable, str(receiver), *entry["args"][2:]])
+    env = dict(
+        os.environ,
+        PYTHONPATH=str(Path(__file__).resolve().parents[1] / "src"),
+        PYTHONIOENCODING="utf-8",
+    )
+    completed = subprocess.run(
+        f'"{cmd}" /d /s /c "{inner}"',
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=10,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+@pytest.mark.skipif(not platform_compat.IS_WINDOWS, reason="requires native cmd.exe")
+@pytest.mark.parametrize("argv", [["-P", "-s"], ["value|with|pipes", ""], ["a&b", "e%PATH%f"]])
+def test_generated_argv_through_cmd(tmp_path, argv):
+    # Exercise the producer, not just the codec in isolation.
+    entry = _entry(tmp_path, argv, identity=True)
+    result = _through_cmd(tmp_path, entry)
+    assert result["payload"]["command_args_hash"] == hashing.hash_command(sys.executable, argv)
+
+
+@pytest.mark.skipif(not platform_compat.IS_WINDOWS, reason="requires native cmd.exe")
+@pytest.mark.parametrize("tools", [["read_file"], ["read_file", "write_file", "list,with,commas"]])
+def test_generated_auto_approve_through_cmd(tmp_path, tools):
+    entry = _entry(tmp_path, ["-P"], auto_approve=tools)
+    direct = stub.build_register_payload(_parsed(entry))
+    result = _through_cmd(tmp_path, entry)
+    assert result["args"] == vars(_parsed(entry))
+    for field in ("autoapprove_set_hash", "command_args_hash"):
+        assert result["payload"][field] == direct[field]
+    assert json.loads(result["args"]["auto_approve"]) == sorted(tools)
+
+
+@pytest.mark.skipif(not platform_compat.IS_WINDOWS, reason="requires native cmd.exe")
+def test_generated_paths_with_spaces_through_cmd(tmp_path):
+    work_dir = tmp_path / "directory with spaces"
+    work_dir.mkdir()
+    target = str(work_dir / "python with spaces.exe")
+    entry = _entry(work_dir, ["probe arg"], identity=True, target_command=target)
+    direct = _parsed(entry)
+    result = _through_cmd(work_dir, entry)
+    assert result["args"] == vars(direct)
+    expected = stub.build_register_payload(direct)
+    for field in ("work_dir", "effective_env_hash", "command_args_hash"):
+        assert result["payload"][field] == expected[field]
+    for field in ("target_command", "work_dir", "env_file", "socket"):
+        assert " " in getattr(direct, field)
+        assert result["args"][field] == getattr(direct, field)
+
+
+def test_rewrite_invalidates_legacy_fingerprint(tmp_path):
+    agents = tmp_path / "kiro" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "probe.json").write_text(
+        json.dumps(
+            {
+                "name": "probe",
+                "mcpServers": {"probe": {"command": sys.executable, "args": ["-P", "-s"]}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    kwargs = dict(
+        source_dir=agents,
+        overlay_dir=tmp_path / "overlay" / "agents",
+        socket_path=tmp_path / "socket",
+        work_dir=tmp_path / "work",
+        stub_servers=frozenset({"probe"}),
+    )
+    # A cache built with the delimiter-era schema must not pin that output.
+    with patch.object(rewriter, "_FINGERPRINT_SCHEMA", 3):
+        rewriter.rewrite_agents(**kwargs)
+    with patch.object(
+        rewriter, "_rewrite_single_spec", wraps=rewriter._rewrite_single_spec
+    ) as rewrite:
+        rewriter.rewrite_agents(**kwargs)
+    assert rewrite.called
+
+
+@pytest.mark.parametrize("windows", [False, True])
+def test_large_generated_command_warns_on_windows(tmp_path, monkeypatch, caplog, windows):
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+    # Private target content must never appear in the warning.
+    argument = "private-argument-" + "x" * 7000
+    entry = _entry(tmp_path, [argument])
+    assert stub._resolve_target_args(_parsed(entry)) == [argument]
+    warnings = [r.message for r in caplog.records if "cmd.exe" in r.message]
+    assert bool(warnings) == windows
+    if windows:
+        assert "probe" in warnings[0]
+        assert "8191" in warnings[0]
+        assert "private-argument" not in warnings[0]
+
+
+def test_short_generated_command_does_not_warn(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    _entry(tmp_path, ["-P", "-s"])
+    assert not [r for r in caplog.records if "cmd.exe" in r.message]

--- a/test/test_strict_identity_diagnostics.py
+++ b/test/test_strict_identity_diagnostics.py
@@ -139,11 +139,12 @@ class TestDoctorStrictIdentity:
     def _darwin(self, monkeypatch) -> None:
         monkeypatch.setattr(cli_doctor._plat, "system", lambda: "Darwin")
 
-    def test_all_routed_reads_healthy(self, monkeypatch, capsys) -> None:
+    def test_all_routed_reports_configuration_only(self, monkeypatch, capsys) -> None:
         self._darwin(monkeypatch)
         cli_doctor._doctor_strict_identity(self._Cfg(list(cli_doctor._STRICT_IDENTITY_SERVERS)))
         out = capsys.readouterr().out
-        assert "strict identity: ✅" in out and "per-call caller" in out
+        assert "routing configured" in out and "live session identity not verified" in out
+        assert "per-call caller" in out and "✅" not in out
 
     def test_unrouted_names_the_servers_and_the_affected_tools(self, monkeypatch, capsys) -> None:
         self._darwin(monkeypatch)

--- a/test/test_windows_logs_and_diagnostics.py
+++ b/test/test_windows_logs_and_diagnostics.py
@@ -1,0 +1,265 @@
+"""Windows log reads and config-only diagnostics must not promise runtime health."""
+
+import argparse
+import logging.handlers
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew import cli_doctor, cli_server, platform_compat
+from kiro_crew.service.common import Platform
+
+
+@pytest.fixture
+def windows_log(monkeypatch, tmp_path):
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.UNSUPPORTED)
+    monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        cli_server, "sel", lambda: SimpleNamespace(log_api_access=lambda **kw: None)
+    )
+
+    def forbidden(*args):
+        raise AssertionError("Windows logs must not exec tail")
+
+    monkeypatch.setattr(cli_server.os, "execvp", forbidden)
+    return tmp_path / "gateway.log"
+
+
+def test_windows_logs_read_utf8_tail_without_external_binary(windows_log, capsys):
+    windows_log.write_text("first\nsecond\n日本語 👻\nlast\n", encoding="utf-8")
+    cli_server._logs_cmd(argparse.Namespace(lines=2, follow=False))
+    assert capsys.readouterr().out == "日本語 👻\nlast\n"
+
+
+def test_windows_empty_log_succeeds(windows_log, capsys):
+    windows_log.write_text("", encoding="utf-8")
+    cli_server._logs_cmd(argparse.Namespace(lines=2, follow=False))
+    assert capsys.readouterr().out == ""
+
+
+def test_windows_follow_reads_appended_lines_and_stops(windows_log, monkeypatch, capsys):
+    windows_log.write_text("initial\n", encoding="utf-8")
+    waits = []
+
+    def tick(_seconds):
+        waits.append(1)
+        if len(waits) == 1:
+            with windows_log.open("a", encoding="utf-8") as log:
+                log.write("appended\n")
+        else:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_server.time, "sleep", tick)
+    cli_server._logs_cmd(argparse.Namespace(lines=1, follow=True))
+    assert capsys.readouterr().out == "initial\nappended\n"
+
+
+@pytest.mark.parametrize("system", ["Windows", "Darwin"])
+def test_doctor_routing_config_is_not_a_verified_session(system, monkeypatch, capsys):
+    monkeypatch.setattr(cli_doctor._plat, "system", lambda: system)
+    cfg = SimpleNamespace(
+        mcp_gateway=SimpleNamespace(stub_servers=cli_doctor._STRICT_IDENTITY_SERVERS)
+    )
+    cli_doctor._doctor_strict_identity(cfg)
+    output = capsys.readouterr().out
+    assert "configured" in output
+    assert "not verified" in output
+    assert "✅" not in output
+
+
+def test_doctor_mcp_success_names_its_probe_scope(tmp_path, monkeypatch, capsys):
+    import json
+
+    names = cli_doctor._MANAGED_MCPS
+    refs = ["@" + name for name in names]
+    spec = tmp_path / "agent.json"
+    spec.write_text(
+        json.dumps(
+            {
+                "mcpServers": {name: {"command": "probe"} for name in names},
+                "tools": refs,
+                "allowedTools": refs,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async def probe(info):
+        info.status = "ok"
+        info.tools = [{"name": "example"}]
+        return info
+
+    monkeypatch.setattr(cli_doctor, "probe_server", probe)
+    monkeypatch.setattr(cli_doctor, "warm_backend", lambda: None)
+    cli_doctor._doctor_mcp_tools(spec, [], gated_off=frozenset())
+    output = capsys.readouterr().out
+    assert "host probe" in output
+    assert "session tool loading is not verified" in output
+
+
+def test_windows_follow_handles_truncation(windows_log, monkeypatch, capsys):
+    windows_log.write_text("a longer initial line\n", encoding="utf-8")
+    waits = []
+
+    def tick(_seconds):
+        waits.append(1)
+        if len(waits) == 1:
+            windows_log.write_text("new\n", encoding="utf-8")
+        elif len(waits) == 3:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_server.time, "sleep", tick)
+    cli_server._logs_cmd(argparse.Namespace(lines=1, follow=True))
+    assert capsys.readouterr().out == "a longer initial line\nnew\n"
+
+
+@pytest.mark.parametrize("during_read", [False, True], ids=["between-polls", "reader-open"])
+def test_follow_allows_real_writer_rollover(windows_log, monkeypatch, capsys, during_read):
+    """Rotation must persist records even when it races an open read handle."""
+    handler = logging.handlers.RotatingFileHandler(
+        windows_log, maxBytes=32, backupCount=1, encoding="utf-8"
+    )
+    logger = logging.Logger("isolated-rotation-test", level=logging.INFO)
+    logger.addHandler(handler)
+    errors = []
+    monkeypatch.setattr(handler, "handleError", errors.append)
+    opens = []
+    real_open = platform_compat.open_log_file_for_tail
+
+    def rotate():
+        # The seed fills the file; these two short records fit in one new file.
+        logger.info("after-1")
+        logger.info("after-2")
+
+    def read_open(path):
+        fd = real_open(path)
+        opens.append(fd)
+        if during_read and len(opens) == 2:
+            rotate()
+        return fd
+
+    monkeypatch.setattr(platform_compat, "open_log_file_for_tail", read_open)
+    ticks = []
+
+    def tick(_seconds):
+        ticks.append(1)
+        if not during_read and len(ticks) == 1:
+            rotate()
+        if len(ticks) == 3:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_server.time, "sleep", tick)
+    try:
+        logger.info("x" * 30)
+        cli_server._tail_log_file(windows_log, 1, True)
+    finally:
+        handler.close()
+    assert not errors
+    assert windows_log.read_text(encoding="utf-8") == "after-1\nafter-2\n"
+    assert capsys.readouterr().out == "x" * 30 + "\nafter-1\nafter-2\n"
+
+
+@pytest.mark.parametrize("replacement", ["new\n", "a much longer replacement than the seed\n"])
+def test_follow_replacement_identity(windows_log, monkeypatch, capsys, replacement):
+    windows_log.write_text("seed\n", encoding="utf-8")
+    ticks = []
+
+    def tick(_seconds):
+        ticks.append(1)
+        if len(ticks) == 1:
+            windows_log.rename(windows_log.with_suffix(".log.1"))
+            windows_log.write_text(replacement, encoding="utf-8")
+        else:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_server.time, "sleep", tick)
+    cli_server._tail_log_file(windows_log, 1, True)
+    assert capsys.readouterr().out == "seed\n" + replacement
+
+
+def test_follow_missing_path_during_rotation(windows_log, monkeypatch, capsys):
+    windows_log.write_text("seed\n", encoding="utf-8")
+    ticks = []
+
+    def tick(_seconds):
+        ticks.append(1)
+        if len(ticks) == 1:
+            windows_log.rename(windows_log.with_suffix(".log.1"))
+        elif len(ticks) == 2:
+            windows_log.write_text("resumed\n", encoding="utf-8")
+        else:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_server.time, "sleep", tick)
+    cli_server._tail_log_file(windows_log, 1, True)
+    assert capsys.readouterr().out == "seed\nresumed\n"
+
+
+@pytest.mark.parametrize("parts", [(b"\xf0\x9f", b"\x91\xbb\n"), (b"line\r", b"\n")])
+def test_follow_split_utf8_and_crlf(windows_log, monkeypatch, capsys, parts):
+    windows_log.write_bytes(b"")
+    writes = iter(parts)
+
+    def tick(_seconds):
+        data = next(writes, None)
+        if data is None:
+            raise KeyboardInterrupt
+        with windows_log.open("ab") as log:
+            log.write(data)
+
+    monkeypatch.setattr(cli_server.time, "sleep", tick)
+    cli_server._tail_log_file(windows_log, 1, True)
+    assert capsys.readouterr().out == b"".join(parts).decode("utf-8").replace("\r\n", "\n")
+
+
+def test_nonfollow_flushes_incomplete_utf8(windows_log, capsys):
+    windows_log.write_bytes(b"line\n\xf0\x9f")
+    cli_server._tail_log_file(windows_log, 2, False)
+    assert capsys.readouterr().out == "line\n\ufffd"
+
+
+def test_no_data_polls_close_read_descriptors(windows_log, monkeypatch):
+    windows_log.write_bytes(b"")
+    real_open = platform_compat.open_log_file_for_tail
+    descriptors = []
+
+    def read_open(path):
+        fd = real_open(path)
+        descriptors.append(fd)
+        return fd
+
+    def tick(_seconds):
+        with pytest.raises(OSError):
+            os.fstat(descriptors[-1])
+        if len(descriptors) == 3:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(platform_compat, "open_log_file_for_tail", read_open)
+    monkeypatch.setattr(cli_server.time, "sleep", tick)
+    cli_server._tail_log_file(windows_log, 1, True)
+    assert len(descriptors) == 3
+
+
+def test_tail_zero_initial_lines(windows_log, capsys):
+    windows_log.write_text("a\nb\n", encoding="utf-8")
+    cli_server._tail_log_file(windows_log, 0, False)
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize("error", [FileNotFoundError("rotating"), PermissionError("unreadable")])
+def test_logs_read_failure_has_guidance(windows_log, monkeypatch, capsys, error):
+    windows_log.write_text("seed\n", encoding="utf-8")
+
+    def cannot_open(_path):
+        raise error
+
+    monkeypatch.setattr(platform_compat, "open_log_file_for_tail", cannot_open)
+    with pytest.raises(SystemExit) as result:
+        cli_server._logs_cmd(argparse.Namespace(lines=1, follow=False))
+    assert result.value.code == 1
+    output = capsys.readouterr()
+    assert "Unable to read gateway log" in output.err
+    assert "kirocrew logs" in output.err
+    assert "Traceback" not in output.err


### PR DESCRIPTION
## Problem / Motivation

Windows sessions can lose MCP servers before initialization. The stub joins target arguments with `|`; cmd.exe can interpret those pipes, and literal pipes inside arguments lose their boundaries. The source comment calls the separator override "not used here; not a problem in practice". Native Windows ACP tests contradict that assumption.

`kirocrew logs` calls `tail`, which Windows does not provide. A Python reader must permit log rotation: an ordinary open handle blocks Windows rename and the writer drops records. A log that disappears during rotation must produce useful guidance, not an uncaught traceback. Doctor's green output can be mistaken for proof of loaded session tools and a working identity channel.

## Why it matters

A running gateway does not guarantee working chat tools. Users need intact server arguments, usable logs and diagnostics that say what was actually checked.

## What changed (motivation → approach → change)

Target arguments and pool-identity names travel as base64url JSON lists. The stub and daemon decode identical values before hashing. Empty arguments, Unicode and literal delimiters keep their boundaries. Legacy flags remain readable; the overlay fingerprint changes so pipe-joined commands regenerate. Windows generation warns when the base stub command reaches cmd.exe's 8,191 UTF-16-unit limit. The warning names the server and length, never the argument payload; it does not reject launchers with a larger limit.

Hosts without systemd/launchd read the foreground log in Python. The reader follows by name, permits Windows rename even during a read, and closes descriptors before output or sleep. Standard incremental decoding handles split UTF-8/CRLF. Replacement, detected truncation and follow-mode rotation gaps are handled; unrecoverable read errors produce file-access/retry guidance with exit status 1. There is no hidden retry framework. Systemd/launchd paths and security-pinning helpers stay unchanged. Rotated backups are not replayed.

Doctor labels MCP counts as host-probe results and strict-identity routing as configuration. Neither claims live session verification. No permission, routing, sandbox or trusted-directory policy changes.

| Case | Before | After |
|---|---|---|
| Stub arguments without spaces | 🟥 Measured ACP initialization failure | 🟩 Exact backend arguments |
| Literal pipe or empty argument | 🟥 Argument boundaries lost | 🟩 Boundaries preserved |
| Windows foreground logs | 🟥 Missing `tail` traceback | 🟩 Python reader with useful read-error guidance |
| Read handle open during rollover | 🟥 Ordinary reader blocks Windows rename | 🟩 Writer can rotate and persist records |
| Oversized generated command | 🟥 No length warning | 🟨 Server-specific Windows warning |
| Doctor identity route | 🟥 Configuration presented as live success | 🟨 Check scope stated |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

## Tests

- Codec tests cover malformed payloads, legacy flags/separators, daemon/stub hash parity, fallback and fingerprint invalidation. Real cmd.exe tests use the producer and cover single/multiple autoApprove JSON and paths containing spaces. Length-warning tests cover Windows/non-Windows, short commands and payload non-disclosure.
- Failure-first proof: the base rewriter produces rc=255 and `'-s' is not recognized` in the native generated-argument test; the fixed producer passes.
- The real RotatingFileHandler regression fails against the old reader, sending both post-rollover records to handleError. The fixed reader passes rotation between polls and while the reader is open. Tests cover larger replacements, missing-path gaps, truncation, split UTF-8/CRLF, final incomplete bytes and idle-poll descriptor cleanup.
- Read-guidance tests for FileNotFoundError and PermissionError and the oversized-Windows warning test fail before their fixes and pass with them.
- Latest related run: **459 passed, 344 platform-conditional skips** across codec, log/diagnostic, platform compatibility and existing CLI coverage tests. The two new files contain 59 passing cases.
- Whole-tree isort/flake8, Linux-platform mypy (1,457 source files), all 33 deterministic Python profile-gate invocations, compile and wheel build pass. GPT and Opus local reviews report no findings on this complete revision.

Full CI for this revision passes: all Linux and Windows backend shards, macOS gateway tests, frontend tests, E2E, coverage, static/security checks and package builds. PR Readiness reports success. Full local backend runs stopped without results, including a worker termination; they are not counted as passes. GitHub API quota failures and one Windows shard's job-budget timeout were investigated and cleared through failed-only retries with unchanged code and test limits. No scanner suppressions or test-selection reductions were added.

## Manual verification

Native Windows Server 2025 build 26100, Python 3.12.10, official kiro-cli-chat 2.21.4. An isolated probe follows rewrite_agents -> pooled_session_servers -> real ACP initialize/session-new. Success requires exact backend arguments and observed tools/list. All five corrected cases pass; no-whitespace initialization and literal-pipe boundaries fail before the codec fix.

A real isolated Windows log-command child fails with FileNotFoundError on the base and prints Japanese/emoji lines with the fixed reader. Rollover tests use actual filesystem handles, not mocked rename success. No running installation or user configuration changes.

Measured generated command lengths: bundled core 494 -> 523 characters; an 80-tool filter fixture 1,964 -> 2,481. These examples fit cmd.exe's limit, not every possible user configuration. The generation warning covers an oversized base command; per-session additions may grow it further.

## Screenshots / video

N/A — no graphical UI changes; MCP transport and terminal output only.

## Related Issues

Fixes https://github.com/kirodotdev/KiroCrew/issues/10289
Fixes https://github.com/kirodotdev/KiroCrew/issues/10291
Fixes https://github.com/kirodotdev/KiroCrew/issues/10318
Fixes https://github.com/kirodotdev/KiroCrew/issues/10319

The full Windows queue is not claimed solved. [The upstream stub-exit fix](https://github.com/kirodotdev/KiroCrew/pull/9902) still needs internal subtree/release delivery. [The chat popover issue](https://github.com/kirodotdev/KiroCrew/issues/10320) is separate. [Permissions compatibility](https://github.com/kirodotdev/KiroCrew/issues/8776) remains open: official 2.10.0 rejects the field while measured 2.21.2/2.21.4 accept it; no guessed cutoff or KAS-policy removal is included. GPU/DisplayLink, internal mwinit/AIM integration, reported stop/status divergence and Japanese-installer failure are not claimed fixed. [Percent expansion in raw stub metadata](https://github.com/kirodotdev/KiroCrew/issues/10346) is independently reproduced and deferred: percent-bearing executable paths and autoApprove names can expand through cmd.exe. Encoded backend target arguments preserve their literal percent characters; this PR does not claim to fix every metadata flag.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Verify generated argv through the real Windows launcher and log readers against a concurrent rotating writer. Distinguish host/config evidence from live session evidence.

## Checklist

- [x] One commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality — focused tests and full applicable CI pass
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff
