### PR TITLE
refactor(cron): share one helper for structural row removal (#10348)

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -3468,11 +3468,10 @@ class CronService:
             logger.warning("Deferred cron removals held: grant-epoch bump failed", exc_info=True)
             self._pending_removals |= pending
             return []
-        self._jobs = [j for j in self._jobs if j.id not in to_remove]
         # A Done()/delete_after_run job that self-removes retires its principal
         # just as a CLI remove does, so its children are released in the SAME
-        # save (see _release_children_of_removed).
-        restore = self._release_children_of_removed(to_remove)
+        # save (see _remove_job_rows).
+        restore = self._remove_job_rows(to_remove)
         # BACKGROUND writer: this runs inside the due-scan, so an unreadable
         # store must not abort the tick and stop every other job. The deferred
         # delete simply stays pending until the store is readable again.
@@ -3557,11 +3556,13 @@ class CronService:
         """
         with self._file_lock():
             self._sync_for_write()
-            before = len(self._jobs)
+            # Bump UNCONDITIONALLY: grant_epoch_ids() raises on corrupt epoch
+            # state, so removing even a missing id surfaces that corruption
+            # instead of answering a quiet False. The bump reads live rows, so
+            # it must precede the filter inside _remove_job_rows.
             self._bump_grant_epochs_for({job_id})
-            self._jobs = [j for j in self._jobs if j.id != job_id]
-            if len(self._jobs) < before:
-                restore = self._release_children_of_removed({job_id})
+            if any(j.id == job_id for j in self._jobs):
+                restore = self._remove_job_rows({job_id})
                 try:
                     self._save()
                 except BaseException:
@@ -3579,6 +3580,26 @@ class CronService:
                 logger.info("Removed cron job %s", job_id)
                 return True
         return False
+
+    def _remove_job_rows(self, removed_ids: set[str]) -> list[tuple[CronJob, str]]:
+        """Filter ``removed_ids`` out of ``self._jobs`` and cascade the release.
+
+        The ONLY sanctioned spelling of a structural remove. Every site that
+        drops a job's row from ``self._jobs`` must route through this helper so
+        the removal and the release of the removed jobs' children land in the
+        SAME save -- a bare list-comprehension filter compiles and passes tests
+        while silently skipping the cascade, stranding every child the removed
+        cron owns. ``test_cron_remove_rows_structural.py`` fails any filter
+        site that bypasses this helper.
+
+        Same contract as :meth:`_release_children_of_removed`: IN-LOCK ONLY,
+        after ``_sync_for_write()``; the caller must ``_save()`` afterwards and
+        on save failure restore the returned ``(job, previous_owner)`` pairs
+        (and reset the fingerprint where its path requires it). Grant-epoch
+        bumps read the live rows, so callers bump BEFORE calling this.
+        """
+        self._jobs = [j for j in self._jobs if j.id not in removed_ids]
+        return self._release_children_of_removed(removed_ids)
 
     def _release_children_of_removed(self, removed_ids: set[str]) -> list[tuple[CronJob, str]]:
         """Clear ownership on jobs whose cron principal is among ``removed_ids``.
@@ -3652,8 +3673,7 @@ class CronService:
                     missing.append(jid)
             if targets:
                 self._bump_grant_epochs_for(targets)
-                self._jobs = [j for j in self._jobs if j.id not in targets]
-                restore = self._release_children_of_removed(targets)
+                restore = self._remove_job_rows(targets)
                 try:
                     self._save()
                 except BaseException:
@@ -3772,8 +3792,7 @@ class CronService:
             if removed:
                 targets = set(removed)
                 self._bump_grant_epochs_for(targets)
-                self._jobs = [j for j in self._jobs if j.id not in targets]
-                restore = self._release_children_of_removed(targets)
+                restore = self._remove_job_rows(targets)
                 try:
                     self._save()
                 except BaseException:
@@ -5160,14 +5179,14 @@ class CronService:
                         by_id[job.id].user_paused = True
                     self._pending_removals.add(job.id)
                 else:
-                    self._jobs = [j for j in self._jobs if j.id != job.id]
-                    consumed_row = True
                     # Consuming the one-shot retires its principal cron:<job id>,
                     # so a child that job created is released in the SAME save --
-                    # the fifth removal core alongside the four locked cores. Runs
-                    # after the row is filtered out so the job cannot release
-                    # itself; rolled back below if the save fails.
-                    restore = self._release_children_of_removed({job.id})
+                    # the fifth removal core alongside the four locked cores.
+                    # _remove_job_rows filters the row out before releasing so
+                    # the job cannot release itself; rolled back below if the
+                    # save fails.
+                    restore = self._remove_job_rows({job.id})
+                    consumed_row = True
             # BACKGROUND writer: a job has already run, so an unreadable store
             # must not surface as a job-runner crash. The run result is lost,
             # which is strictly better than clobbering the store.

--- a/test/test_cron_remove_rows_structural.py
+++ b/test/test_cron_remove_rows_structural.py
@@ -1,0 +1,173 @@
+"""Every structural remove of a cron row must route through _remove_job_rows.
+
+Removing a cron retires its principal ``cron:<job id>``; the removal and the
+release of the jobs that principal owned must land in the SAME save, or every
+child of the removed cron strands -- owned by a principal no session can ever
+present again, unlistable, unremovable, still firing. A bare
+``self._jobs = [j for j in self._jobs if ...]`` filter compiles, passes tests,
+and silently skips that cascade.
+
+``_remove_job_rows`` is the only sanctioned spelling: it filters the rows out
+and calls ``_release_children_of_removed`` in one place. The AST scan here
+flags EVERY write to ``self._jobs`` -- assignment in any form (plain, slice,
+subscript, augmented, annotated), ``del``, and mutating method calls -- and
+fails unless the enclosing function is on the explicit allowlist, so a rogue
+remover cannot skip the cascade in ANY spelling: the direct filter, the
+two-step ``keep = [...]; self._jobs = keep`` form, ``self._jobs[:] = [...]``,
+a ``.remove()`` loop, ``list(filter(...))``, or a rebuild from an index.
+Out of static reach by nature: mutating through a local alias
+(``jobs = self._jobs; jobs.remove(...)``) -- nothing in cron.py does this, and
+a reviewer seeing an alias of ``self._jobs`` should treat it as the same
+violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import kiro_crew.cron as cron_module
+from kiro_crew.cron import CronService
+
+SANCTIONED_HELPER = "_remove_job_rows"
+
+# Functions allowed to write self._jobs, and why. Adding a name here is a
+# review decision: the new writer must either not remove live rows, or route
+# removals through _remove_job_rows.
+ALLOWED_WRITERS = {
+    SANCTIONED_HELPER,  # the one sanctioned structural remover
+    "__init__",  # initial empty list, no rows exist yet
+    "_sync",  # rebuilds the cache from disk, not a removal decision
+    "_load",  # rebuilds from disk; its malformed-entry skip is outside this gate
+    "_persist_add_if_absent_locked",  # append-only add
+    "_persist_add_locked",  # append-only add
+}
+
+_MUTATING_METHODS = {
+    "pop",
+    "remove",
+    "clear",
+    "insert",
+    "append",
+    "extend",
+    "sort",
+    "reverse",
+}
+
+
+def _is_self_jobs(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "_jobs"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    )
+
+
+def _touches_self_jobs(target: ast.expr) -> bool:
+    """True for ``self._jobs`` itself and for ``self._jobs[...]`` subscripts."""
+    if isinstance(target, ast.Subscript):
+        return _is_self_jobs(target.value)
+    return _is_self_jobs(target)
+
+
+def _jobs_writes_by_function(tree: ast.Module) -> dict[str, list[str]]:
+    """Map enclosing function name -> descriptions of self._jobs writes."""
+    writes: dict[str, list[str]] = {}
+
+    def record(func_name: str, lineno: int, kind: str) -> None:
+        writes.setdefault(func_name, []).append(f"line {lineno}: {kind}")
+
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(func):
+            if isinstance(node, ast.Assign):
+                if any(_touches_self_jobs(t) for t in node.targets):
+                    record(func.name, node.lineno, "assignment")
+            elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+                if _touches_self_jobs(node.target):
+                    record(func.name, node.lineno, "assignment")
+            elif isinstance(node, ast.Delete):
+                if any(_touches_self_jobs(t) for t in node.targets):
+                    record(func.name, node.lineno, "del")
+            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if node.func.attr in _MUTATING_METHODS and _is_self_jobs(node.func.value):
+                    record(func.name, node.lineno, f".{node.func.attr}() call")
+    return writes
+
+
+def test_every_self_jobs_write_is_allowlisted():
+    source = inspect.getsource(cron_module)
+    tree = ast.parse(source, filename=str(Path(cron_module.__file__)))
+    writes = _jobs_writes_by_function(tree)
+    assert SANCTIONED_HELPER in writes, (
+        "expected the sanctioned helper's own filter assignment to be found; "
+        "if it was renamed, update SANCTIONED_HELPER and ALLOWED_WRITERS"
+    )
+    rogue = {name: sites for name, sites in writes.items() if name not in ALLOWED_WRITERS}
+    assert not rogue, (
+        f"self._jobs is written outside the allowlist: {rogue}. Dropping a row "
+        "from self._jobs without _release_children_of_removed strands every "
+        "job the removed cron owned (unlistable, unremovable, still firing) -- "
+        f"route structural removals through {SANCTIONED_HELPER}, or if the new "
+        "write is provably not a removal, add it to ALLOWED_WRITERS with a "
+        "reason."
+    )
+
+
+def test_helper_itself_calls_the_cascade_release():
+    source = inspect.getsource(getattr(CronService, SANCTIONED_HELPER))
+    tree = ast.parse(source.lstrip())
+    calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    assert "_release_children_of_removed" in calls, (
+        f"{SANCTIONED_HELPER} must call _release_children_of_removed so every "
+        "routed removal releases the removed jobs' children in the same save"
+    )
+
+
+def test_scan_catches_rogue_remover_spellings():
+    """The gate must flag every remover spelling a sixth site could use."""
+    spellings = {
+        "direct_filter": "self._jobs = [j for j in self._jobs if j.id not in ids]",
+        "two_step_local": (
+            "keep = [j for j in self._jobs if j.id not in ids]\n" "        self._jobs = keep"
+        ),
+        "slice_assignment": ("self._jobs[:] = [j for j in self._jobs if j.id not in ids]"),
+        "remove_loop": (
+            "for j in list(self._jobs):\n"
+            "            if j.id in ids:\n"
+            "                self._jobs.remove(j)"
+        ),
+        "filter_call": ("self._jobs = list(filter(lambda j: j.id not in ids, self._jobs))"),
+        "rebuild_from_index": "self._jobs = [by_id[i] for i in keep_ids]",
+        "del_subscript": "del self._jobs[0]",
+        "pop_call": "self._jobs.pop()",
+    }
+    for name, body in spellings.items():
+        src = f"class C:\n    def _rogue_remover(self, ids):\n        {body}\n"
+        writes = _jobs_writes_by_function(ast.parse(src))
+        assert "_rogue_remover" in writes, f"scan missed rogue remover spelling {name!r}: {body!r}"
+
+
+def test_remove_job_rows_filters_rows_and_returns_rollback(tmp_path):
+    service = CronService(base_dir=tmp_path)
+    parent = service.add_job("parent", "run", every_secs=3600)
+    child = service.add_job("child", "run", every_secs=3600, session_key=f"cron:{parent.id}")
+    bystander = service.add_job("bystander", "run", every_secs=3600, session_key="dashboard:x")
+
+    restore = service._remove_job_rows({parent.id})
+
+    remaining = {j.id for j in service._jobs}
+    assert parent.id not in remaining, "removed row must be filtered out"
+    assert {child.id, bystander.id} <= remaining, "children are released, never deleted"
+    assert child.session_key == "", "child of the removed cron must drop to ownerless"
+    assert bystander.session_key == "dashboard:x", "unrelated owners are untouched"
+    assert restore == [
+        (child, f"cron:{parent.id}")
+    ], "rollback list must name each released child with its previous owner"


### PR DESCRIPTION
## Problem / Motivation

Every site that filters a job's row out of `self._jobs` must release the jobs that cron owned in the same atomic save. Four locked removal cores did; the fifth (`_merge_job_result`, #9282, fixed in #10340) shipped without the cascade and was caught only by review. Nothing structurally prevents a sixth remover from repeating the omission.

## Why it matters

A remover that skips the cascade strands every child of the removed cron: owned by a `cron:<job id>` principal no session can ever present again, so `cron_list` omits it and `cron_update`/`cron_remove` answer "job not found" while it keeps firing on schedule. This class of bug has now shipped once and been caught in review once; the next one may do neither.

## What changed (motivation -> approach -> change)

Symptom: each new structural remover must remember to pair its filter with `_release_children_of_removed`, and one already forgot. Root cause: the pairing is a convention, not a structure -- a bare list-comprehension filter compiles, passes tests, and drops the cascade.

The pairing is now a structure. `_remove_job_rows(removed_ids)` filters `self._jobs` and calls `_release_children_of_removed` in one place, returning the rollback list; all five structural removers (the deferred-removal drain, `_remove_job_locked`, `_remove_jobs_locked`, `_remove_jobs_by_owner_locked`, and the `_merge_job_result` one-shot consume) route through it. Each site's save-failure rollback and fingerprint-reset handling is untouched, and grant-epoch bumps still run before the filter (they read live rows). A structural AST test flags EVERY write to `self._jobs` -- assignment in any spelling (direct filter, two-step local, slice, subscript), `del`, and mutating method calls -- and fails unless the enclosing function is on an explicit allowlist, so a sixth remover cannot bypass the helper in any spelling without failing the suite.

Two pre-push review rounds (GPT and Opus model-pinned reviewers) hardened this: the scan was widened from listcomp-filters-only to the full write surface after both reviewers produced rogue spellings that slipped the first version, and `_remove_job_locked` keeps its unconditional grant-epoch bump so removing a missing id still surfaces corrupt epoch state instead of answering a quiet False.

## Tests

- `test/test_cron_remove_rows_structural.py` (new): allowlist scan over every `self._jobs` write; a rogue-spelling matrix (two-step, slice, `.remove()` loop, `filter()`, index rebuild, `del`, `.pop()`) proving the scan catches each; helper-calls-cascade assertion; behavioral test locking the helper's release-and-rollback contract.
- `test/test_cron_merge_result_cascade.py` (from #10340) passes unchanged through the new routing, as do the scoped cron suites covering the four locked cores (312 tests: removal audit seam, store-unreadable boundaries, secret-env grant epochs, locking regression, delete handlers).
- Gates: `isort --check-only`, `flake8`, `mypy src/kiro_crew/` all clean.

## Manual verification

Not applicable -- no user-facing surface changed; behavior preservation at all five sites is pinned by the existing scoped suites listed above.

## Screenshots / video

Not applicable (backend-only refactor).

## Related Issues

Closes #10348

## Pattern harvest

A convention that every call site must remember ("pair the filter with the release") became a defect the second a fifth site was added. Replacing the convention with one sanctioned helper plus an AST allowlist test converts "remember to pair" into "cannot compile past CI unpaired" -- the same shape as routing all privileged writes through one audited seam. Reviewer-driven hardening mattered: the first scan caught only the spelling the last bug used; adversarial rogue-spelling probes from two reviewers widened it to the whole write surface.

## Checklist

- [x] Single commit, conventional title
- [x] Backend gates green (isort, flake8, mypy, scoped pytest)
- [x] Spec/docs impact checked (no doc documents the removal cores; comments updated in-code)

## Contribution License Agreement

By submitting this pull request, I confirm my contribution is made under the terms of the project's license.
