### PR TITLE
refactor(dashboard): resolve the member thread's crew once

### DIFF
--- a/src/kiro_crew/dashboard/handlers/members.py
+++ b/src/kiro_crew/dashboard/handlers/members.py
@@ -330,15 +330,19 @@ async def api_member_thread(request: web.Request) -> web.Response:
     # The bound member wins as long as it still exists AND still derives this
     # slug — dm.json's `member` field is operator-editable state, so it is
     # honored only when the registry independently corroborates it (the name
-    # exists and folds to the slug being opened). Otherwise fall back to the
-    # first crew (config order) whose name derives this slug. This keeps a
-    # colliding slug's thread stably attributed to whoever bound it first.
+    # exists and folds to the slug being opened). This keeps a colliding
+    # slug's thread stably attributed to whoever bound it first. With no
+    # binding at all, the first crew in config order whose name derives this
+    # slug takes the thread. An uncorroborated binding resolves to that same
+    # crew here — but only far enough to look up its slot; the branches below
+    # refuse the open rather than rebinding the slug to it.
     slug_owners = _member_names_for_slug(cfg, slug)
-    member_name = (
-        binding["member"]
-        if binding is not None and binding.get("member") in slug_owners
-        else (slug_owners[0] if slug_owners else "")
-    )
+    if binding is not None and binding.get("member") in slug_owners:
+        member_name = binding["member"]
+    elif slug_owners:
+        member_name = slug_owners[0]
+    else:
+        member_name = ""
     slot_key, generation = "", ""
     if member_name:
         try:
@@ -350,19 +354,19 @@ async def api_member_thread(request: web.Request) -> web.Response:
 
             return _store_unavailable_response(cfg.agents[member_name].memory_store, exc)
     if binding is not None:
-        if binding.get("member") in slug_owners:
-            member_name = binding["member"]
-        else:
-            # The binding names a crew that no longer derives this slug
-            # (renamed, or deleted with a same-slug successor). Falling
-            # through to the successor here would hand it the SAME derived
-            # key — and with it the previous crew's entire transcript,
-            # rendered under the successor's name with the pin chip vouching
-            # for it. The live-slot mismatch check below cannot catch this
-            # (after a restart no live slot exists), so the refusal must
-            # key off the BINDING itself. Fail closed, leave dm.json
-            # untouched (re-entrant), and let the user resolve it in the
-            # crew manager.
+        if binding.get("member") not in slug_owners:
+            # The binding names a crew absent from the registry (renamed, or
+            # deleted). It still derives this slug — `read_dm_binding`
+            # refuses any binding that does not — so falling through to a
+            # same-slug successor here would hand it the SAME derived key,
+            # and with it the previous crew's entire transcript, rendered
+            # under the successor's name with the pin chip vouching for it.
+            # The live-slot mismatch check below cannot catch this (after a
+            # restart no live slot exists), so the refusal must key off the
+            # BINDING itself. Fail closed, leave dm.json untouched
+            # (re-entrant), and let the user resolve it in the crew manager.
+            # A binding whose slug has no owner left lands here too, and is
+            # refused the same way rather than reaching the 404 below.
             try:
                 _sel().log_api_access(
                     caller=request.remote or "",
@@ -382,7 +386,6 @@ async def api_member_thread(request: web.Request) -> web.Response:
                 status=409,
             )
     else:
-        member_name = slug_owners[0] if slug_owners else ""
         # No binding, but the canonical history key already holds a
         # transcript: rebinding here would hand whoever currently derives the
         # slug the PREVIOUS occupant's entire conversation (ChatPane hydrates

--- a/test/test_members_dm_thread.py
+++ b/test/test_members_dm_thread.py
@@ -423,6 +423,26 @@ class TestMemberRoutes:
         assert [r["name"] for r in bound_rows] == ["Review_Agent"]
 
     @pytest.mark.asyncio
