### PR TITLE
feat: configurable Telegram Bot API base URL for proxy setups

### DIFF
--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -4674,8 +4674,13 @@ async def _validate_telegram_token(token: str) -> str | None:
     import aiohttp  # noqa: F811
 
     timeout = aiohttp.ClientTimeout(total=_TOKEN_VERIFY_TIMEOUT)
+    _tg_base = os.environ.get(
+        "TELEGRAM_API_BASE_URL",
+        "https://api.telegram.org/bot{token}/{method}",
+    )
+    verify_url = _tg_base.format(token=token, method="getMe")
     async with aiohttp.ClientSession(timeout=timeout) as session:
-        async with session.get(f"https://api.telegram.org/bot{token}/getMe") as resp:
+        async with session.get(verify_url) as resp:
             data = await resp.json(content_type=None)
             if isinstance(data, dict) and data.get("ok"):
                 return None

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -218,6 +218,17 @@ Everything lives in the `telegram` section of `config.json`:
 Prefer the `TELEGRAM_BOT_TOKEN` env var over `bot_token` — it keeps your secret
 out of `config.json`.
 
+**Behind a network that blocks `api.telegram.org`?** Set `TELEGRAM_API_BASE_URL`
+to a reverse proxy that forwards to the Bot API. It is a full method template
+containing `{token}` and `{method}`, e.g.
+`https://your-proxy.example.com/bot{token}/{method}`. When set, it is used for
+all Bot API method calls, the dashboard's token verification (`getMe`), and
+file/photo downloads (whose origin is derived from it). When unset, everything
+uses the public `https://api.telegram.org` host exactly as before. This is
+distinct from `HTTPS_PROXY`: use `HTTPS_PROXY` for an ordinary forward proxy, and
+`TELEGRAM_API_BASE_URL` when the API host itself must be swapped for a
+reverse-proxy origin.
+
 **If something's off:** no reply usually means your ID isn't allowed or
 `enabled` is `false`; a missing `Telegram channel started` line means the token
 isn't set; slow replies behind a proxy mean you should set `HTTPS_PROXY` for the

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -191,8 +191,25 @@ TELEGRAM_CHUNK_LIMIT = 4000
 #: table-bearing segments are budgeted against this cap, not the render cap.
 TELEGRAM_RICH_MAX_CHARS = 32768
 
-# Bot API base URL.
-_API_BASE = "https://api.telegram.org/bot{token}/{method}"
+# Bot API base URL. Override with TELEGRAM_API_BASE_URL for proxy/reverse-proxy
+# setups (e.g. a network that blocks api.telegram.org). Must be a full method
+# template containing {token} and {method}; unset falls back to the public host.
+_API_BASE = os.environ.get(
+    "TELEGRAM_API_BASE_URL",
+    "https://api.telegram.org/bot{token}/{method}",
+)
+
+
+def _file_base() -> str:
+    """Origin (scheme + host) for Telegram file downloads.
+
+    Derived from ``_API_BASE`` so that a configured proxy also serves
+    ``/file/bot<token>/<path>`` downloads; falls back to the public host when
+    ``TELEGRAM_API_BASE_URL`` is unset or unparseable.
+    """
+    m = re.match(r"^(https?://[^/]+)", _API_BASE)
+    return m.group(1) if m else "https://api.telegram.org"
+
 
 #: Consecutive polling failures before the status callback reports unhealthy.
 _STATUS_FAILURE_THRESHOLD = 3
@@ -1202,7 +1219,7 @@ class TelegramClient:
         if not file_path:
             raise ValueError(f"getFile returned empty file_path for file_id={file_id!r}")
 
-        url = f"https://api.telegram.org/file/bot{self._token}/{file_path}"
+        url = f"{_file_base()}/file/bot{self._token}/{file_path}"
 
         session = await self._ensure_session()
         try:


### PR DESCRIPTION
Closes #10354.

## Problem / Motivation

On some networks `api.telegram.org` is blocked by DPI (TCP connects but the TLS
handshake is dropped), so the Telegram integration cannot connect at all — the
bot silently fails to send or receive. The Bot API host is hardcoded, so there
is no way to point the client at a reverse proxy that forwards to Telegram.

## Why it matters

Anyone on such a network currently cannot use the Telegram integration at all.
A thin reverse proxy (e.g. a Cloudflare Worker) is the standard workaround, but
it only works if the client's base URL is configurable. This unblocks those
deployments with a purely additive, opt-in change.

## What changed (motivation → approach → change)

Goal: let a proxied deployment reach the Bot API without changing default
behavior. Approach: a single environment variable that overrides the base URL,
with the file-download origin derived from it so the whole surface (methods,
token verification, media downloads) goes through the proxy consistently; unset
means today's public host. No config-schema change, no protocol change.

- **`telegram/client.py`** — `_API_BASE` now reads `TELEGRAM_API_BASE_URL`
  (a full method template with `{token}`/`{method}`), falling back to the public
  host. New module-level `_file_base()` derives the download origin (scheme +
  host) from `_API_BASE` so `/file/bot<token>/<path>` downloads also traverse the
  proxy, falling back to `https://api.telegram.org`.
- **`dashboard/handlers/messaging.py`** — the dashboard's `getMe` token-verify
  URL is built from the same env var, so verification works on a proxied install.
- **`src/kiro_crew/docs/telegram-integration.md`** — documents the variable and
  how it differs from `HTTPS_PROXY` (same commit).

## Tests

- Telegram suites pass locally with the change: `test_telegram`,
  `test_telegram_attachments`, `test_telegram_config_handlers`,
  `test_telegram_parity` (700+ tests, all green).
- `isort`, `flake8`, `mypy` clean on the changed files.

## Manual verification

Running in production on 0.6.0 against a Cloudflare Worker reverse proxy on a
network that blocks `api.telegram.org`: with `TELEGRAM_API_BASE_URL` set, Bot API
method calls, `getMe` token verification, and photo/file downloads all succeed
through the proxy. With the variable unset, all traffic uses
`https://api.telegram.org` exactly as before. File downloads keep
`allow_redirects=False`, so the proxy indirection adds no new SSRF surface.
