### PR TITLE
fix: deduplicate inherited default agent label

### DIFF
--- a/website/src/test/ChatInput.agentChipDefaultMarker.test.tsx
+++ b/website/src/test/ChatInput.agentChipDefaultMarker.test.tsx
@@ -15,10 +15,12 @@
  * the chip shows the marker for an inherited default, the bare alias for a pin,
  * and that the raw alias still drives the chip's switch tooltip.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import i18next from 'i18next'
 import { renderWithProviders } from './helpers'
 import ChatInput from '../components/ChatInput'
 import { agentOrDefaultLabel } from '../utils/agentLabel'
+import '../i18n/all'
 
 vi.mock('../api/client', () => ({ api: {} }))
 
@@ -50,6 +52,7 @@ function agentChipText(): string {
 
 describe('ChatInput — agent chip inherited-default marker', () => {
   beforeEach(() => vi.clearAllMocks())
+  afterEach(async () => { await i18next.changeLanguage('en') })
 
   it('marks an inherited default so it differs from a pin to the same alias', () => {
     // agent-less slot resolving to `kirocrew` -> the call site composes this.
@@ -64,6 +67,42 @@ describe('ChatInput — agent chip inherited-default marker', () => {
     expect(agentChipText()).toBe(inherited)
     expect(agentChipText()).toContain('kirocrew')
     expect(agentChipText()).toContain('default')
+  })
+
+  it('shows the built-in default alias once when a remote-bound slot inherits it', () => {
+    const inherited = agentOrDefaultLabel(undefined, 'default')
+    renderWithProviders(
+      <ChatInput
+        {...props({
+          agentName: 'default',
+          agentLabel: inherited,
+          agentIsInheritedDefault: true,
+        })}
+      />,
+    )
+
+    expect(agentChipText()).toBe('default')
+    expect(agentChipText()).not.toContain('default · default')
+    expect(agentChip()).toHaveAttribute('title', expect.stringContaining('follows the default'))
+  })
+
+  it('keeps the literal fallback while no default has loaded', async () => {
+    await i18next.changeLanguage('zh-CN')
+    expect(agentOrDefaultLabel(undefined, '')).toBe('default')
+  })
+
+  it('keeps the real alias when the localized default marker differs', async () => {
+    await i18next.changeLanguage('zh-CN')
+    const defaultLabel = i18next.t('components.agentSelector.default')
+    expect(defaultLabel).not.toBe('default')
+    expect(agentOrDefaultLabel(undefined, 'default')).toBe(`default · ${defaultLabel}`)
+  })
+
+  it('keeps a named alias marked when it matches the localized marker', async () => {
+    await i18next.changeLanguage('de')
+    const defaultLabel = i18next.t('components.agentSelector.default')
+    expect(defaultLabel).not.toBe('default')
+    expect(agentOrDefaultLabel(undefined, defaultLabel)).toBe(`${defaultLabel} · ${defaultLabel}`)
   })
 
   it('shows the bare alias when the slot is pinned to that agent', () => {

--- a/website/src/utils/agentLabel.ts
+++ b/website/src/utils/agentLabel.ts
@@ -6,14 +6,23 @@ import { i18nT } from '../i18n/t'
  * An empty agent means the record resolves the CURRENT default at run time,
  * so the accurate label is the resolved alias — marked `· default` (reusing
  * AgentSelector's badge key) so an inherited default stays distinguishable
- * from an explicit pin. Degrades to the literal 'default' until the default
- * loads or when none is configured. Textual (not a styled badge) because the
- * Worlds scene layers render it as a plain string.
+ * from an explicit pin. The built-in wire alias `default` and the English marker
+ * render as the same word, so that one combination shows it once. A named alias
+ * remains marked even when its spelling happens to equal a translated marker:
+ * the first word is the agent's identity and the second is its inherited state.
+ * Degrades to the literal `default` until the default loads or when none is
+ * configured. The inherited-default tooltip also explains the dynamic binding
+ * on interactive surfaces. Textual (not a styled badge) because the Worlds scene
+ * layers render it as a plain string.
  *
  * The one shared spelling for every surface that renders this state; do not
  * inline copies.
  */
 export function agentOrDefaultLabel(agent: string | undefined, defaultAgent: string): string {
   if (agent) return agent
-  return defaultAgent ? `${defaultAgent} · ${i18nT('components.agentSelector.default')}` : 'default'
+  if (!defaultAgent) return 'default'
+  const defaultLabel = i18nT('components.agentSelector.default')
+  return defaultAgent === 'default' && defaultLabel === 'default'
+    ? defaultLabel
+    : `${defaultAgent} · ${defaultLabel}`
 }


### PR DESCRIPTION
## Problem / Motivation

A remote-bound chat could show `default · default` in its agent chip. The session has no pinned agent, and the peer’s built-in agent is also named `default`, so the inherited-state marker repeated the same word.

## Why it matters

The repeated label looks broken and makes the new remote-chat flow harder to trust at a glance.

## What changed (motivation → approach → change)

The formatter collapses only the exact built-in English collision: wire alias `default` plus English marker `default`. It renders that state once.

Other cases keep both facts. A non-English UI preserves the real wire alias beside its localized marker, and a named alias stays marked even when its spelling matches that marker.

The inherited-default tooltip and accessible name still explain that the session follows the current default and can be pinned.

## Tests

- Added English coverage that rejects `default · default` and keeps the inherited tooltip.
- Added coverage that preserves the original literal `default` while no default has loaded.
- Added zh-CN coverage that preserves the wire alias as `default · 默认`.
- Added German coverage that keeps a named `Standard` alias marked as `Standard · Standard`.
- Full frontend floor passed: 2,042 Vitest files / 32,535 tests and 1,868 Electron tests, with TypeScript, ESLint, i18n, rendered-locale, duplication, bundle-size, and chunk-cycle gates green.
- The cross-surface backend run passed 34,622 tests. Its 109 host-only failures were unrelated to this TypeScript diff; all eight sampled failure classes reproduced on clean `origin/main` (user-bus denial, protected-home checks, doctor setup, and symbolizer timeout).

## Manual verification

Rendered the production bundle with a remote-bound, agent-less slot whose peer default is the built-in `default`. The agent chip was asserted to contain exactly `default`, while its accessible label still explained inheritance.

## Screenshots / video

![Remote-bound chat agent chip shows one default](https://github.com/user-attachments/assets/1a09e0ec-ab67-4a87-bf61-ff3391d65520)

## Related Issues

no linked issue: reported directly from dashboard dogfooding.

## Pattern harvest

Rule candidate: review-prompt
Pattern: deduplicate a localized status marker only for the exact reserved identifier collision; generic rendered-string equality can hide a real user-defined identifier.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (not applicable: this is display-only formatting covered by the existing feature contract and code comment)
- [x] No secrets, credentials, or internal references in the diff