+    async def test_colliding_slug_honors_a_binding_naming_the_later_crew(self, tmp_path):
+        """A corroborated binding OUTRANKS config order, it does not tie it.
+
+        Binding the second of two colliding names is the only case where the
+        bound member and the config-order fallback differ, so it is the only
+        case that can observe which of the two the handler picks. Every other
+        binding in this suite names the sole owner, where both answers agree.
+        """
+        state = _make_state(tmp_path)
+        write_dm_binding(
+            "review-agent", member="review-agent", slot_key=member_slot_key("review-agent")
+        )
+        with _patched_config(["Review_Agent", "review-agent"], default="Review_Agent"):
+            async with TestClient(TestServer(_make_members_app(state))) as client:
+                opened = await (await client.post("/api/members/review-agent/thread")).json()
+        # Config order answers Review_Agent; the binding answers review-agent.
+        assert opened["member"] == "review-agent"
+        assert read_dm_binding("review-agent")["member"] == "review-agent"
+
+    @pytest.mark.asyncio
     async def test_app_tokens_are_denied(self, tmp_path):
         state = _make_state(tmp_path)
 


### PR DESCRIPTION
## Problem / Motivation

`api_member_thread` picks the crew member twice. A three-way chained ternary picks
it, then the two binding branches below pick it again — same conditions, same
answers — before deciding whether to refuse the open. Reading the function means
comparing the two picks to work out which one wins.

Two comments over that code also say something the code does not do. One offers
the config-order fallback as the whole answer for a binding the registry cannot
corroborate; the branches below in fact refuse the open. The other says the
refusal fires when a binding "no longer derives this slug" — `read_dm_binding`
already makes that impossible, since it drops any binding whose member folds to a
different slug.

## Why it matters

This handler is a fail-closed gate. It refuses to open a member's DM thread when
the binding names a crew the registry does not have, and writes a SEL audit line
each time. Two copies of one choice are two places that have to stay in step. And
a comment describing a check the read layer already performs invites a maintainer
to delete that branch as redundant — the branch whose whole job is to stop a
renamed crew's transcript being handed to a same-slug successor.

## What changed (motivation → approach → change)

The crew is picked once. The chained ternary is an `if`/`elif`/`else`, and the two
re-assignments below it are gone.

Both were dead. The path reaching `member_name = binding["member"]` is exactly the
path the first pick had already taken, and the same holds for the `slug_owners[0]`
fallback in the no-binding branch. Nothing in between can change the answer:
`binding` is a fresh dict and `slug_owners` a fresh list, both held by this
function alone, and the only work between the two is a read-only slot lookup.

The two comments now say what runs — including that a binding whose slug has no
owner left is refused here rather than reaching the 404 below.

| case | Before | After |
|---|---|---|
| binding names a current owner | 🟦 that name (picked, then re-picked) | 🟦 that name (picked once) |
| binding names a non-owner | 🟦 409 `member_pin_mismatch` | 🟦 409 `member_pin_mismatch` |
| binding, slug has no owners left | 🟦 409 `member_pin_mismatch` | 🟦 409 `member_pin_mismatch` |
| no binding, owners exist, history on disk | 🟦 409 `member_binding_missing` | 🟦 409 `member_binding_missing` |
| no binding, owners exist, no history | 🟦 first owner, binds | 🟦 first owner, binds |
| no binding, no owners | 🟦 404 `member_not_found` | 🟦 404 `member_not_found` |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*Every case answers exactly what it answered before. Only the number of times the
answer gets computed changed.*

## Tests

One test added: `test_colliding_slug_honors_a_binding_naming_the_later_crew`. It
is the only case that can observe which crew the resolution picks. Two crew names
fold to one slug and `dm.json` names the second, so the bound member and the
config-order fallback finally differ. Every other binding in the suite names the
sole owner, where both answers agree — the neighbouring
`test_colliding_slug_stays_with_first_bound_member` included, which is why the
rule had no test that could fail. Forcing the first branch off makes the new test
fail with `assert 'Review_Agent' == 'review-agent'`.

Nothing else needed a test: the rest of the change is behavior-preserving, and the
existing suites already cover every row of the table above.
`test/test_members_dm_thread.py`, `test/test_member_memory_ownership.py`,
`test/test_member_memory_runtime.py`,
`test/test_workspace_member_thread_owner_gate.py` — 271 tests, green.

## Manual verification

N/A — unit coverage sufficient. The diff adds no branch and no new call, and the
four suites above exercise every refusal code and the happy bind.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — one Python handler and its test, no
rendered output and no file under `website/`.

## Related Issues

no linked issue: module-simplification sweep, tracked by the campaign rather than
an issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
