### PR TITLE
fix: preserve crew member context with private memory

### DIFF
--- a/docs/system-specs/modules/crew-mode.md
+++ b/docs/system-specs/modules/crew-mode.md
@@ -66,6 +66,15 @@ using V1 or explicitly choose empty V2 memory from their settings; former Global
 or named V1 contents remain untouched. Config fields, atomic publication, ownership manifest and
 recovery semantics are owned by [config](config.md#named-memory-stores-memory_storespy).
 
+A new member DM inherits the member's configured workspace, falling back to
+`default_workspace` when that name is undeclared. Its project directory uses the
+shared `default_project_dir` validation, so provider cwd and project essentials
+refer to the same workspace. Resolution finishes before publishing the slot;
+the first slot broadcast includes its project directory. A concurrent opener's
+existing slot is preserved. Reopening a live or restored
+thread keeps its saved workspace and project, including an explicitly empty
+project, rather than resetting a session choice to the member default.
+
 Opting into V2 opens a fresh member conversation. Existing V1 conversation and
 native provider context cannot become private context by changing the config.
 The member-thread binding records its private store generation and reuses that

--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -1202,9 +1202,16 @@ their existing context path.
 bound custom-template persona on fresh, warm, resumed, post-compaction and
 minimal turns, including delegated and cron turns with no DM member argument.
 An execution-template override supplies task instructions; it does not replace
-the memory owner's persona. The generic `kirocrew` product prompt retains its
-existing provider/session-start path. The member's working briefing keeps its
-existing bounded/platform-gated reader; it is not unbounded archival memory.
+the memory owner's persona. The generic product prompt retains its existing
+provider/session-start path, including when a member's fork inherits it. The
+loader recognizes the exact current `file://` URI selected by `_prompt_path()`,
+not a template name or file basename. Package installs outside the user home,
+development prompt overrides and the global user prompt override therefore do
+not become project essentials or spend the essential envelope's budget. A
+custom persona, including one on a template named `kirocrew`, remains essential
+and passes the same file-admission checks as other declared sources. The member's
+working briefing keeps its existing bounded/platform-gated reader; it is not
+unbounded archival memory.
 
 Admitted project essentials are the active project's root `AGENTS.md` and
 `SOUL.md`, default/`always` documents under `.kiro/steering`, and Markdown file

--- a/src/kiro_crew/dashboard/handlers/members.py
+++ b/src/kiro_crew/dashboard/handlers/members.py
@@ -25,7 +25,7 @@ from aiohttp import web
 
 import kiro_crew.dashboard.handlers as _h
 from kiro_crew import members as members_mod
-from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.loader import KiroCrewConfig, default_project_dir
 from kiro_crew.dashboard.chat_persistence import (
     pin_private_agent_store,
     rehydrate_slot_from_history_async,
@@ -435,13 +435,23 @@ async def api_member_thread(request: web.Request) -> web.Response:
         # member thread, so a ✕-closed transcript reopens with its history.
         slot = await rehydrate_slot_from_history_async(state, slot_key, adopt_closed=True)
     if slot is None:
-        # No usable history — a genuinely fresh thread.
-        slot = state.get_or_create_slot(
-            name=slot_key,
-            agent=member_name,
-            mode=members_mod.DM_SLOT_MODE,
-            origin=request_slot_origin(request.get("app", "")),
-        )
+        member_workspace = cfg.agents[member_name].workspace
+        if member_workspace not in cfg.workspaces:
+            member_workspace = cfg.default_workspace
+        project = await asyncio.to_thread(default_project_dir, member_workspace)
+        # Resolve before publication, then re-check: another opener can create
+        # the slot while path validation waits. Its project remains its choice.
+        slot = state._slots.get(slot_key)
+        if slot is None:
+            with state.suspend_slots_push():
+                slot = state.get_or_create_slot(
+                    name=slot_key,
+                    agent=member_name,
+                    workspace=member_workspace,
+                    mode=members_mod.DM_SLOT_MODE,
+                    origin=request_slot_origin(request.get("app", "")),
+                )
+                slot.project = project
     if slot.mode != members_mod.DM_SLOT_MODE:
         # The derived key is already occupied by a foreign slot (mode is set at
         # creation only, so a pre-existing non-member slot keeps its own). Never

--- a/src/kiro_crew/member_essential_context.py
+++ b/src/kiro_crew/member_essential_context.py
@@ -255,7 +255,7 @@ def documents_for_member(
     documents are deliberately left to their native trigger. Generic product
     prompts keep their existing provider/session-start path.
     """
-    from kiro_crew.agent import agent_spec_path
+    from kiro_crew.agent import _prompt_path, agent_spec_path
     from kiro_crew.agent_discovery import _read_agent_spec, project_agent_files
 
     documents: list[tuple[str, str]] = []
@@ -328,7 +328,9 @@ def documents_for_member(
     prompt = spec.get("prompt", "")
     if not isinstance(prompt, str):
         raise MemberEssentialContextError(f"Essential template {spec_path}: prompt must be text")
-    if template != "kirocrew" and isinstance(prompt, str) and prompt:
+    # Forks inherit the product prompt URI too. Its provider/session-start
+    # injection is independent of the template name and the install directory.
+    if prompt and prompt != f"file://{_prompt_path()}":
         if prompt.startswith("file://"):
             path = Path(prompt[7:]).expanduser()
             add(

--- a/test/test_member_essential_context.py
+++ b/test/test_member_essential_context.py
@@ -529,3 +529,92 @@ def test_refused_workspace_root_is_never_resolved(env, monkeypatch, tmp_path):
 
     assert not any("share-host" in p for p in resolved), resolved
     assert mec._comparable_root(refused) == Path(os.path.abspath(refused))
+
+
+@pytest.mark.parametrize("source", ["package", "development", "user-override"])
+@pytest.mark.parametrize(
+    "fresh, options",
+    [
+        (True, {}),
+        (False, {}),
+        (False, {"needs_reinjection": True}),
+        (True, {"resumed": True}),
+        (True, {"minimal_context": True}),
+    ],
+)
+def test_inherited_product_prompt_uses_session_start_not_essentials(
+    env, tmp_path, monkeypatch, source, fresh, options
+):
+    from kiro_crew import agent
+    from kiro_crew.config import config_dir
+
+    package = tmp_path / "installed-package" / "config"
+    development = tmp_path / "checkout"
+    monkeypatch.setattr(agent, "_BUNDLED_CFG_DIR", package)
+    monkeypatch.setattr(agent, "_project_dir", lambda: development)
+    paths = {
+        "package": package / "prompt.md",
+        "development": development / "agents" / "prompt.md",
+        "user-override": config_dir() / "prompt.md",
+    }
+    prompt_path = paths[source]
+    prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text("PRODUCT_PROMPT_AT_SESSION_START", encoding="utf-8")
+    assert agent._prompt_path() == prompt_path
+    spec = env.project / ".kiro" / "agents" / "writer-template.json"
+    spec.write_text(
+        json.dumps({"name": "writer-template", "prompt": f"file://{prompt_path}"}),
+        encoding="utf-8",
+    )
+
+    message, _ = env.builder.build_message(
+        "Continue", fresh, memory_store=env.store, project=str(env.project), **options
+    )
+
+    assert message.count("[V2 ESSENTIAL CONTEXT") == 1
+    assert "You are writer." in message and "Do not publish drafts." in message
+    assert "Preference anchor" in message and "Project rules" in message
+    assert f"[Essential source: {prompt_path}]" not in message
+    if fresh and not options.get("resumed"):
+        assert message.count("PRODUCT_PROMPT_AT_SESSION_START") == 1
+    env.forbidden.assert_not_called()
+
+
+@pytest.mark.parametrize("template", ["writer-template", "kirocrew"])
+@pytest.mark.parametrize("source", ["inline", "relative", "absolute"])
+def test_custom_persona_is_not_classified_by_template_name(env, template, source):
+    cfg = KiroCrewConfig.load()
+    cfg.agents["writer"].kiro_agent = template
+    cfg.save()
+    persona = env.project / "prompt.md"
+    persona.write_text("CUSTOM_OWNER_PERSONA", encoding="utf-8")
+    prompts = {
+        "inline": "CUSTOM_OWNER_PERSONA",
+        "relative": "file://prompt.md",
+        "absolute": f"file://{persona}",
+    }
+    spec = env.project / ".kiro" / "agents" / f"{template}.json"
+    spec.write_text(json.dumps({"name": template, "prompt": prompts[source]}), encoding="utf-8")
+
+    message, _ = env.builder.build_message(
+        "Continue", False, agent="task-template", memory_store=env.store, project=str(env.project)
+    )
+
+    assert "CUSTOM_OWNER_PERSONA" in message
+    assert "Do not publish drafts." in message
+
+
+@pytest.mark.parametrize("template", ["writer-template", "kirocrew"])
+def test_unmanaged_prompt_outside_root_is_not_exempted_by_name(env, tmp_path, template):
+    cfg = KiroCrewConfig.load()
+    cfg.agents["writer"].kiro_agent = template
+    cfg.save()
+    persona = tmp_path / "prompt.md"
+    persona.write_text("OUTSIDE_PERSONA", encoding="utf-8")
+    spec = env.project / ".kiro" / "agents" / f"{template}.json"
+    spec.write_text(json.dumps({"name": template, "prompt": f"file://{persona}"}), encoding="utf-8")
+
+    with pytest.raises(MemberEssentialContextError, match="outside the admitted document root"):
+        env.builder.build_message(
+            "Continue", False, memory_store=env.store, project=str(env.project)
+        )

--- a/test/test_members_dm_thread.py
+++ b/test/test_members_dm_thread.py
@@ -48,6 +48,8 @@ def _fake_config(names, default=CREW):
         agents={name: KiroCrewAgentConfig(kiro_agent=name) for name in names},
         default_agent=default,
         memory_stores={},
+        workspaces={"default": SimpleNamespace(dir="workspace")},
+        default_workspace="default",
     )
 
 
@@ -322,6 +324,101 @@ class TestMemberRoutes:
         slot = state._slots["member-code-reviewer"]
         assert slot.agent == CREW
         assert slot.mode == DM_SLOT_MODE
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("private", [False, True])
+    @pytest.mark.parametrize("workspace", ["team-a", "missing"])
+    async def test_thread_create_honors_member_workspace_and_project(
+        self, tmp_path, monkeypatch, private, workspace
+    ):
+        """A new member DM uses the configured workspace for cwd and project guides."""
+        from member_memory_helpers import patch_private_memory_supported
+
+        from kiro_crew.config.loader import KiroCrewConfig
+        from kiro_crew.config.sections import WorkspaceConfig
+        from kiro_crew.memory_stores import provision_member_memory
+
+        team_dir = tmp_path / "team-a-workspace"
+        team_dir.mkdir()
+        cfg = KiroCrewConfig.load()
+        cfg.agents[CREW] = KiroCrewAgentConfig(kiro_agent=CREW, workspace=workspace)
+        cfg.workspaces["team-a"] = WorkspaceConfig(dir=str(team_dir))
+        cfg.default_workspace = "team-a"
+        if private:
+            patch_private_memory_supported(monkeypatch)
+            await asyncio.to_thread(provision_member_memory, cfg, CREW)
+        await asyncio.to_thread(cfg.save)
+        state = _make_state(tmp_path)
+        frames = []
+        monkeypatch.setattr(state, "_slots_broadcast_lock", None)
+        monkeypatch.setattr(
+            state,
+            "_do_slots_broadcast",
+            lambda: frames.append(
+                [(slot.workspace, slot.project) for slot in state._slots.values()]
+            ),
+        )
+        async with TestClient(TestServer(_make_members_app(state))) as client:
+            resp = await client.post(f"/api/members/{CREW}/thread")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+        slot = state._slots[data["slot_key"]]
+        assert slot.workspace == "team-a"
+        assert slot.project == str(team_dir.resolve())
+        assert frames and frames[0] == [("team-a", str(team_dir.resolve()))]
+        if private:
+            assert slot.memory_store == cfg.agents[CREW].memory_store
+
+    @pytest.mark.asyncio
+    async def test_workspace_resolution_does_not_overwrite_a_concurrent_opener(self, tmp_path):
+        state = _make_state(tmp_path)
+        entered, release = threading.Event(), threading.Event()
+
+        def resolve(workspace):
+            entered.set()
+            assert release.wait(timeout=5)
+            return str(tmp_path / "resolved")
+
+        with (
+            _patched_config([CREW]),
+            patch("kiro_crew.dashboard.handlers.members.default_project_dir", resolve),
+        ):
+            async with TestClient(TestServer(_make_members_app(state))) as client:
+                pending = asyncio.create_task(client.post(f"/api/members/{CREW}/thread"))
+                try:
+                    assert await asyncio.to_thread(entered.wait, 5)
+                    slot = state.get_or_create_slot(
+                        member_slot_key(CREW), agent=CREW, mode=DM_SLOT_MODE, workspace="chosen"
+                    )
+                    slot.project = str(tmp_path / "chosen")
+                finally:
+                    release.set()
+                    response = await asyncio.wait_for(pending, timeout=5)
+                assert response.status == 200
+        assert state._slots[member_slot_key(CREW)] is slot
+        assert slot.project == str(tmp_path / "chosen")
+        assert slot.workspace == "chosen"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("project", ["", "chosen-project"])
+    async def test_reopening_live_member_preserves_explicit_project(self, tmp_path, project):
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot(
+            member_slot_key(CREW), agent=CREW, mode=DM_SLOT_MODE, workspace="chosen"
+        )
+        slot.project = project
+        with (
+            _patched_config([CREW]),
+            patch(
+                "kiro_crew.dashboard.handlers.members.default_project_dir",
+                side_effect=AssertionError("existing project was re-resolved"),
+            ),
+        ):
+            async with TestClient(TestServer(_make_members_app(state))) as client:
+                response = await client.post(f"/api/members/{CREW}/thread")
+                assert response.status == 200
+        assert slot.workspace == "chosen"
+        assert slot.project == project
 
     @pytest.mark.asyncio
     async def test_thread_reopen_rehydrates_dormant_history(self, tmp_path):


### PR DESCRIPTION
## Problem / Motivation

Private Memory V2 members can fail before answering a message. A member fork inherits the product prompt's file URI, but essential-context loading mistakes it for a custom persona. A package installed outside the user's home fails the document-root check. A global prompt override can hit the managed-state fence instead.

New member conversations also ignore the member's workspace. Their project starts empty, so the working directory and project guides do not follow the member's configuration.

## Why it matters

An ordinary inherited template can make every turn fail. A member that does start can miss the project's instructions. Both failures affect the basic experience of using a member with private memory.

## What changed (motivation → approach → change)

The product prompt stays on its provider/session-start path. Essential-context loading identifies it by the exact current URI from `_prompt_path()`, not the template name. Real custom personas remain essential, even on a template named `kirocrew`. File admission and private-memory checks stay intact.

New member threads inherit their configured workspace and use `default_project_dir` for the project. An undeclared workspace uses `default_workspace`. Path resolution finishes before slot creation, and an existing slot is checked again after that wait. Creation and project assignment share the existing `suspend_slots_push()` block, so the first broadcast is complete. Existing and restored session choices are preserved.

| Case | Before | After |
|---|---|---|
| Inherited package prompt outside home | 🟥 Turn fails | 🟩 Provider/session-start prompt |
| Inherited development or global prompt override | 🟥 Re-read as an essential, possibly refused | 🟩 Provider/session-start prompt |
| Custom persona on a template named `kirocrew` | 🟥 Omitted from essentials | 🟩 Included with normal admission checks |
| Custom file outside the admitted root | 🟦 Refused | 🟦 Refused |
| New V1 or V2 member with a named workspace | 🟥 Default workspace and empty project | 🟩 Configured workspace and validated project |
| New member with an undeclared workspace | 🟥 Implicit default slot | 🟩 Configured `default_workspace` fallback |
| First slot broadcast | 🟥 Empty project | 🟩 Resolved project |
| Reopened or concurrently created slot | 🟦 Keeps its choices | 🟦 Keeps its choices |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

Members keep their persona and start new conversations in the right project without widening access to private data.

## Tests

213 focused member and essential-context tests pass. New cases cover package, development and global prompt sources across fresh, warm, resumed, reinjected and minimal turns; inline, relative and absolute custom personas; outside-root refusal; real V2 and legacy V1 member creation; workspace fallback; concurrent opens; existing project choices; and the first broadcast. The prompt regressions failed before the fix. All four first-frame cases failed before broadcast batching. The prepare-pr regression proof reports `PROVEN` when production fixes are reverted.

All resolved static and frontend gates pass. Full mypy checks 1,457 source files. The frontend cross-surface suite passes 6,784 tests in 232 files; Electron reports 1,868 passed and zero failures. Production frontend builds, bundle/chunk checks, and an isolated wheel build pass.

Full backend result on this candidate: **100,274 passed, 12 failed, 359 skipped, 9 xfailed, plus 2 teardown errors**. This is not an all-green full-suite claim. The failures and teardown errors reproduce in clean-main controls: host D-Bus access, executable-path trust, kernel-header availability, service path ownership, and two cold-start agent-home isolation tests. Running the whole isolation test file warms state and hides the latter two; running those two cases alone reproduces both failures and both teardown errors on main and the candidate. No tests or gates were disabled to obtain these results.

Local review used the extracted CI contracts for GPT and Opus. Opus found no confirmed issue. GPT's first-broadcast finding is covered by the failing-then-passing regression and a clean focused verification of the final commit.

## Manual verification

Verified on Linux in an isolated worktree with test-owned state. No live gateway or user memory was changed. Provider/session-start prompt delivery is checked through `ContextBuilder`; workspace assignment and first-frame state are checked through the member HTTP endpoint. Native macOS and Windows runs were not available locally and remain CI coverage.

## Screenshots / video

N/A. No frontend component, layout, or user-facing string changes. The backend first-frame regression asserts the state delivered to the existing interface.

## Related Issues

no linked issue: reported directly in a member conversation after the earlier root-normalization fix was merged.

## Pattern harvest

Rule candidate: review-prompt

Pattern: classify inherited configuration by the value its producer writes, not the consumer's display name. When slot creation broadcasts immediately, finish its initial fields inside the existing broadcast-suspension mechanism. Test the first published frame, not only the final object.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality (focused tests pass; full-suite baseline failures are disclosed above)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
