### PR TITLE
fix(cron): cascade child release when a one-shot is consumed by _merge_job_result

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -5127,6 +5127,8 @@ class CronService:
                 job.fire_time_denied or job.run_never_started
             )
             removed_one_shot = False
+            restore: list[tuple[CronJob, str]] = []
+            consumed_row = False
             if delete_owed:
                 # Presence check keeps the audit honest: a Done-script one-shot
                 # already removed by the gateway path leaves nothing to delete
@@ -5159,31 +5161,57 @@ class CronService:
                     self._pending_removals.add(job.id)
                 else:
                     self._jobs = [j for j in self._jobs if j.id != job.id]
+                    consumed_row = True
+                    # Consuming the one-shot retires its principal cron:<job id>,
+                    # so a child that job created is released in the SAME save --
+                    # the fifth removal core alongside the four locked cores. Runs
+                    # after the row is filtered out so the job cannot release
+                    # itself; rolled back below if the save fails.
+                    restore = self._release_children_of_removed({job.id})
             # BACKGROUND writer: a job has already run, so an unreadable store
             # must not surface as a job-runner crash. The run result is lost,
             # which is strictly better than clobbering the store.
             try:
                 self._save()
-            except CronStoreUnreadable as exc:
-                # Return WITHOUT auditing: the emit below records only a SAVED
-                # removal, and nothing was saved. Auditing here would file a
-                # removal record for a delete that never reached disk.
-                #
-                # But hand the CONSUME to the deferred queue on the way out, so
-                # the drain retries it once the store is readable. The one-shot
-                # is gone from _jobs and absent from the queue otherwise, so the
-                # next _sync restores it from disk and it runs again. Only when
-                # a delete was actually owed: a job already removed elsewhere
-                # leaves nothing to retry.
-                # Keyed on delete_owed, NOT presence: the store could not be
-                # read, so an absent id proves nothing about whether the delete
-                # is owed. An id that really was removed elsewhere is harmless
-                # here -- the drain intersects the queue with what is present
-                # and drops the rest.
+            except BaseException as exc:
+                # EVERY save failure rolls back the child release, not just
+                # CronStoreUnreadable: the release lives in memory only until the
+                # save lands it, so a bare OSError (ENOSPC/EROFS/EIO out of
+                # atomic_write) that left the cleared owners in place while disk
+                # still named the old owner would let the next successful save
+                # persist a release nothing asked for, from a consume that never
+                # reached disk.
+                if consumed_row:
+                    for child, previous_owner in restore:
+                        child.session_key = previous_owner
+                    # The consumed row is still filtered out of self._jobs and
+                    # only a reload can put it back, so drop the fingerprint to
+                    # force one -- otherwise the next _save skips the reload and
+                    # persists the removal this path was told had failed,
+                    # completing the parent's removal while its children keep the
+                    # ownership just rolled back.
+                    self._reset_fingerprint()
+                # Queue the consume for EVERY save failure, not just the
+                # store-unreadable one: the fingerprint reset above forces a
+                # reload, and the save never landed, so the disk copy is still
+                # enabled. Without a queue entry the reloaded one-shot comes back
+                # enabled and runs a second time on the next tick. Keyed on
+                # delete_owed, NOT presence: an absent id proves nothing about
+                # whether the delete is owed, and the drain intersects the queue
+                # with what is present and drops the rest.
                 if delete_owed:
                     self._pending_removals.add(job.id)
-                logger.warning("Cron job result not persisted: %s", exc)
-                return
+                if isinstance(exc, CronStoreUnreadable):
+                    # Return WITHOUT auditing: the emit below records only a SAVED
+                    # removal, and nothing was saved. Auditing here would file a
+                    # removal record for a delete that never reached disk. The
+                    # drain retries the queued consume once the store is readable.
+                    logger.warning("Cron job result not persisted: %s", exc)
+                    return
+                # Anything else is a real write fault, not the tolerated
+                # store-unreadable case: surface it rather than reporting a quiet
+                # no-op after the disk refused the write.
+                raise
         if removed_one_shot:
             # The delete_after_run consume is an automated removal with no
             # handler-level caller, so the emit lives with the removal.

