### PR TITLE
ci: move the frontend shards and coverage jobs to the CodeBuild runner (pilot wave 2)

### DIFF
--- a/.github/scripts/frontend-blob-normalize-paths.mjs
+++ b/.github/scripts/frontend-blob-normalize-paths.mjs
@@ -1,0 +1,94 @@
+// Rewrite the absolute workspace root inside each frontend shard blob to THIS
+// runner's workspace root, so `vitest --merge-reports --coverage` sees one
+// path per source file.
+//
+// Why: a blob stores every path absolute — the coverage map is keyed by
+// `/<workspace>/website/src/…`. GitHub-hosted runners all check out under the
+// same `/home/runner/work/<repo>/<repo>`, so four shards and the merge job
+// agree on the root by accident. The CodeBuild-hosted runner gives EVERY build
+// its own root (`/codebuild/output/src<random>/src/actions-runner/_work/…`),
+// so four shards produce four roots, none of them the merge job's. Vitest
+// then unions nothing: the text report lists each file four times (once per
+// shard, each with that shard's partial numbers), the cobertura/lcov output
+// points at four directories that do not exist here, and the merge step exits
+// non-zero without naming a failing test. Seen on the pilot's first two runs.
+//
+// What it does: for each `blob-*.json`, find the workspace root — the prefix
+// of any `"/…/website/"` path inside the blob — and replace every occurrence
+// with the root derived from the current working directory. Plain string
+// replacement on the raw file: the root appears only inside JSON string values
+// and contains no quote characters, and the blob is flatted-encoded, so
+// re-serializing through a parser is neither needed nor safe. A blob whose
+// root already matches is left untouched (hosted runners: no-op). A blob with
+// no recognizable root is left alone and reported.
+//
+// Usage (cwd must be website/):
+//   node ../.github/scripts/frontend-blob-normalize-paths.mjs [blob-dir]
+//
+// Exits 0 always: a blob this script cannot normalize still reaches the merge
+// step, whose own exit code stays the verdict.
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve, join, basename, dirname } from 'node:path';
+
+const WEBSITE_DIR = 'website';
+
+function main() {
+  const cwd = process.cwd();
+  if (basename(cwd) !== WEBSITE_DIR) {
+    console.log(`::warning::frontend-blob-normalize-paths: expected to run from ${WEBSITE_DIR}/, got ${cwd}. Skipping.`);
+    return;
+  }
+  const localRoot = dirname(cwd);
+  const blobDir = resolve(cwd, process.argv[2] ?? '.vitest-reports');
+
+  let entries;
+  try {
+    entries = readdirSync(blobDir).filter((f) => f.endsWith('.json'));
+  } catch {
+    console.log(`frontend-blob-normalize-paths: no blob directory at ${blobDir} — nothing to do.`);
+    return;
+  }
+  if (entries.length === 0) {
+    console.log(`frontend-blob-normalize-paths: no blob files under ${blobDir} — nothing to do.`);
+    return;
+  }
+
+  // A JSON string value that is an absolute path into the website tree:
+  // capture everything before "/website/". Quote-delimited on the left so the
+  // root cannot span into a preceding value.
+  const rootPattern = new RegExp(`"(/[^"\\\\]*?)/${WEBSITE_DIR}/`, 'g');
+
+  for (const name of entries) {
+    const file = join(blobDir, name);
+    const text = readFileSync(file, 'utf8');
+    const roots = new Set();
+    for (const match of text.matchAll(rootPattern)) roots.add(match[1]);
+
+    if (roots.size === 0) {
+      console.log(`frontend-blob-normalize-paths: ${name}: no /…/${WEBSITE_DIR}/ path found — left as is.`);
+      continue;
+    }
+    if (roots.size > 1) {
+      // One shard, one checkout: more than one root means the blob is not what
+      // this script understands. Do not guess.
+      console.log(`::warning::frontend-blob-normalize-paths: ${name}: ${roots.size} distinct roots (${[...roots].join(', ')}) — left as is.`);
+      continue;
+    }
+    const [blobRoot] = roots;
+    if (blobRoot === localRoot) {
+      console.log(`frontend-blob-normalize-paths: ${name}: root already ${localRoot} — no change.`);
+      continue;
+    }
+    // Replace every occurrence, quoted or not: stack traces and error
+    // messages inside the blob carry the same root mid-string, and the root
+    // is long and specific enough that a stray match is not a concern.
+    const parts = text.split(`${blobRoot}/`);
+    const count = parts.length - 1;
+    const rewritten = parts.join(`${localRoot}/`);
+    writeFileSync(file, rewritten);
+    console.log(`frontend-blob-normalize-paths: ${name}: ${blobRoot} -> ${localRoot} (${count} path(s)).`);
+  }
+}
+
+main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,15 @@ jobs:
       leaf_tests: ${{ steps.leaf.outputs.leaf_tests }}
       leaf_targets: ${{ steps.leaf.outputs.leaf_targets }}
       leaf_gates: ${{ steps.leaf.outputs.leaf_gates }}
