### PR TITLE
fix(admission): read gate flags strictly and compare signatures as bytes (#9641)

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -1289,7 +1289,11 @@ which parses fine — so fail-closing on a *malformed* file would catch only a c
 variant of an attack the design already concedes, while turning a non-atomic fleet
 push or a hand-edit typo into an unbootable host. Corruption there is a reliability
 event: it is logged at WARNING, plugin admission independently fails closed on the
-same file, and `kirocrew doctor` reports it.
+same file, and `kirocrew doctor` reports it. Distinct from a broken FILE: a
+well-formed trust root whose `require_policy_signature` is present but not a
+real JSON boolean (explicit `null`, `"false"`, `0`) reads fail-closed as
+opted-IN — both the enforcement gate and the key store route through the one
+strict `admission.AdmissionPolicy.from_dict` reader (#9641).
 
 
 **Threat model.** This detects **offline / at-rest tampering and substitution** of

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -317,6 +317,17 @@ Policy shape (`admission_policy.json`):
 }
 ```
 
+**Strict gate-flag reading.** `require_signature` and
+`require_policy_signature` are read strictly by `_coerce_flag`: a real JSON
+boolean is honoured, an absent key leaves the gate off (the documented
+default), and any other present value — explicit `null`, the string
+`"false"`, `0`, `1` — is warned about and read as **on**, the fail-closed
+direction (#9641). `bool()` on the raw value used to read any non-empty
+string as ON but `null`/`""` as OFF, so a template rendering
+`"require_policy_signature": null` silently disabled the gate. Same
+strict-read shape as the `boot` gate flags in
+[governance](governance.md) (#9176).
+
 **This policy is also the trust root for the security ceiling.**
 `require_policy_signature` (default `false`) additionally demands a *verified*
 `identity.signature` on `security_policy.json`, keyed by that document's

--- a/src/kiro_crew/platform/admission.py
+++ b/src/kiro_crew/platform/admission.py
@@ -230,6 +230,48 @@ def _coerce_trust_keys(raw: object) -> Dict[str, str]:
     return out
 
 
+# Sentinel distinguishing "key absent" from "key present with value null":
+# ``d.get(key)`` alone cannot tell ``"require_signature": null`` apart from the
+# key not being written at all, and the two must read differently (absent means
+# the gate is off by its documented default; present-but-not-boolean reads
+# fail-closed).
+_MISSING = object()
+
+
+def _coerce_flag(d: Mapping[str, object], key: str) -> bool:
+    """Read one admission gate flag strictly.
+
+    A real JSON boolean is honoured; an absent key leaves the gate OFF (the
+    documented default). Any other PRESENT value — ``null``, the string
+    ``"false"``, ``0``, ``1``, a list — is NOT interpreted: ``bool()`` on a raw
+    JSON value turns any non-empty string (``"false"`` included) into ``True``
+    while ``null`` and ``""`` read as ``False``, so a hand-edited or
+    template-rendered policy carrying ``"require_policy_signature": null``
+    silently disables the very gate the operator wrote down. Such a value is
+    warned about and read as ``True`` — ON, the fail-closed direction for an
+    admission gate. ``bool`` is a subclass of ``int``, so the boolean check
+    must run before any int handling. Same strict-read shape as
+    ``governance._coerce_boot_flag`` for the ``boot`` gate flags.
+    """
+    value = d.get(key, _MISSING)
+    if value is _MISSING:
+        return False
+    if isinstance(value, bool):
+        return value
+    # Log the TYPE, never the value: a mis-typed flag can carry a secret (a
+    # credential pasted into the policy — this file also holds ``trust_keys``),
+    # and this warning lands in the persistent gateway log ring, which
+    # ``GET /api/logs`` serves. Mirrors ``governance._coerce_boot_flag``.
+    logger.warning(
+        "admission policy %s is %s, not a boolean; reading it fail-closed "
+        "as True. Write true or false (unquoted), or omit the key to leave the "
+        "gate off. Earlier releases read a null or empty value here as off.",
+        key,
+        type(value).__name__,
+    )
+    return True
+
+
 @dataclass(frozen=True)
 class AdmissionPolicy:
     """The fleet-controlled trust root. Never sourced from a plugin."""
@@ -276,8 +318,8 @@ class AdmissionPolicy:
         approved = d.get("approved", None)
         return AdmissionPolicy(
             mode=str(d.get("mode", MODE_OPEN)),
-            require_signature=bool(d.get("require_signature", False)),
-            require_policy_signature=bool(d.get("require_policy_signature", False)),
+            require_signature=_coerce_flag(d, "require_signature"),
+            require_policy_signature=_coerce_flag(d, "require_policy_signature"),
             trust_keys=_coerce_trust_keys(d.get("trust_keys")),
             approved=(_coerce_str_list(approved) if approved is not None else None),
             banned=_coerce_str_list(d.get("banned", [])),
@@ -456,7 +498,13 @@ def _verify_seed_integrity(policy_bytes: bytes) -> None:
             return
         expected = checksum_path.read_text(encoding="utf-8").strip()
         actual = hashlib.sha256(policy_bytes).hexdigest()
-        if not hmac.compare_digest(expected, actual):
+        # Bytes for the same reason as ``_signature_valid``: ``expected`` is
+        # text from a user-owned file, and a non-ASCII character in it would
+        # make ``hmac.compare_digest`` raise instead of reporting a mismatch.
+        if not hmac.compare_digest(
+            expected.encode("utf-8", "surrogatepass"),
+            actual.encode("utf-8", "surrogatepass"),
+        ):
             logger.error(
                 "admission policy at %s does not match its seed checksum "
                 "(modified since first-run); recording integrity event",
@@ -630,7 +678,17 @@ def _signature_valid(manifest: PluginManifest, policy: AdmissionPolicy) -> bool:
     if not secret:
         return False
     expected = hmac_signature(secret, manifest.signing_payload())
-    return hmac.compare_digest(expected, manifest.signature)
+    # Compare as BYTES: ``hmac.compare_digest`` accepts two ASCII-only strs but
+    # raises TypeError the moment either str operand carries a non-ASCII
+    # character, and ``manifest.signature`` is attacker-supplied text from the
+    # plugin's own manifest — the TypeError would escape ``evaluate_admission``
+    # on exactly the input this gate exists to refuse. Encoding both sides
+    # (``surrogatepass`` so a lone surrogate accepted by ``json.loads`` cannot
+    # crash the encode either) makes any malformed signature an ordinary False.
+    return hmac.compare_digest(
+        expected.encode("utf-8", "surrogatepass"),
+        str(manifest.signature).encode("utf-8", "surrogatepass"),
+    )
 
 
 def _capabilities_within_ceiling(

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -62,7 +62,6 @@ from kiro_crew.config.paths import config_dir
 from kiro_crew.platform.admission import (
     canonical_signing_bytes,
     hmac_signature,
-    policy_trust_root_path,
     read_policy_trust_root,
 )
 from kiro_crew.platform.context import PlatformCompositionError
@@ -2898,24 +2897,31 @@ def _policy_trust_settings() -> Tuple[bool, Dict[str, str]]:
 def _policy_signature_required() -> bool:
     """True when the admission policy explicitly opted in.
 
-    A trust root that is absent, unreadable, or not a JSON object reads as **no
-    opt-in**, and that is deliberate rather than a gap.  An attacker who can write
-    ``admission_policy.json`` is explicitly out of this feature's threat model (see
-    the threat-model note in ``docs/system-specs/modules/governance.md``) — such a
-    process would simply set the flag to ``false``, which is well-formed JSON, so
-    fail-closing on a *malformed* file only catches a clumsy version of an attack
-    the design already concedes.  What a corrupt trust root actually indicates in
-    practice is a non-atomic fleet push or a hand-edit typo — a reliability event —
-    and the useful response to that is to log loudly and behave predictably, which
-    ``read_policy_trust_root`` already does.  ``kirocrew doctor`` surfaces it.
+    Routed through :func:`_policy_trust_settings` — and thus
+    ``admission.AdmissionPolicy.from_dict`` and its strict ``_coerce_flag``
+    reader — so the opt-in flag and the ``trust_keys`` the verifier consults
+    are read by ONE parser.  Two independent readers of the same field is how
+    a well-formed trust root carrying ``"require_policy_signature": null``
+    can log a fail-closed warning on one path while the enforcement path
+    silently reads the gate as off: with the shared reader, a flag that is
+    present but not a real JSON boolean reads fail-closed as opted-IN.
+
+    A trust root that is absent, unreadable, or not a JSON object still reads
+    as **no opt-in**, and that is deliberate rather than a gap.  An attacker
+    who can write ``admission_policy.json`` is explicitly out of this
+    feature's threat model (see the threat-model note in
+    ``docs/system-specs/modules/governance.md``) — such a process would simply
+    set the flag to ``false``, which is well-formed JSON, so fail-closing on a
+    *malformed* file only catches a clumsy version of an attack the design
+    already concedes.  What a corrupt trust root actually indicates in
+    practice is a non-atomic fleet push or a hand-edit typo — a reliability
+    event — and the useful response to that is to log loudly and behave
+    predictably, which ``read_policy_trust_root`` already does.  ``kirocrew
+    doctor`` surfaces it.
 
     Never raises.
     """
-    try:
-        data = json.loads(policy_trust_root_path().read_text(encoding="utf-8"))
-    except Exception:
-        return False
-    return bool(isinstance(data, dict) and data.get("require_policy_signature", False))
+    return _policy_trust_settings()[0]
 
 
 def _audit_policy_signature(state: str, detail: str, path_label: str) -> None:

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -1651,6 +1651,23 @@ class TestPolicySignatureAbsenceGate:
             parse_policy(_policy_body(), signature_state=SIGNATURE_UNSIGNED)
         )
 
+    @pytest.mark.parametrize("junk", ["false", None, 0, 1, ""])
+    def test_junk_flag_in_wellformed_trust_root_fails_closed(
+        self, monkeypatch, tmp_path, junk
+    ):
+        # A well-formed trust root whose flag is PRESENT but not a boolean is a
+        # different case from a broken file: the operator wrote the key down, so
+        # it reads fail-closed as opted-in (via admission._coerce_flag) and an
+        # unsigned policy is refused. Locks the enforcement reader to the same
+        # strict read as the key store.
+        adm = tmp_path / "admission_policy.json"
+        adm.write_text(json.dumps({"require_policy_signature": junk}))
+        monkeypatch.setenv("KIROCREW_ADMISSION_POLICY", str(adm))
+        with pytest.raises(PlatformCompositionError):
+            assert_policy_signature_satisfied(
+                parse_policy(_policy_body(), signature_state=SIGNATURE_UNSIGNED)
+            )
+
     def test_absent_admission_file_is_a_noop(self, monkeypatch, tmp_path):
         # No trust root: nobody opted in, so an unsigned policy still loads and
         # governs (the compatibility contract) and no policy stays ungoverned.

--- a/test/test_platform_admission.py
+++ b/test/test_platform_admission.py
@@ -685,3 +685,89 @@ class TestReadPolicyTrustRoot:
         assert governance_health.governance_status() == "unknown"
         assert governance_health.last_incident() is None
         governance_health.reset()
+
+
+class TestStrictBooleanFlagCoercion:
+    """Gate flags in ``AdmissionPolicy.from_dict`` reject non-boolean JSON.
+
+    ``bool()`` on a raw JSON value turns any non-empty string (``"false"``
+    included) into ``True`` while ``null`` and ``""`` read as ``False`` — the
+    fail-open direction for an admission gate. A present-but-not-boolean value
+    must read as ON (fail-closed) with a warning; an absent key stays OFF (the
+    documented default); a real boolean is honoured.
+    """
+
+    _FLAGS = ("require_signature", "require_policy_signature")
+
+    @pytest.mark.parametrize("flag", _FLAGS)
+    def test_absent_key_reads_off(self, flag):
+        assert getattr(AdmissionPolicy.from_dict({}), flag) is False
+
+    @pytest.mark.parametrize("flag", _FLAGS)
+    @pytest.mark.parametrize("real", [True, False])
+    def test_real_boolean_is_honoured(self, flag, real):
+        assert getattr(AdmissionPolicy.from_dict({flag: real}), flag) is real
+
+    @pytest.mark.parametrize("flag", _FLAGS)
+    @pytest.mark.parametrize("junk", ["false", "true", None, "", 0, 1, []])
+    def test_present_non_boolean_reads_fail_closed_on(self, flag, junk):
+        assert getattr(AdmissionPolicy.from_dict({flag: junk}), flag) is True
+
+    @pytest.mark.parametrize("junk", ["false", None, 0, 1])
+    def test_present_non_boolean_is_warned_about(self, junk, caplog):
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="kiro_crew.platform.admission"):
+            AdmissionPolicy.from_dict({"require_policy_signature": junk})
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(
+            "require_policy_signature" in m
+            and "true or false" in m
+            and "fail-closed" in m
+            for m in messages
+        ), messages
+
+    def test_a_real_boolean_emits_no_warning(self, caplog):
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="kiro_crew.platform.admission"):
+            AdmissionPolicy.from_dict(
+                {"require_signature": True, "require_policy_signature": False}
+            )
+        assert not caplog.records
+
+
+class TestNonAsciiSignature:
+    """A malformed signature must produce an ordinary refusal, never raise.
+
+    ``hmac.compare_digest`` accepts two ASCII-only strs but raises TypeError on
+    a non-ASCII str operand, and ``manifest.signature`` is plugin-supplied text
+    — the exception would escape ``evaluate_admission`` as a generic error on
+    exactly the input the gate exists to refuse.
+    """
+
+    # Non-ASCII character plus a lone surrogate (json.loads accepts both).
+    _BAD_SIG = "d\u00ebadbeef\udc80"
+
+    def _policy(self):
+        return AdmissionPolicy(
+            mode=MODE_ENFORCE, require_signature=True, trust_keys={"p13n": "s3cret"}
+        )
+
+    def test_signature_valid_returns_false(self):
+        from kiro_crew.platform.admission import _signature_valid
+
+        m = PluginManifest(
+            name="amazon", publisher="p13n", version="1", signature=self._BAD_SIG
+        )
+        assert _signature_valid(m, self._policy()) is False
+
+    def test_a_non_ascii_signature_is_refused_not_raised(self, patch_manifest):
+        m = PluginManifest(
+            name="amazon", publisher="p13n", version="1", signature=self._BAD_SIG
+        )
+        patch_manifest(m)
+        ep = _FakeEntryPoint(name="amazon")
+        decision = evaluate_admission(ep, self._policy())
+        assert not decision.allowed
+        assert "signature" in decision.reason


### PR DESCRIPTION
## What

Two fail-open shapes in the admission trust root (`src/kiro_crew/platform/admission.py`), plus the sibling reader the review round surfaced:

1. **Strict boolean gate flags.** `AdmissionPolicy.from_dict` read `require_signature` / `require_policy_signature` with `bool(d.get(key, False))`: any non-empty string (the string `"false"` included) turned the gate ON, while explicit `null`, `""` and `0` silently turned it OFF — so a template rendering `"require_policy_signature": null` disabled the gate the operator wrote down. Both flags now go through a strict `_coerce_flag` reader (`_MISSING` sentinel): absent key → OFF (documented default), real JSON boolean → honoured, any other present value → ON (fail-closed) plus one WARNING naming the key and the received **type** (never the value — the trust root also carries `trust_keys`, and the log ring is served by `GET /api/logs`). Same shape as `governance._coerce_boot_flag` (#9176).
2. **Bytes-safe signature compare.** `_signature_valid` called `hmac.compare_digest` on `str` operands; a plugin-supplied signature containing a non-ASCII character raised `TypeError`, which escaped `evaluate_admission` as a generic exception on exactly the input the gate exists to refuse. Both operands are now encoded `utf-8` / `surrogatepass`, so any malformed signature is an ordinary `False`. The seed-integrity compare in `_verify_seed_integrity` had the same str-operand shape (`expected` comes from a user-owned sidecar file) and is hardened identically.
3. **One reader for the policy-signature opt-in** (review finding). `governance._policy_signature_required` — the reader that actually enforces `require_policy_signature` in `assert_policy_signature_satisfied` and `policy_distribution` — read the flag with its own `bool(data.get(...))`, so fixing `from_dict` alone would have left `null` still disabling enforcement while the admission-side warning claimed fail-closed. It now routes through `_policy_trust_settings()` → `read_policy_trust_root()` → the same strict `from_dict` read. The deliberate "absent / unreadable / not-a-JSON-object trust root = no opt-in" stance is unchanged (a broken FILE is a reliability event; a well-formed object with a junk FLAG value is an operator intent signal and reads fail-closed).

Docs updated in the same commit: `docs/system-specs/modules/platform-context.md` (strict gate-flag reading) and `docs/system-specs/modules/governance.md` (broken-file vs junk-flag distinction).

## Before you upgrade

A present `require_signature` / `require_policy_signature` value that is not a real JSON boolean — including explicit `null`, the string `"false"`, `0`, `1` — now **enables** the gate and logs a warning. Earlier releases read a `null`/empty value as off. If your `admission_policy.json` (or a template that renders it) writes anything but unquoted `true`/`false` for these keys, fix the value or remove the key before upgrading; otherwise plugin admission and/or policy-signature enforcement will turn on at next boot.

## Tests

- `test/test_platform_admission.py`: `TestStrictBooleanFlagCoercion` (absent → OFF; real boolean honoured; `"false"`/`"true"`/`null`/`""`/`0`/`1`/`[]` → ON; warning names the key, the remedy and is type-only; no warning on real booleans) and `TestNonAsciiSignature` (`_signature_valid` returns `False` on a signature carrying a non-ASCII char + lone surrogate; `evaluate_admission` refuses without raising).
- `test/test_governance_policy.py`: `test_junk_flag_in_wellformed_trust_root_fails_closed` (junk flag value → unsigned policy refused); the existing `test_a_broken_trust_root_reads_as_no_optin_by_design` still passes, pinning the malformed-file stance.
- Local gates: isort, flake8, mypy, diff-scoped black, comment-history, brand — all green. Test execution is left to CI per operator policy (no local test runs on this host).
- Pre-push review: two model-pinned read-only lanes; the GPT mirror reported no blocking findings, the Opus mirror reported the two blocking findings fixed as item 3 and the type-only warning above.

## Notes

- The task spec said not to touch `governance.py` (owned by #9588 for #9176). #9588 is closed and its `_coerce_boot_flag` fix is already on main; item 3 touches a different function (`_policy_signature_required`) and is required for the defect this issue names — without it `"require_policy_signature": null` still disables enforcement. Deviation disclosed deliberately.
- `CHANGELOG.md` deliberately untouched (release PR owns it per `AGENTS.md`); the upgrade note above is the disclosure.

Closes #9641. Refs #9176.

## Pattern harvest

Rule candidate: semgrep
Pattern: `bool(d.get("<flag>", ...))` on a JSON config value feeding a security gate — reads the string `"false"` as ON and `null`/`""` as OFF. Gate flags must go through a strict `isinstance(v, bool)` reader (`admission._coerce_flag`, `governance._coerce_boot_flag`). Second pattern: `hmac.compare_digest(<str>, <str>)` where either operand is externally supplied text — raises `TypeError` on non-ASCII input; compare as bytes. Third pattern (review finding): two independent readers of one trust-root field — route every consumer through the single strict parser.