--- a/test/test_cron_merge_result_cascade.py
+++ b/test/test_cron_merge_result_cascade.py
@@ -1,0 +1,80 @@
+"""Child release must cascade when a one-shot is consumed by _merge_job_result.
+
+Removing a cron retires its principal ``cron:<job id>``. Every locked removal
+core releases the jobs that cron owned in the same save. ``_merge_job_result``
+consumes a completed ``delete_after_run`` one-shot inline, so it is a removal
+core too: a child cron created during that job's own run must have its owner
+cleared in the same save, or it strands as owned by a principal that runs of a
+deleted job can never present again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.cron import CronService, CronStoreUnreadable
+
+
+def _completed_one_shot(service: CronService) -> object:
+    """An 'at' delete_after_run job that has already fired successfully."""
+    job = service.add_job("parent", "run", at_ts=1.0, delete_after_run=True)
+    job.last_status = "ok"
+    job.last_run_ts = 100.0
+    job.fire_time_denied = False
+    job.run_never_started = False
+    return job
+
+
+def test_merge_job_result_releases_child_of_consumed_one_shot(tmp_path):
+    service = CronService(base_dir=tmp_path)
+    parent = _completed_one_shot(service)
+    child = service.add_job("child", "run", every_secs=3600, session_key=f"cron:{parent.id}")
+
+    service._merge_job_result(parent)
+
+    assert service.get_job(parent.id) is None, "one-shot parent was not consumed"
+    surviving_child = service.get_job(child.id)
+    assert surviving_child is not None, "child must be released, not deleted"
+    assert surviving_child.session_key == "", (
+        "child owned by the consumed one-shot must be released to ownerless, "
+        "not left stranded under a cron principal that runs can never present"
+    )
+
+
+def test_merge_job_result_rolls_back_child_release_on_save_failure(tmp_path, monkeypatch):
+    service = CronService(base_dir=tmp_path)
+    parent = _completed_one_shot(service)
+    child = service.add_job("child", "run", every_secs=3600, session_key=f"cron:{parent.id}")
+
+    def boom() -> None:
+        raise CronStoreUnreadable("store unreadable")
+
+    monkeypatch.setattr(service, "_save", boom)
+
+    # An unreadable store must not surface as a run-path crash; the consume is
+    # deferred and retried later.
+    service._merge_job_result(parent)
+
+    # The save never landed, so the child's ownership must be exactly what it
+    # was before the attempt -- not silently cleared in memory.
+    assert child.session_key == f"cron:{parent.id}"
+    assert parent.id in service._pending_removals
+
+
+def test_merge_job_result_queues_consume_on_non_unreadable_save_failure(tmp_path, monkeypatch):
+    service = CronService(base_dir=tmp_path)
+    parent = _completed_one_shot(service)
+
+    def boom() -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(service, "_save", boom)
+
+    # A real write fault must surface, not be swallowed as a quiet no-op.
+    with pytest.raises(OSError):
+        service._merge_job_result(parent)
+
+    # The fingerprint reset forces a reload and the save never landed, so the
+    # disk copy is still enabled; without a queue entry the reloaded one-shot
+    # would run a second time. The consume must be queued for retry.
+    assert parent.id in service._pending_removals


### PR DESCRIPTION
## What is the problem?

`_merge_job_result` consumes a completed `delete_after_run` one-shot inline: it
filters the job's row out of `self._jobs` and saves. It never releases the jobs
that cron owned. A child cron created during that job's own run therefore
strands the moment the epoch bump succeeds -- it stays owned by
`cron:<job id>`, a principal no session can ever present again.

## Why this issue matters to the user

A stranded child is manageable by nobody: `cron_list` omits it,
`cron_update`/`cron_remove` answer "job not found", yet it keeps firing on
schedule. That is exactly the dead-owner state the four locked removal cores
were given cascade + rollback to prevent -- but `_merge_job_result` is a fifth
structural remover that was left out, so a one-shot that spawns a child before
it completes silently creates an unkillable job.

## How our fix solves it

Symptom: a child fires forever and cannot be listed or removed.
Root cause: `_merge_job_result` removes the parent row but never calls
`_release_children_of_removed`, so the child keeps a `cron:<parent>` owner that
runs of the deleted job can never present again.

The consume now calls `_release_children_of_removed({job.id})` right after the
row is filtered out (so the job cannot release itself), landing the removal and
the release it implies in one atomic save -- the same shape as the four
existing cores. The rollback matches them: every `_save` failure restores the
child owners and resets the fingerprint, gated on whether the row was actually
consumed so the plain result-merge path is unchanged. Because that fingerprint
reset forces a reload while the save never landed, every post-consume save
failure -- `CronStoreUnreadable` and a plain `OSError` (ENOSPC/EROFS/EIO) alike
-- also queues the consume to `_pending_removals`, so the reloaded one-shot is
retired by the deferred drain rather than reloading enabled and running a
second time. A `CronStoreUnreadable` returns without auditing; any other write
fault still surfaces via `raise`.

## What tests we did

Red-first, in `test/test_cron_merge_result_cascade.py`:

- `test_merge_job_result_releases_child_of_consumed_one_shot` failed before the
  fix with `assert 'cron:<id>' == ''` (the child stranded under the consumed
  principal) and passes after -- the parent is consumed, the child survives and
  is released to ownerless.
- `test_merge_job_result_rolls_back_child_release_on_save_failure` pins the
  `CronStoreUnreadable` path: the child's ownership is preserved and the consume
  is requeued.
- `test_merge_job_result_queues_consume_on_non_unreadable_save_failure` pins the
  plain-`OSError` path: it failed before this revision with
  `assert '<id>' in set()` (the `raise` propagated but nothing was queued, so
  the reloaded one-shot would re-run) and passes after -- the `OSError`
  surfaces AND the consume is queued.

Also green with no regression: `test_cron.py` (119), `test_cron_locking_regression.py` (36),
`test_cron_removal_audit_seam.py` (6). black, isort and ruff clean on the changed files.

## Any other suggestions on the work

No wire contract, persisted field or API shape changes, so no module-spec update
is required. Design Review suggested closing the defect CLASS -- a shared
remove-rows helper, or a structural test asserting every `self._jobs` filter
site cascades -- which is out of scope here and filed as follow-up #10348.

## Pattern harvest

Rule candidate: agents-md / review-prompt. When a method removes a job from the
store (filters it out of `self._jobs` and saves), it is a removal core and must
release that job's children in the same save via `_release_children_of_removed`,
with the matching rollback -- restore child owners and reset the fingerprint on
any `_save` failure, AND requeue the consume so a forced reload cannot re-run a
save that never landed. An inline one-shot consume is a removal even though it
does not resemble the CLI/MCP remove paths, so any new structural remover must
adopt the cascade + rollback + requeue shape rather than only filtering the row.

Fixes #9282