+      # Where the routed Linux jobs run: the CodeBuild-hosted runner for this
+      # repository's own runs, `ubuntu-latest` for forks. Computed ONCE here
+      # (five jobs consume them) so a drifted copy cannot reroute one job. Every
+      # consumer reads it as `${{ needs.changes.outputs.linux_runner || 'ubuntu-latest' }}`:
+      # if this job fails or is cancelled the output is empty, and a job that
+      # runs anyway (`coverage-gate` fails closed with `if: always()`) must still
+      # get a runner rather than error out before its own checks execute.
+      linux_runner: ${{ steps.runner.outputs.linux_runner }}
+      linux_runner_large: ${{ steps.runner.outputs.linux_runner_large }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -201,6 +210,28 @@ jobs:
             printf '%s\n' "$gates"
             echo "GATE_EOF"
           } >> "$GITHUB_OUTPUT"
+
+      # CodeBuild-hosted runner pilot (docs/ci/ci-and-reviews.md). A run in any
+      # repository other than kirodotdev/KiroCrew (a fork's own CI), or a
+      # pull_request whose head repository is not this one, stays on
+      # ubuntu-latest; everything else gets the per-run CodeBuild label. The
+      # webhook on the AWS side independently allowlists the triggering actor,
+      # so this expression is the routing decision, not the trust boundary.
+      # `instance-size:large` is the documented CodeBuild label override
+      # (8 vCPU / 15 GB) for the memory-bound test shards.
+      - name: Pick the Linux runner label
+        id: runner
+        env:
+          IS_FORK: ${{ (github.repository != 'kirodotdev/KiroCrew' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)) }}
+          LABEL: codebuild-kirocrew-gha-linux-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          if [ "$IS_FORK" = "true" ]; then
+            echo "linux_runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
+            echo "linux_runner_large=ubuntu-latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "linux_runner=$LABEL" >> "$GITHUB_OUTPUT"
+            echo "linux_runner_large=$LABEL instance-size:large" >> "$GITHUB_OUTPUT"
+          fi
 
   # Build the Linux desktop packages and install them for real, but ONLY when the
   # diff could change what a package installs. The check is expensive (a PBS
@@ -489,6 +520,13 @@ jobs:
   backend-test:
     name: Backend Tests
     needs: [changes, await-fast-gate]
+    # NOT on the CodeBuild-hosted runner (yet). The pilot's first run routed
+    # these shards there and every shard failed 37-42 tests: the CodeBuild runner
+    # executes the job as root, and this suite asserts permission semantics
+    # (read-only refusals, root-owned checks, PermissionError) that root does not
+    # have; the standard:7.0 image also lacks the hosted toolchain (jq 1.7). They
+    # move once a non-root custom image exists -- see docs/ci/ci-and-reviews.md,
+    # "CodeBuild-hosted runner (pilot)".
     runs-on: ubuntu-latest
     # Full coverage shards need room for collection, tests and artifact upload.
     # The 120-second per-test timeout still bounds a stalled individual test.
@@ -1099,7 +1137,8 @@ jobs:
     if: >-
       needs.changes.outputs.only_frontend != 'true'
       && needs.changes.outputs.leaf_tests != 'true'
-    runs-on: ubuntu-latest
+    # CodeBuild-hosted runner (pilot); artifact-only job, default size. Rollback: `ubuntu-latest`.
+    runs-on: ${{ needs.changes.outputs.linux_runner || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1161,7 +1200,8 @@ jobs:
   # requires it is still satisfied.
   coverage-gate:
     name: Coverage Gate
-    runs-on: ubuntu-latest
+    # CodeBuild-hosted runner (pilot); artifact-only job, default size. Rollback: `ubuntu-latest`.
+    runs-on: ${{ needs.changes.outputs.linux_runner || 'ubuntu-latest' }}
     timeout-minutes: 10
     needs: [coverage-combine, frontend-test, frontend-coverage-merge, backend-test, changes]
     # Single source of truth for the floors -- referenced by the check steps,
@@ -1648,13 +1688,12 @@ jobs:
     # The templates it lints live under src/kiro_crew/deploy/, which the
     # paths-filter counts as backend, so a frontend-only diff cannot touch one.
     if: needs.changes.outputs.only_frontend != 'true'
-    # PILOT: this one job runs on a CodeBuild-hosted runner (project
-    # `kirocrew-gha-linux`, Ubuntu 22.04) instead of ubuntu-latest. Only runs
-    # inside kirodotdev/KiroCrew that are not fork PRs get the codebuild label;
-    # a fork's own CI and fork PRs stay on ubuntu-latest, because the runner
-    # never serves them. Rollback: `ubuntu-latest`. Policy, image caveat and
-    # exit condition: docs/ci/ci-and-reviews.md, "CodeBuild-hosted runner (pilot)".
-    runs-on: ${{ (github.repository != 'kirodotdev/KiroCrew' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)) && 'ubuntu-latest' || format('codebuild-kirocrew-gha-linux-{0}-{1}', github.run_id, github.run_attempt) }}
+    # PILOT (first wave): runs on a CodeBuild-hosted runner (project
+    # `kirocrew-gha-linux`, Ubuntu 22.04) instead of ubuntu-latest. The label is
+    # chosen once in `changes` (forks and fork PRs get ubuntu-latest, because the
+    # runner never serves them). Rollback: `ubuntu-latest`. Policy, image caveat
+    # and exit condition: docs/ci/ci-and-reviews.md, "CodeBuild-hosted runner (pilot)".
+    runs-on: ${{ needs.changes.outputs.linux_runner || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1724,7 +1763,11 @@ jobs:
   frontend-test:
     name: Frontend Tests
     needs: [changes, await-fast-gate]
-    runs-on: ubuntu-latest
+    # CodeBuild-hosted runner (pilot, second wave). `instance-size:large` for the
+    # vitest --coverage shards' memory; routing and rollback as for cfn-lint. See
+    # docs/ci/ci-and-reviews.md, "CodeBuild-hosted runner (pilot)".
+    # Rollback: `ubuntu-latest`.
+    runs-on: ${{ needs.changes.outputs.linux_runner_large || 'ubuntu-latest' }}
     # Per-shard budget. The whole suite was ~23 min on one runner; split four
     # ways each shard is well under this, and a hung shard fails fast.
     timeout-minutes: 25
@@ -1873,7 +1916,9 @@ jobs:
       ${{ !cancelled()
       && needs.frontend-test.result != 'skipped'
       && needs.changes.outputs.only_backend != 'true' }}
-    runs-on: ubuntu-latest
+    # CodeBuild-hosted runner (pilot), default size: a merge is one process
+    # re-reading four blobs, not a test run. Rollback: `ubuntu-latest`.
+    runs-on: ${{ needs.changes.outputs.linux_runner || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1896,6 +1941,19 @@ jobs:
           path: website/.vitest-reports
           pattern: frontend-blob-*
           merge-multiple: true
+
+      - name: Normalize blob paths to this runner's workspace
+        # A blob stores every path absolute, and vitest's coverage map is keyed
+        # by those paths. Hosted runners all check out under the same root, so
+        # the shards and this job agree by accident; the CodeBuild-hosted runner
+        # gives every build its own root (/codebuild/output/src<random>/...), so
+        # four shards arrive with four roots and the merge unions nothing: each
+        # file is reported four times with one shard's numbers and the step
+        # exits non-zero with no failing test (pilot runs 1 and 2, 2026-09-12).
+        # This rewrites each blob's root to this checkout's; a no-op when they
+        # already match, so hosted runs are unaffected.
+        working-directory: website
+        run: node "$GITHUB_WORKSPACE/.github/scripts/frontend-blob-normalize-paths.mjs" .vitest-reports
 
       - name: Merge reports and coverage
         id: merge

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -269,15 +269,15 @@ Every job here is blocking. Every job that costs real runner time also `needs:`
 | `changes` | "Detect changed surface". Resolves the path filters every other job reads, so a diff that cannot affect a surface does not pay for it |
 | `await-fast-gate` | Polls the `Fast Gate` run for this exact head commit and **fails closed** in all three ways it can go wrong: a run that never appears (180s budget), one that never completes (720s budget), and one that completes non-success. A barrier that passed when it could not read its subject would be worse than none, because the matrix would run anyway and the log would claim it was cleared to. One extra ~1-minute job buys the whole matrix the right to not start |
 | `backend-lint` | `isort --check-only`, `flake8`, `mypy` on Python 3.12, plus `scripts/check_black_formatting.py` — black enforced on every file outside `.github/black-baseline.txt`, which can only shrink — and `scripts/check_subprocess_encoding.py` (self-test first) — no text-mode subprocess call without an explicit `encoding=`, `**UTF8_TEXT`, or a `# subprocess-encoding: locale` marker, outside `.github/subprocess-encoding-baseline.txt`, which can only shrink — and `scripts/check_sync_io_in_async.py` (self-test first) — no blocking db / subprocess / http / `time.sleep` call inside an `async def` under `src/`, outside `.github/sync-io-in-async-baseline.txt`, which can only shrink. A stall past `dashboard.loop_stall_exit_after_secs` (25s) makes the watchdog kill the gateway and drop every in-flight turn (#3057, #1572); the escape is an offload (`await asyncio.to_thread(...)`, or a named lane from `src/kiro_crew/executors.py`) or a `# on-loop-io-ok: <why it cannot block>` marker whose reason is mandatory. All four baselined gates in this job read their diff scope from the one shared resolver in `scripts/ratchet_scope.py`, so they cannot disagree about which lines a change added; the env-base gates (`check_brand_name.py`, `check_harness_parity.py`, `check_focus_cue.py`) share the same diff parsing through its explicit-base entry points while keeping their `*_BASE_REF` base semantics |
-| `backend-test` | 4 pytest-split shards on Python 3.12, `-n auto` within each; 50-minute job budget includes coverage upload, with the 120-second per-test timeout retained |
+| `backend-test` | 4 pytest-split shards on Python 3.12, `-n auto` within each; 50-minute job budget includes coverage upload, with the 120-second per-test timeout retained. Stays on `ubuntu-latest`: the CodeBuild runner runs jobs as root and this suite asserts permission semantics root does not have (pilot, below) |
 | `backend-test-windows` | windows-latest, 4 shards, `--no-cov`, 180s per-test timeout. The backend supports Windows natively via `platform_compat`, and nothing else in CI holds that line |
 | `backend-test-macos` | macos-14, deliberately SCOPED (gateway, socketsec, platform-compat, pod and MCP-apps suites via a glob). A full macOS run needs its own exclusion burn-down first, and a job that is red on arrival trains people to ignore it |
 | `backend-test-sandbox` | The one job that clears the AppArmor userns restriction, so the tests guarded by `skipif(not userns_available())` EXECUTE instead of skipping. Runs all eleven sandbox-dependent suites. The shards collect the same files — nothing is deselected — but there the sandbox-guarded tests skip, so this is the only lane where those 85 assertions (the `~/.kiro/crew` keystone among them) actually execute |
-| `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces the project line-rate floors, plus a per-file floor with a shrink-only baseline (all floors live in the job's `env:` block) |
+| `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces the project line-rate floors, plus a per-file floor with a shrink-only baseline (all floors live in the job's `env:` block). **CodeBuild-hosted runner** (pilot, below) except for forks |
 | `frontend-lint` | `tsc -b`, `eslint` under a hard-zero warning ceiling, `jscpd`, and `npm run i18n:check` |
 | `electron-test` | The Electron shell's own node:test suite (`website/electron`) |
-| `frontend-test` | `vitest run --coverage` |
-| `frontend-coverage-merge` | Merges the frontend coverage shards so the gate reads one report |
+| `frontend-test` | `vitest run --coverage`. **CodeBuild-hosted runner, `instance-size:large`** (pilot, below) except for forks |
+| `frontend-coverage-merge` | Merges the frontend coverage shards so the gate reads one report. **CodeBuild-hosted runner** (pilot, below) except for forks |
 | `cfn-lint` | Lints the artifact-deploy templates with a pinned `cfn-lint`. **Runs on the CodeBuild-hosted runner** (pilot, below) except for fork PRs |
 | `linux-packaging` | "Linux Packaging (build + smoke-install)". Builds all three Linux desktop formats from one backend tree through `packaging/build-desktop.sh`, then installs them in their target distros with `scripts/smoke-linux-packages.sh`. Path-filtered on the packaging surface |
 | `lockfile-engines-floor` | "Lockfile Installs On Declared Node Floor". Runs a real `npm ci` in `website/` on the LOWEST Node version `engines.node` declares, so a lockfile that only resolves under the newer npm major cannot land. The version is a literal pinned to that floor by `test_the_engines_floor_job_pins_the_declared_floor` rather than a range, because resolving a range picks the newest match and makes the job vacuous |
@@ -297,8 +297,50 @@ Details worth knowing:
   org's Actions consumption, so the wait is a fair-use ceiling no workflow change
   can lift. The runner infrastructure (project, role, webhook filters) is
   modelled in the maintainers' internal `KiroCrewPublishCDK` package, not here.
-  Three things to know when touching it:
-  - **Forks never see it.** The `runs-on` value is an expression: a run in any
+  **Second wave:** `frontend-test` (4 shards), `frontend-coverage-merge`,
+  `coverage-combine` and `coverage-gate` are routed the same way. The frontend
+  shards add an `instance-size:large` label suffix (8 vCPU / 15 GB, the hosted
+  runner's memory class; the default CodeBuild size has 7 GB) because `vitest
+  --coverage` is memory-bound; the merge and the two Python coverage jobs use
+  the project default. One thing the runner changes for the merge: every
+  CodeBuild build has its own workspace root (`/codebuild/output/src<random>/…`),
+  and a vitest blob stores paths absolute, so the four shards' blobs arrive with
+  four different roots and `--merge-reports --coverage` unions nothing (each
+  file reported four times, non-zero exit, no failing test named — the pilot's
+  first two runs). `frontend-coverage-merge` therefore rewrites each blob's
+  root to its own checkout before merging
+  (`.github/scripts/frontend-blob-normalize-paths.mjs`); on hosted runners the
+  roots already match and the step is a no-op. The Python side has the same
+  seam — the `backend-test` shards (hosted) record coverage under
+  `/home/runner/work/…` and `coverage-combine` (CodeBuild) runs under another
+  root — closed at the source instead: `[coverage:run] relative_files = true`
+  in `setup.cfg`, so shard data files carry repo-relative paths and combine
+  wherever the repo is checked out. A third effect of that root: vitest matches
+  `coverage.include` against the absolute path with picomatch `contains`, so
+  `src/**` is satisfied by the `/src/actions-runner/` segment of every
+  CodeBuild checkout and non-`src/` files loaded by tests (integration mocks,
+  `scripts/`) gained coverage numbers of their own, which the per-file gate
+  failed. `website/vite.config.ts` now excludes every non-`src/` directory of
+  `website/` by name, anchored on `website/`, which is a no-op on hosted paths.
+  **`backend-test` stays on `ubuntu-latest`**, and not for lack
+  of trying: the first pilot run routed its four shards to CodeBuild large and
+  each failed 37–42 tests (25k passed), because the CodeBuild runner executes
+  the job as root — this suite asserts permission semantics (read-only
+  refusals, root-owned-ancestor checks, `PermissionError`) that root does not
+  have, and the code refuses to run providers as root by design — and because
+  the `standard:7.0` image ships jq 1.6 where the hosted image has 1.7. AWS
+  documents no non-root mode for the CodeBuild GitHub Actions runner, so those
+  shards move only once a custom image (non-root user, hosted-parity tools)
+  exists. Peak-hour measurement behind the move (2026-09-11, 38 runs):
+  backend shards queued p90 521 s / max 763 s, frontend shards p90 569 s / max
+  813 s, with 103 of these jobs running at once. Things to know when touching it:
+  - **Forks never see it.** The label is computed once, in the `changes` job
+    (outputs `linux_runner` and `linux_runner_large`), and the routed jobs read
+    it as `runs-on: ${{ needs.changes.outputs.linux_runner || 'ubuntu-latest' }}`,
+    so there is one copy of the decision rather than one per job, and a job
+    that runs after `changes` failed (`coverage-gate` fails closed with
+    `if: always()`) still gets a runner instead of erroring out before its own
+    checks execute: a run in any
     repository other than `kirodotdev/KiroCrew` (a fork's own CI on its `main`),
     or a `pull_request` whose head repository is not this one, gets
     `ubuntu-latest`; everything else gets the CodeBuild label. The webhook on the AWS side is
@@ -311,8 +353,10 @@ Details worth knowing:
     (Ubuntu 22.04). Anything a job assumed pre-installed must come from a
     `setup-*` action; `cfn-lint` already installs its own Python. Moving another
     job here means checking that first.
-  - **Rollback is one line:** set `runs-on` back to `ubuntu-latest`. A CodeBuild
-    project that receives webhooks for jobs it does not match starts nothing.
+  - **Rollback is one line:** in the `changes` job's `Pick the Linux runner
+    label` step, set both outputs to `ubuntu-latest` (or, for one job, replace
+    its `runs-on` reference with `ubuntu-latest`). A CodeBuild project that
+    receives webhooks for jobs it does not match starts nothing.
   - **A queued job is not bounded by `timeout-minutes`.** That budget starts when a
     runner picks the job up. A job whose log shows the `codebuild-…` label and no
     runner means the webhook did not start a build — the project name in the label
@@ -335,11 +379,18 @@ Details worth knowing:
     owner), and a check that the App installation is scoped to this repository
     alone (needs repository-settings access).
   - **Pilot exit condition.** The pilot ends on whichever comes first: **50
-    non-fork `CI` runs** on this job or **2026-10-10**. Expand to more Linux jobs
-    only if the median queue-to-start on CodeBuild is under 60 s and no run waited
-    longer than the hosted baseline's mean (155 s) for a runner; otherwise roll it
-    back. Either way the outcome is recorded here so this entry does not become a
-    permanent one-off.
+    non-fork `CI` runs** with the second wave in place or **2026-10-10**. The
+    second wave went in one day after the first, on the first wave's early data
+    (every `cfn-lint` build started 18–21 s after the job was queued) plus the
+    second wave's own first run (all ten jobs it routed, same 18–21 s); that is a
+    small sample, which is why the criterion below now covers the whole routed
+    set rather than gating a further expansion. Keep the routing only if the
+    median queue-to-start on CodeBuild stays under 60 s and no routed job waits
+    longer than the hosted baseline's mean (155 s) for a runner; otherwise roll
+    it back. The remaining `ubuntu-latest` jobs (`backend-test`, `changes`, the
+    lint jobs, `electron-test`, `bundle-size`, `linux-packaging`) stay where
+    they are until that window closes. Either way the outcome is recorded here so this entry
+    does not become a permanent one-off.
 
 - **The macOS peer-identity canary is asserted by name.** `pytest -q` does not name
   passing tests and a skip exits 0, so a canary that quietly stopped running (a

--- a/setup.cfg
+++ b/setup.cfg
@@ -353,6 +353,18 @@ looponfailroots = src test
 [coverage:run]
 branch = true
 parallel = true
+# Store measured paths relative to the working directory (the repo root, where
+# pytest runs) instead of absolute. The four backend shards and the Coverage
+# Combine job are separate runners with separate checkouts: GitHub-hosted
+# runners happen to share /home/runner/work/<repo>/<repo>, but the
+# CodeBuild-hosted runner (docs/ci/ci-and-reviews.md, "CodeBuild-hosted runner
+# (pilot)") gives every build its own root, and absolute shard paths recorded
+# under one root make `coverage xml` in the combine job abort with "No source
+# for code" under another. The [coverage:paths] aliases below are relative
+# patterns and cannot remap an absolute foreign root either. Relative data
+# files combine anywhere the repo is checked out; coverage.xml filenames were
+# already relative, so the gate's per-file baseline is unaffected.
+relative_files = true
 # Ephemeral pytest tmp fixtures fabricate checkout layouts at
 # <tmp>/<name>/src/kiro_crew/agent.py. No real file is ever written there, but
 # the phantom path lands in the coverage data and makes `coverage xml`/`coverage

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -750,6 +750,34 @@ export default defineConfig({
         'src/**/*.stories.{ts,tsx}',
         'src/**/*.d.ts',
         'src/vite-env.d.ts',
+        // Everything in website/ that is NOT src/, spelled out. Vitest matches
+        // `include` against the ABSOLUTE file path with picomatch
+        // `{ contains: true }`, so `src/**` is satisfied by any `src/` segment
+        // anywhere in the path -- and the CodeBuild-hosted CI runner checks out
+        // under `/codebuild/output/src<random>/src/actions-runner/...`. There,
+        // every loaded file under website/ (integration mocks, scripts/) matched
+        // `src/**` and landed in the merged report with its own coverage number,
+        // which the per-file gate then failed. GitHub-hosted runners have no
+        // such segment, which is why this never showed before. Anchoring on
+        // `website/` keeps these correct on every checkout path; they are
+        // no-ops where the include already did not match.
+        //
+        // Why a blocklist and not an anchored include (`**/website/src/**`):
+        // vitest reuses `include` as a filesystem glob RELATIVE to root to add
+        // never-imported source files at 0% (getUntestedFilesByRoot), and from
+        // website/ that anchored form matches nothing, so untested files would
+        // silently drop out of the report and the per-file gate. A new
+        // top-level website/ directory whose files tests import needs an entry
+        // here -- the symptom is a non-src path in the merged report on the
+        // CodeBuild runner only.
+        '**/website/integration/**',
+        '**/website/scripts/**',
+        '**/website/capture/**',
+        '**/website/playwright/**',
+        '**/website/electron/**',
+        '**/website/eslint-rules/**',
+        '**/website/docs/**',
+        '**/website/*.ts',
       ],
     },
   },


### PR DESCRIPTION
## Summary

Pilot wave 2: route `Frontend Tests (1-4)`, `Frontend Coverage Merge`, `Coverage Combine` and `Coverage Gate` onto the CodeBuild-hosted runner introduced by #10297 (`cfn-lint`). **`Backend Tests (3.12, 1-4)` stay on `ubuntu-latest`** — see the finding below. Windows and macOS shards, `E2E`, and everything else are unchanged. Single commit on top of the merged #10297.

> **Finding from the first run — the backend shards do not pass on this runner.** Revision 1 of this PR routed all four `Backend Tests (3.12)` shards to CodeBuild large; each finished with 37–42 failures (25k passed). Two causes, neither a code bug: (1) the CodeBuild runner executes the job as **root** (`pytest-of-root`), while `ubuntu-latest` runs as the non-root `runner` user — the codebase refuses root in 34 places ("provider execution is disabled for a root gateway") and ~226 test files assert chmod / read-only / `PermissionError` semantics that root ignores; (2) the `standard:7.0` image ships jq 1.6 (hosted: 1.7) and lacks a couple of binaries the suite shells out to (`rc=127`). AWS documents no non-root option for the CodeBuild GitHub Actions runner; fixing it means a custom image (non-root user + hosted-parity toolchain), which is beyond a `runs-on` flip. So this revision keeps `backend-test` on `ubuntu-latest` (with a comment saying why) and ships the set the first run proved green. The verification comment below has the per-job numbers.

## Why — measured

Peak hour, 2026-09-11 17:27–19:52 UTC, 38 completed `CI` runs (successful jobs only), versus a quiet-hour sample (28 runs, 06:51–07:50 UTC):

| job | peak queue p50 / p90 / max | quiet queue | execution p50 / max (hosted) |
|---|---|---|---|
| Backend Tests (3.12, 1-4) | 18 s / **521 s** / 763 s | 2 s | 37 min / 43 min |
| Frontend Tests (1-4) | 38 s / **569 s** / 813 s | 2 s | 7.7 min / 9.2 min |
| Coverage Combine / Gate / FE Merge | ~20 s / 200–750 s / 835 s | 2 s | 0.5–2 min |

Every `CI` run has exactly 12 of these jobs (8 of them now routed, counting `cfn-lint`). At the peak, **103 of them were running at the same time**.

## Concurrency ceiling

- CodeBuild account quota (us-east-1): **300** concurrent builds for Linux/Medium and **300** for Linux/Large, counted separately.
- Runner project `ConcurrentBuildLimit` raised from 20 to **250** before this PR (infrastructure package; confirmed live — see the verification comment).
- Worst case per run: 4 large builds (the frontend shards) + 3 medium aggregation jobs (`Frontend Coverage Merge`, `Coverage Combine`, `Coverage Gate`) + `cfn-lint` = 8 builds. 250 ÷ 8 ≈ **31 concurrent CI runs** before the CodeBuild queue engages (≈ 20 if the backend shards join later); the observed peak (103 jobs ≈ 9 runs' worth in flight) fits with >3× headroom. If the repo's peak grows past ~250 simultaneous jobs the project limit and quota both need raising — that is a known number now, not a surprise.

## Secrets

`ci.yml` references **no** `secrets.*`; these jobs use only the read-only `GITHUB_TOKEN` to move artifacts. Nothing sensitive enters the runner container. Verified by grep before routing.

## Compute size

| | hosted `ubuntu-latest` | CodeBuild default (`BUILD_GENERAL1_MEDIUM`) | `instance-size:large` |
|---|---|---|---|
| vCPU / RAM | 4 / 16 GB | 4 / 7 GB | 8 / 15 GB |

The frontend shards use `instance-size:large` (label suffix, the documented CodeBuild override) because of the suite's own configured ceilings, not hosted parity: `website/vite.config.ts` runs `maxWorkers: 3` forks each with `--max-old-space-size=3072`, so the configured worst case is 3 × 3 GB of heap plus the main process — above the 7 GB default, within the 15 GB large. Measured peak on the six heaviest files was 2.7 GB total, so the default would probably pass most runs; the failure mode when it does not is the opaque kernel-killed fork the config comment documents, on a required check. The premium is ≈ $0.08 per shard-run. `Frontend Coverage Merge` and the two Python aggregation jobs take the project default.

**Correction to an earlier revision of this PR:** the merge job's failure in the first run was *not* an OOM (revision 2 said it was and bumped the job to large — that was a misread of the reconcile step's generic warning). The real cause, confirmed on both runs: every CodeBuild build has its own workspace root (`/codebuild/output/src<random>/…`), a vitest blob stores paths absolute, and the coverage map is keyed by them — so four shards arrive with four roots, `--merge-reports --coverage` unions nothing, each file is reported four times with one shard's numbers, and the step exits non-zero without naming a failing test. Hosted runners share one root and never hit this. Fix in this revision: a `Normalize blob paths to this runner's workspace` step (`.github/scripts/frontend-blob-normalize-paths.mjs`) rewrites each blob's root to the merge job's checkout before merging — a no-op on hosted runners. The merge job is back on the default size. Image is `standard:7.0` (Ubuntu 22.04) — its bundled Python/Node are not the hosted versions, which is irrelevant here because every job already pins its toolchain through `actions/setup-python` / `actions/setup-node` (expect ~20–40 s extra per job on first tool download; no hosted toolcache). `actions/cache`, `setup-uv` and `setup-node` caches go through GitHub's cache service with host-independent keys, so hit rate carries over; first-run numbers are in the verification comment.

## What changed

- `.github/workflows/ci.yml` — the routing decision (forks → `ubuntu-latest`, everything else → the per-run CodeBuild label) is computed **once**, in the `changes` job (`Pick the Linux runner label` step, outputs `linux_runner` / `linux_runner_large`), and the five routed jobs (`cfn-lint` included) read it as `runs-on: ${{ needs.changes.outputs.linux_runner… || 'ubuntu-latest' }}`. Every routed job already `needs: changes`; the `|| 'ubuntu-latest'` fallback covers the case where `changes` failed or was cancelled and the output is empty — `coverage-gate` runs anyway (`if: always()`, fails closed) and must get a runner rather than error out before its own checks execute. One copy of the expression instead of six, so a drifted copy cannot reroute one job. `backend-test` keeps a literal `ubuntu-latest` with a comment on why. Comments say how to roll back.
- `.github/scripts/frontend-blob-normalize-paths.mjs` (new) + a step in `frontend-coverage-merge` — rewrites each shard blob's absolute workspace root to the merge job's own before `vitest --merge-reports`, because CodeBuild gives every build a different root (see Compute size). Plain string replacement on the flatted-encoded blob; leaves a blob alone if its root already matches or is unrecognizable; always exits 0 so the merge step's own verdict stands.
- `setup.cfg` — `[coverage:run] relative_files = true`. Same seam on the Python side (caught by the GPT lane on revision 4): the hosted `backend-test` shards record absolute coverage paths under `/home/runner/work/…`, `coverage-combine` now runs under a CodeBuild root, and the relative `[coverage:paths]` aliases cannot remap an absolute foreign root — `coverage xml` would abort with "No source for code" on every backend-touching PR. Relative data files combine wherever the repo is checked out; `coverage.xml` filenames were already relative, so the gate's per-file baseline is unaffected.
- `website/vite.config.ts` — coverage `exclude` gains every non-`src/` directory of `website/`, anchored on `website/`. Third consequence of the CodeBuild root (surfaced by the Coverage Gate on revision 6, after the merge itself was fixed): vitest matches `coverage.include` against the *absolute* path with picomatch `{ contains: true }`, so `src/**/*.{ts,tsx}` is satisfied by the `/src/actions-runner/` segment of every CodeBuild checkout, and the five non-`src/` files that tests load (`integration/mocks/server.ts`, `integration/__mocks__/…`, `scripts/settingsExtract.ts`) landed in the merged report with their own coverage — the per-file gate then failed two of them at 40.7 % and 79.6 %. Hosted paths have no such segment (1393 files measured there vs 1398 on CodeBuild). Verified against picomatch 4 locally for both roots; no-op on hosted.
- `docs/ci/ci-and-reviews.md` — table rows, a "Second wave" paragraph with the measurement, the per-build-root finding (both sides) and the backend finding, the single-source routing, and an exit-condition paragraph rewritten so it no longer reads as a gate this PR jumped: the criterion (median CodeBuild queue-to-start < 60 s, no routed job waiting longer than the hosted mean of 155 s) now covers the whole routed set over the same 50-run / 2026-10-10 window, and names the `ubuntu-latest` jobs that stay put until it closes.

## Trust model

Unchanged from #10297 — same project, same role, same webhook filters, same alert; see its "Trust model & mitigations" section. This PR adds no new identity or permission; it adds jobs that carry no secrets to a runner that already exists.

## How it was verified

This PR's own CI is the test: each routed job is picked up by a CodeBuild runner (`runner_name` = a CodeBuild build id, working dir `/codebuild/output/…`). Per-job before/after (queue, execution, cost) is in the verification comment below, including the first runs that surfaced the per-build-root merge failure and the backend root-runner failures. The normalizer was exercised locally on a real shard blob downloaded from run 34696497598 (6 882 paths rewritten, file still parses, coverage map keyed under the local root). Static gates run locally: `scripts/check_brand_name.py`, `scripts/docs-lint.sh`, YAML parse of the workflow. No test suite was run locally; CI is the run.

## Rollback

In the `changes` job's `Pick the Linux runner label` step, set both outputs to `ubuntu-latest` (or replace one job's `runs-on` reference). Nothing else to undo; a rollback PR runs its own edited workflow, so it works during a runner outage.

## UX CONCERNS

none (CI-only)
