### PR TITLE
fix: persist Files tab expansion and filter across remounts (#9653)

### DIFF
--- a/website/src/pages/chat/FileBrowserRail.tsx
+++ b/website/src/pages/chat/FileBrowserRail.tsx
@@ -19,6 +19,30 @@ const RAIL_W_KEY = 'mc-files-rail-w'
  *  defaults to All files. */
 let sessionChangedMode = false
 
+/** Filter text for the current page session, keyed by project directory.
+ *  Module-level like `sessionChangedMode` (and deliberately NOT localStorage:
+ *  a filter is session-scoped intent, and a stale filter surviving a page
+ *  reload would hide the tree with no visible reason): in-place tab
+ *  navigation remounts the rail and the typed filter must survive that. */
+const sessionQuery = new Map<string, string>()
+
+/** Cap on remembered project entries, mirroring the expansion memory's dir
+ *  cap: delete-then-set keeps insertion order least-recently-written-first,
+ *  so a long-lived tab drops the stalest project's filter, not the newest. */
+const MAX_SESSION_QUERY_DIRS = 20
+function rememberQuery(projectDir: string, value: string): void {
+  sessionQuery.delete(projectDir)
+  // An empty filter is indistinguishable from no entry: storing it would
+  // occupy an LRU slot (evicting some other project's live filter) for
+  // nothing, so clearing removes the entry outright.
+  if (value === '') return
+  sessionQuery.set(projectDir, value)
+  for (const k of sessionQuery.keys()) {
+    if (sessionQuery.size <= MAX_SESSION_QUERY_DIRS) break
+    sessionQuery.delete(k)
+  }
+}
+
 /** Whether the tree APIs answer for this directory. Shares the tree
  *  component's query key, so the probe costs no extra request. */
 /**
@@ -72,7 +96,20 @@ export default function FileBrowserRail({ projectDir, onFileOpen, onAddToContext
     sessionChangedMode = v
     _setChangedMode(v)
   }
-  const [query, setQuery] = useState('')
+  const [query, _setQuery] = useState(() => sessionQuery.get(projectDir) ?? '')
+  // Rehydrate on an in-place projectDir change (React's adjust-state-on-prop
+  // pattern, synchronous before paint): `useState` reads the map only on the
+  // first mount, and without this a new project would inherit — and then
+  // store under its own key — the previous project's filter.
+  const [queryDir, setQueryDir] = useState(projectDir)
+  if (queryDir !== projectDir) {
+    setQueryDir(projectDir)
+    _setQuery(sessionQuery.get(projectDir) ?? '')
+  }
+  const setQuery = (v: string) => {
+    rememberQuery(projectDir, v)
+    _setQuery(v)
+  }
 
   const { data: status, isError: statusError } = useQuery({
     queryKey: ['git-status', projectDir],
@@ -200,10 +237,8 @@ export default function FileBrowserRail({ projectDir, onFileOpen, onAddToContext
           <PierreWorkspaceTree
             mode={changedMode ? 'changed' : 'all'}
             projectDir={projectDir}
-            onFileOpen={(abs) => {
-              setQuery('')
-              onFileOpen(abs, changedMode)
-            }}
+            persistExpansion
+            onFileOpen={(abs) => onFileOpen(abs, changedMode)}
             onAddToContext={onAddToContext}
             searchQuery={query || null}
             selectedPath={selectedPath ?? null}

--- a/website/src/pierre/PierreWorkspaceTreeImpl.tsx
+++ b/website/src/pierre/PierreWorkspaceTreeImpl.tsx
@@ -27,6 +27,7 @@ import { useMenuKeyboard } from '../hooks/useMenuKeyboard'
 import { i18nT } from '../i18n/t'
 import { useFileMenuItems, visibleFileMenuItems, invokeFileMenuItem, FileMenuItemIcon, FileMenuItemLabel, type ContributedFileMenuItem, type ReportFileMenuError } from '../apps/fileMenuContributions'
 import { normalizeWindowsPath } from '../utils/fileTokens'
+import { recallExpandedPaths, rememberExpandedPaths } from './treeExpansionMemory'
 import { TreeSkeleton } from './tree'
 
 /** The kind vocabulary the composer's `@`-mention plumbing speaks: a file is
@@ -265,7 +266,7 @@ function TreeContextMenu({ item, context, root, onAddToContext, contribItems, on
   }
 }
 
-export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext, searchQuery, mode = 'all', selectedPath }: {
+export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext, searchQuery, mode = 'all', selectedPath, persistExpansion = false }: {
   projectDir: string
   onFileOpen?: (absPath: string) => void
   /** Right-click "Add to context" on a row: hands the host the ABSOLUTE path
@@ -284,6 +285,11 @@ export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext
    *  selection (and scrolled into view). Selection changes caused by this
    *  prop never re-fire `onFileOpen`. */
   selectedPath?: string | null
+  /** Remember and restore the expanded directories across remounts (keyed by
+   *  `projectDir`, see `./treeExpansionMemory`). Opt-in per host so the other
+   *  hosts of this shared tree keep their collapsed-by-default behavior.
+   *  Applies to `all` mode only: `changed` mode starts fully open by design. */
+  persistExpansion?: boolean
 }) {
   // Whether any app contributes a 'tree-context' row at all — gates whether the
   // tree wires a context menu (per-node `when` filtering happens in the menu).
@@ -379,15 +385,114 @@ export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext
   // the same pre-paint pass so the first visible frame is already correct.
   const pathsKey = useMemo(() => paths.join('\n'), [paths])
   const lastPathsKey = useRef<string | null>(null)
+  // Expansion persists for `all` mode only: `changed` mode starts fully open
+  // by design and holds a handful of paths, so there is nothing to remember.
+  const remembersExpansion = persistExpansion && mode === 'all'
+  // Directory set of the current payload, for the capture below: remembered
+  // directories NOT in this set are temporarily absent (truncated payload,
+  // another branch checked out) and must survive a snapshot rather than be
+  // erased by it.
+  const payloadDirsRef = useRef<Set<string> | null>(null)
   useLayoutEffect(() => {
     if (!ready) return
     if (lastPathsKey.current === pathsKey) return
     lastPathsKey.current = pathsKey
-    model.resetPaths(paths)
-  }, [ready, paths, pathsKey, model])
+    if (!remembersExpansion) {
+      model.resetPaths(paths)
+      return
+    }
+    const dirs = new Set<string>()
+    for (const p of paths) {
+      const segments = p.split('/')
+      for (let i = 1; i < segments.length; i++) dirs.add(segments.slice(0, i).join('/'))
+    }
+    payloadDirsRef.current = dirs
+    // Restore the remembered expansion (see `./treeExpansionMemory`): the rail
+    // remounts on in-place tab navigation and the model is created per mount,
+    // so without this every file open collapses the tree back to the root.
+    // The ARGUMENT is filtered to directories present in this payload (the
+    // controller tolerates unknown paths, but there is nothing to expand);
+    // the remembered set itself keeps absent entries — see the capture below.
+    const remembered = recallExpandedPaths(projectDir)
+    const alive = remembered.filter(d => dirs.has(d))
+    if (alive.length > 0) {
+      model.resetPaths(paths, { initialExpandedPaths: alive })
+    } else {
+      model.resetPaths(paths)
+    }
+  }, [ready, paths, pathsKey, model, remembersExpansion, projectDir])
   useEffect(() => {
     model.setGitStatus(statusEntries)
   }, [statusEntries, model])
+
+  // Capture the expanded directory set on every model notification so the next
+  // mount can restore it. Skipped while a search is active: the search session
+  // expands matches transiently, and persisting that would restore an
+  // unrelated expansion after the filter is cleared. Known limitation, noted
+  // deliberately: a directory expanded under a collapsed ancestor is not
+  // visible, so it drops out of the remembered set — acceptable, since
+  // re-expanding the ancestor is what the user does on return anyway.
+  const searchQueryRef = useRef(searchQuery)
+  searchQueryRef.current = searchQuery
+  const lastSnapshotKey = useRef<string | null>(null)
+  const lastVisibleCount = useRef<number | null>(null)
+  useEffect(() => {
+    if (!remembersExpansion) return
+    const unsubscribe = model.subscribe(() => {
+      if (searchQueryRef.current) {
+        // A search session expands matches transiently, so nothing is
+        // captured while it is active — and the count on exit may match the
+        // count on entry, so the pre-filter below must not swallow the first
+        // post-search notification.
+        lastVisibleCount.current = null
+        return
+      }
+      const count = model.getVisibleCount()
+      // A model that currently holds no rows — a transient empty `project-tree`
+      // payload, or the window before the first payload lands — carries no
+      // expansion information: writing its empty set would erase the memory.
+      // In `all` mode a non-empty payload always keeps top-level rows visible,
+      // so zero visible rows can only mean an empty model, never the user
+      // collapsing everything.
+      if (count === 0) return
+      // Focus, selection, and git-status notifications far outnumber
+      // expansion changes, and materializing every visible row on each one
+      // defeats the tree's virtualization on a large workspace. With
+      // `flattenEmptyDirectories` an expand/collapse always changes the
+      // visible count, so an unchanged count means an unchanged expansion —
+      // skip the O(visible rows) scan entirely.
+      if (lastVisibleCount.current === count) return
+      lastVisibleCount.current = count
+      const rows = model.getVisibleRows(0, count)
+      const expanded: string[] = []
+      for (const row of rows) {
+        // Directory rows come back with the library's canonical trailing
+        // slash; strip it so the remembered paths compare equal to the
+        // payload-derived directory prefixes on restore.
+        if (row.kind === 'directory' && row.isExpanded) expanded.push(row.path.replace(/\/$/, ''))
+      }
+      // A visible-row scan can only see directories the current payload
+      // holds. A remembered directory absent from the payload — beyond the
+      // backend's truncation cap, or gone on the currently checked-out
+      // branch — is not evidence of a collapse: carry it forward so a
+      // transient absence cannot permanently erase it. A genuinely deleted
+      // directory is carried indefinitely and dropped only when the
+      // per-project path cap truncates the tail — the cost of never being
+      // able to tell "deleted" from "temporarily absent" here.
+      const payloadDirs = payloadDirsRef.current
+      if (payloadDirs) {
+        for (const d of recallExpandedPaths(projectDir)) {
+          if (!payloadDirs.has(d)) expanded.push(d)
+        }
+      }
+      // Skip the write when the set is unchanged to avoid storage churn.
+      const key = expanded.join('\n')
+      if (lastSnapshotKey.current === key) return
+      lastSnapshotKey.current = key
+      rememberExpandedPaths(projectDir, expanded)
+    })
+    return unsubscribe
+  }, [remembersExpansion, model, projectDir])
 
   // Forward the panel's shared search box into the tree's search session.
   useLayoutEffect(() => {

--- a/website/src/pierre/tree.tsx
+++ b/website/src/pierre/tree.tsx
@@ -35,7 +35,7 @@ export function TreeSkeleton() {
   )
 }
 
-export function PierreWorkspaceTree({ projectDir, onFileOpen, onAddToContext, searchQuery, mode, selectedPath }: {
+export function PierreWorkspaceTree({ projectDir, onFileOpen, onAddToContext, searchQuery, mode, selectedPath, persistExpansion }: {
   projectDir: string
   onFileOpen?: (absPath: string) => void
   /** Right-click "Add to context" on a row — forwards the ABSOLUTE path and
@@ -47,10 +47,20 @@ export function PierreWorkspaceTree({ projectDir, onFileOpen, onAddToContext, se
   mode?: 'all' | 'changed'
   /** Absolute path of the host's open file — echoed as the tree selection. */
   selectedPath?: string | null
+  /** Remember and restore expanded directories across remounts (all mode only).
+   *  Opt-in per host; hosts that omit it keep collapsed-by-default. */
+  persistExpansion?: boolean
 }) {
+  // Remount on mode change: initial expansion is fixed at model creation.
+  // A persisting host also remounts on an in-place projectDir change — the
+  // model, the reset guard, and the capture subscription are all per-instance,
+  // so reusing them across projects would leak one project's expansion into
+  // another's view (and into its remembered set). Hosts that do not persist
+  // keep the mode-only key, and with it their exact current behavior.
+  const key = persistExpansion ? [mode ?? 'all', projectDir].join('\u0000') : (mode ?? 'all')
   return (
     <Suspense fallback={<TreeSkeleton />}>
-      <TreeImpl key={mode ?? 'all'} projectDir={projectDir} onFileOpen={onFileOpen} onAddToContext={onAddToContext} searchQuery={searchQuery} mode={mode} selectedPath={selectedPath} />
+      <TreeImpl key={key} projectDir={projectDir} onFileOpen={onFileOpen} onAddToContext={onAddToContext} searchQuery={searchQuery} mode={mode} selectedPath={selectedPath} persistExpansion={persistExpansion} />
     </Suspense>
   )
 }

--- a/website/src/pierre/treeExpansionMemory.ts
+++ b/website/src/pierre/treeExpansionMemory.ts
@@ -1,0 +1,112 @@
+/**
+ * Remembered expansion state for the workspace file tree, keyed by project
+ * directory.
+ *
+ * The Files tab mounts only while active, so in-place tab navigation (opening
+ * a file focuses the file's tab) unmounts and remounts the whole tree, and the
+ * tree model is created per mount. Sibling rail state already survives that
+ * remount — the All/Changed mode through a module-scope variable, the rail
+ * width through `localStorage`. This module is the expansion's equivalent:
+ * a module-scope map for the page session, mirrored to `localStorage` so a
+ * page reload keeps it too — without it, every remount starts fully
+ * collapsed and every file open costs re-expanding the path from the root.
+ *
+ * Paths are the project-relative POSIX directory paths the tree model itself
+ * speaks (`resetPaths` input, and `FileTreeVisibleRow.path` with the library's
+ * trailing directory slash stripped), so a `project-tree` refetch that
+ * rebuilds the snapshot with fresh node ids cannot invalidate them. Storage
+ * access is best-effort: private mode or a full quota degrades to
+ * session-only memory, never to a crash — the same tolerance the rail width
+ * code has for a bad stored value.
+ */
+
+/** One storage key for every project directory, holding a `{ dir: paths }`
+ *  record in least-recently-written-first insertion order. A key per project
+ *  dir would grow the origin's quota use without bound; one record with an
+ *  LRU cap keeps the footprint fixed. */
+const STORAGE_KEY = 'mc-files-tree-expanded'
+
+/** Cap on remembered project directories: the least recently written entry is
+ *  evicted past this, so an old project only costs its restored state. */
+const MAX_REMEMBERED_DIRS = 20
+
+/** Cap on remembered paths per project: a pathological workspace with
+ *  thousands of expanded directories must not bloat `localStorage`. Dropping
+ *  the tail only costs those directories their restored state. */
+const MAX_REMEMBERED_PATHS = 500
+
+/** Expansion for the current page session. Module-level so it survives the
+ *  rail's remount on in-place tab navigation. Bounded like the stored record:
+ *  a long-lived tab must not retain an entry per project dir ever visited. */
+const sessionExpansion = new Map<string, readonly string[]>()
+
+/** Delete-then-set keeps insertion order meaning "least recently written
+ *  first"; evicting the first key past the cap then drops the stalest. */
+function setBounded(map: Map<string, readonly string[]>, key: string, value: readonly string[]): void {
+  map.delete(key)
+  map.set(key, value)
+  for (const k of map.keys()) {
+    if (map.size <= MAX_REMEMBERED_DIRS) break
+    map.delete(k)
+  }
+}
+
+/** Read the whole stored record. `{}` for a missing or malformed value;
+ *  `null` when storage itself is unusable (so a write should not follow). */
+function readStore(): Record<string, unknown> | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    return parsed as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+/** Remember the expanded directory set for a project directory.
+ *
+ *  The mirror write serializes the whole record synchronously. Accepted
+ *  deliberately: the caller only invokes this on a REAL expansion change
+ *  (user-paced clicks, deduped upstream), and one JSON.stringify of a
+ *  20x500-capped record is far below frame budget on those. Deferring the
+ *  write would add a lost-on-navigation window for no felt gain. */
+export function rememberExpandedPaths(projectDir: string, expanded: readonly string[]): void {
+  const capped = expanded.slice(0, MAX_REMEMBERED_PATHS)
+  setBounded(sessionExpansion, projectDir, capped)
+  const store = readStore()
+  if (store === null) return
+  // Delete-then-set keeps insertion order meaning "least recently written
+  // first", so eviction below always drops the stalest project.
+  delete store[projectDir]
+  store[projectDir] = capped
+  const dirs = Object.keys(store)
+  for (let i = 0; i < dirs.length - MAX_REMEMBERED_DIRS; i++) delete store[dirs[i]]
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store))
+  } catch {
+    // Private mode / quota exceeded: the session map above still covers the
+    // remount case, only reload persistence is lost.
+  }
+}
+
+/** Recall the remembered expanded directory set for a project directory:
+ *  session map first, then `localStorage`, then empty. */
+export function recallExpandedPaths(projectDir: string): readonly string[] {
+  const inSession = sessionExpansion.get(projectDir)
+  if (inSession) return inSession
+  const store = readStore()
+  const entry = store?.[projectDir]
+  if (!Array.isArray(entry)) return []
+  const paths = entry
+    .filter((p): p is string => typeof p === 'string')
+    .slice(0, MAX_REMEMBERED_PATHS)
+  setBounded(sessionExpansion, projectDir, paths)
+  return paths
+}
+
+/** Test-only: drop the module-scope session map so suites stay isolated. */
+export function __resetTreeExpansionMemoryForTests(): void {
+  sessionExpansion.clear()
+}

--- a/website/src/test/FileBrowserRail.test.tsx
+++ b/website/src/test/FileBrowserRail.test.tsx
@@ -56,12 +56,12 @@ function newClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function mount(props: { onFileOpen?: (p: string, d: boolean) => void; selectedPath?: string | null } = {}) {
+function mount(props: { onFileOpen?: (p: string, d: boolean) => void; selectedPath?: string | null; projectDir?: string } = {}) {
   const qc = newClient()
   const onFileOpen = props.onFileOpen ?? vi.fn()
   const utils = render(
     <QueryClientProvider client={qc}>
-      <FileBrowserRail projectDir={DIR} onFileOpen={onFileOpen} selectedPath={props.selectedPath} />
+      <FileBrowserRail projectDir={props.projectDir ?? DIR} onFileOpen={onFileOpen} selectedPath={props.selectedPath} />
     </QueryClientProvider>,
   )
   return { qc, onFileOpen, ...utils }
@@ -79,6 +79,10 @@ beforeEach(() => {
   // test's toggle survives into this one. Drive it back to All explicitly.
   mount()
   fireEvent.click(screen.getByLabelText('All files'))
+  // The filter lives in a module-level map keyed by projectDir (it must
+  // survive the rail's remount), so a prior test's typed filter survives into
+  // this one — drive it back to empty the same way the mode is driven to All.
+  fireEvent.change(screen.getByLabelText('Filter files…'), { target: { value: '' } })
   cleanup()
   H.api.projectTree.mockClear()
   H.api.projectGitStatus.mockClear()
@@ -157,16 +161,67 @@ describe('FileBrowserRail search field', () => {
     fireEvent.keyDown(input, { key: 'Enter' })
     expect(input).toHaveValue('rail')
   })
+
+  it('keeps the typed query across a remount of the same project directory', () => {
+    // In-place tab navigation (opening a file focuses its tab) remounts the
+    // rail; the filter survives through the module-level session map, the
+    // same way the All/Changed mode does.
+    mount()
+    fireEvent.change(screen.getByLabelText('Filter files…'), { target: { value: 'rail' } })
+    cleanup()
+    mount()
+    expect(screen.getByLabelText('Filter files…')).toHaveValue('rail')
+    expect(tree()).toHaveAttribute('data-query', 'rail')
+  })
+
+  it('rehydrates the query when the mounted rail switches project directory', () => {
+    // An in-place projectDir change (switching chat slots) must not carry the
+    // previous project's filter into the new one — the seed read happens only
+    // on first mount, so the rail rehydrates from the session map on change.
+    const qc = newClient()
+    const view = render(
+      <QueryClientProvider client={qc}>
+        <FileBrowserRail projectDir={DIR} onFileOpen={vi.fn()} />
+      </QueryClientProvider>,
+    )
+    fireEvent.change(screen.getByLabelText('Filter files…'), { target: { value: 'rail' } })
+    view.rerender(
+      <QueryClientProvider client={qc}>
+        <FileBrowserRail projectDir="/elsewhere-switched" onFileOpen={vi.fn()} />
+      </QueryClientProvider>,
+    )
+    expect(screen.getByLabelText('Filter files…')).toHaveValue('')
+    expect(tree()).toHaveAttribute('data-query', '')
+
+    // And switching back restores the first project's filter from the map.
+    view.rerender(
+      <QueryClientProvider client={qc}>
+        <FileBrowserRail projectDir={DIR} onFileOpen={vi.fn()} />
+      </QueryClientProvider>,
+    )
+    expect(screen.getByLabelText('Filter files…')).toHaveValue('rail')
+  })
+
+  it('starts a different project directory with an empty query', () => {
+    mount()
+    fireEvent.change(screen.getByLabelText('Filter files…'), { target: { value: 'rail' } })
+    cleanup()
+    mount({ projectDir: '/elsewhere' })
+    expect(screen.getByLabelText('Filter files…')).toHaveValue('')
+    expect(tree()).toHaveAttribute('data-query', '')
+  })
 })
 
 describe('FileBrowserRail file opens', () => {
-  it('opens a plain file in All mode and drops the query', () => {
+  it('opens a plain file in All mode and keeps the query', () => {
+    // Deliberate contract: opening a file keeps the filter, so a second file
+    // can be opened from the same filtered result without re-typing it.
     const onFileOpen = vi.fn()
     mount({ onFileOpen })
     fireEvent.change(screen.getByLabelText('Filter files…'), { target: { value: 'a.ts' } })
     fireEvent.click(tree())
     expect(onFileOpen).toHaveBeenCalledWith(H.OPENED, false)
-    expect(tree()).toHaveAttribute('data-query', '')
+    expect(tree()).toHaveAttribute('data-query', 'a.ts')
   })
 
   it('opens in diff mode from Changed mode', () => {

--- a/website/src/test/PierreWorkspaceTree.lazy.test.tsx
+++ b/website/src/test/PierreWorkspaceTree.lazy.test.tsx
@@ -112,6 +112,30 @@ describe('PierreWorkspaceTree', () => {
     expect(treeMock.models[1].options).toMatchObject({ initialExpansion: 'open' })
   })
 
+  it('remounts a persisting tree when the project directory changes in place', async () => {
+    // The model, the reset guard, and the expansion-capture subscription are
+    // all per-instance: reusing them across projects would leak one project's
+    // expansion into another's view (and into its remembered set), so a
+    // persisting host gets a fresh instance per projectDir.
+    const { rerender } = render(wrap(<PierreWorkspaceTree projectDir={ROOT} persistExpansion />))
+    await waitFor(() => expect(screen.getByTestId('file-tree')).toBeInTheDocument(), { timeout: 5000 })
+    expect(treeMock.models).toHaveLength(1)
+
+    rerender(wrap(<PierreWorkspaceTree projectDir="/repo/other" persistExpansion />))
+    await waitFor(() => expect(treeMock.models).toHaveLength(2))
+  })
+
+  it('keeps one instance across a project change when not persisting', async () => {
+    // Hosts that do not opt into persistence keep the mode-only key — and
+    // with it their exact current single-instance behavior.
+    const { rerender } = render(wrap(<PierreWorkspaceTree projectDir={ROOT} />))
+    await waitFor(() => expect(screen.getByTestId('file-tree')).toBeInTheDocument(), { timeout: 5000 })
+    expect(treeMock.models).toHaveLength(1)
+
+    rerender(wrap(<PierreWorkspaceTree projectDir="/repo/other" />))
+    expect(treeMock.models).toHaveLength(1)
+  })
+
   it('defaults to the full-workspace mode', async () => {
     render(wrap(<PierreWorkspaceTree projectDir={ROOT} />))
     await waitFor(() => expect(screen.getByTestId('file-tree')).toBeInTheDocument())

--- a/website/src/test/PierreWorkspaceTreeImpl.test.tsx
+++ b/website/src/test/PierreWorkspaceTreeImpl.test.tsx
@@ -33,6 +33,11 @@ vi.mock('../components/AppIcon', () => ({ default: () => null }))
 
 import { PierreWorkspaceTreeImpl } from '../pierre/PierreWorkspaceTreeImpl'
 import { api } from '../api/client'
+import {
+  recallExpandedPaths,
+  rememberExpandedPaths,
+  __resetTreeExpansionMemoryForTests,
+} from '../pierre/treeExpansionMemory'
 import { treeMock } from './__mocks__/pierreTreesReact'
 import type { MenuItem, MenuContext } from './__mocks__/pierreTreesReact'
 
@@ -842,5 +847,247 @@ describe('PierreWorkspaceTreeImpl — app-contributed context rows', () => {
 
     const notice = await waitFor(() => screen.getByTestId('workspace-tree-action-error'))
     expect(notice).toHaveTextContent('endpoint refused')
+  })
+})
+
+describe('PierreWorkspaceTreeImpl — expansion persistence', () => {
+  // The Files tab mounts only while active, so opening a file remounts the
+  // whole tree; `persistExpansion` remembers the expanded directories (keyed
+  // by projectDir) and restores them through `resetPaths`'
+  // `initialExpandedPaths`. Off by default: the other hosts of this shared
+  // tree keep their collapsed-by-default behavior.
+  const TREE_PATHS = ['src/a.ts', 'src/lib/b.ts', 'README.md']
+  // `@pierre/trees` materializes DIRECTORY row paths with a trailing slash
+  // (`src/`, not `src`); the helper emits that canonical shape so these tests
+  // exercise what the real library hands the capture. Shape verified against
+  // @pierre/trees 1.0.0-beta.6 (path-store materializeNodePath appends `/`
+  // to directory nodes) — re-verify on an upgrade.
+  const expandedDir = (path: string) => ({ kind: 'directory' as const, path: path + '/', isExpanded: true })
+
+  beforeEach(() => {
+    __resetTreeExpansionMemoryForTests()
+    localStorage.clear()
+    vi.mocked(api.projectTree).mockResolvedValue(mkTree({ paths: TREE_PATHS }))
+  })
+
+  it('passes no expansion options on a first mount with nothing remembered', async () => {
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+
+    expect(treeMock.last().calls.resetPaths).toEqual([TREE_PATHS])
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([undefined])
+  })
+
+  it('restores the expanded directories on a remount of the same projectDir', async () => {
+    const { unmount } = renderTree({ persistExpansion: true })
+    await waitForTree()
+    act(() => {
+      treeMock.last().simulateVisibleRows([
+        expandedDir('src'),
+        expandedDir('src/lib'),
+        { kind: 'file', path: 'src/a.ts', isExpanded: false },
+      ])
+    })
+    unmount()
+
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([
+      { initialExpandedPaths: ['src', 'src/lib'] },
+    ])
+  })
+
+  it('gives a different projectDir nothing', async () => {
+    const { unmount } = renderTree({ persistExpansion: true })
+    await waitForTree()
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src')]) })
+    unmount()
+
+    renderTree({ persistExpansion: true, projectDir: '/repo/other' })
+    await waitForTree()
+
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([undefined])
+  })
+
+  it('drops remembered directories absent from the new payload', async () => {
+    const { unmount } = renderTree({ persistExpansion: true })
+    await waitForTree()
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src'), expandedDir('src/lib')]) })
+    unmount()
+
+    // `src/lib` no longer exists in the new payload: a stale path must be
+    // filtered out rather than handed to the controller.
+    vi.mocked(api.projectTree).mockResolvedValue(mkTree({ paths: ['src/a.ts'] }))
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([
+      { initialExpandedPaths: ['src'] },
+    ])
+  })
+
+  it('snapshots nothing while a search is active', async () => {
+    // The search session expands matches transiently; persisting that would
+    // restore an unrelated expansion after the filter is cleared.
+    const { unmount } = renderTree({ persistExpansion: true, searchQuery: 'lib' })
+    await waitForTree()
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src'), expandedDir('src/lib')]) })
+    unmount()
+
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([undefined])
+  })
+
+  it('neither reads nor writes the memory in changed mode', async () => {
+    vi.mocked(api.projectGitStatus).mockResolvedValue(
+      mkStatus([mkFile('project/src/a.ts', 'M')]),
+    )
+    rememberExpandedPaths(ROOT, ['src'])
+
+    const { unmount } = renderTree({ persistExpansion: true, mode: 'changed' })
+    await waitForTree()
+    // Changed mode starts fully open by design: the remembered set must not
+    // narrow it.
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([undefined])
+
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src'), expandedDir('src/x')]) })
+    unmount()
+
+    // And the changed-mode notification must not have overwritten the memory.
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([
+      { initialExpandedPaths: ['src'] },
+    ])
+  })
+
+  it('carries a remembered directory through a payload that temporarily lacks it', async () => {
+    // The backend truncates large payloads and a branch switch can drop a
+    // subtree: a remembered directory absent from the current payload is not
+    // evidence of a collapse, so a capture during that window must not erase
+    // it, and it must restore once the payload carries it again.
+    const first = renderTree({ persistExpansion: true })
+    await waitForTree()
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src'), expandedDir('src/lib')]) })
+    first.unmount()
+
+    vi.mocked(api.projectTree).mockResolvedValue(mkTree({ paths: ['src/a.ts'] }))
+    const second = renderTree({ persistExpansion: true })
+    await waitForTree()
+    // Only the still-present directory is passed to the controller…
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([
+      { initialExpandedPaths: ['src'] },
+    ])
+    // …and a capture during this window keeps the absent one remembered.
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src')]) })
+    second.unmount()
+
+    vi.mocked(api.projectTree).mockResolvedValue(mkTree({ paths: TREE_PATHS }))
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([
+      { initialExpandedPaths: ['src', 'src/lib'] },
+    ])
+  })
+
+  it('does not erase the memory when the model transiently holds no rows', async () => {
+    // A `project-tree` poll can answer with an empty payload (re-indexing,
+    // transient backend miss); the resulting empty visible set must not
+    // overwrite the remembered expansion.
+    const { unmount } = renderTree({ persistExpansion: true })
+    await waitForTree()
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src')]) })
+    act(() => { treeMock.last().simulateVisibleRows([]) })
+    unmount()
+
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([
+      { initialExpandedPaths: ['src'] },
+    ])
+  })
+
+  it('evicts the least recently written project from storage past the dir cap', () => {
+    // One storage key holds every project's entry; without eviction a long
+    // session would grow the origin's quota use without bound.
+    for (let i = 0; i <= 20; i++) rememberExpandedPaths(`/repo/p${i}`, ['src'])
+    __resetTreeExpansionMemoryForTests()
+
+    expect(recallExpandedPaths('/repo/p0')).toEqual([])
+    expect(recallExpandedPaths('/repo/p1')).toEqual(['src'])
+    expect(recallExpandedPaths('/repo/p20')).toEqual(['src'])
+  })
+
+  it('restores from the localStorage mirror after a page reload', async () => {
+    const { unmount } = renderTree({ persistExpansion: true })
+    await waitForTree()
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src')]) })
+    unmount()
+
+    // A page reload drops the module-scope session map; the localStorage
+    // mirror is what carries the expansion across it.
+    __resetTreeExpansionMemoryForTests()
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([
+      { initialExpandedPaths: ['src'] },
+    ])
+  })
+
+  it('tolerates localStorage throwing on both write and read', async () => {
+    // Private mode / quota: storage access is best-effort, the module-scope
+    // session map still covers the remount case.
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage unavailable')
+    })
+    try {
+      const first = renderTree({ persistExpansion: true })
+      await waitForTree()
+      act(() => { treeMock.last().simulateVisibleRows([expandedDir('src')]) })
+      first.unmount()
+
+      const second = renderTree({ persistExpansion: true })
+      await waitForTree()
+      expect(treeMock.last().calls.resetPathsOptions).toEqual([
+        { initialExpandedPaths: ['src'] },
+      ])
+      second.unmount()
+
+      // With the session map gone (a fresh page load) the throwing read falls
+      // back to nothing remembered rather than crashing.
+      __resetTreeExpansionMemoryForTests()
+      const third = renderTree({ persistExpansion: true })
+      await waitForTree()
+      expect(treeMock.last().calls.resetPathsOptions).toEqual([undefined])
+      third.unmount()
+    } finally {
+      setItem.mockRestore()
+      getItem.mockRestore()
+    }
+  })
+
+  it('leaves the memory alone when persistExpansion is off (the default)', async () => {
+    rememberExpandedPaths(ROOT, ['src'])
+
+    const { unmount } = renderTree()
+    await waitForTree()
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([undefined])
+
+    act(() => { treeMock.last().simulateVisibleRows([expandedDir('src'), expandedDir('src/x')]) })
+    unmount()
+
+    renderTree({ persistExpansion: true })
+    await waitForTree()
+    expect(treeMock.last().calls.resetPathsOptions).toEqual([
+      { initialExpandedPaths: ['src'] },
+    ])
   })
 })

--- a/website/src/test/__mocks__/pierreTreesReact.tsx
+++ b/website/src/test/__mocks__/pierreTreesReact.tsx
@@ -17,6 +17,12 @@ import type { CSSProperties, ReactElement, ReactNode } from 'react'
 
 export type StatusEntry = { path: string; status: string }
 
+/** The subset of `FileTreeVisibleRow` the wrapper's expansion snapshot reads. */
+export type VisibleRow = { kind: 'directory' | 'file'; path: string; isExpanded: boolean }
+
+/** The subset of `FileTreeResetBehaviorOptions` the wrapper passes. */
+export type ResetOptions = { initialExpandedPaths?: readonly string[] }
+
 type Handle = {
   getPath: () => string
   isDirectory: () => boolean
@@ -31,9 +37,12 @@ export function createFakeModel(options: Record<string, unknown>) {
   const selected = new Set<string>()
   const listeners = new Set<() => void>()
   let focused: string | null = null
+  let visibleRows: VisibleRow[] = []
 
   const calls = {
     resetPaths: [] as string[][],
+    /** Options argument of each `resetPaths` call, index-aligned with `resetPaths`. */
+    resetPathsOptions: [] as Array<ResetOptions | undefined>,
     gitStatus: [] as StatusEntry[][],
     search: [] as Array<string | null>,
     focusPath: [] as string[],
@@ -67,8 +76,9 @@ export function createFakeModel(options: Record<string, unknown>) {
     /** Options `useFileTree` was created with — the wrapper's prop mapping. */
     options,
     calls,
-    resetPaths(next: readonly string[]) {
+    resetPaths(next: readonly string[], options?: ResetOptions) {
       calls.resetPaths.push([...next])
+      calls.resetPathsOptions.push(options)
       files.splice(0, files.length, ...next)
       dirs.clear()
       for (const p of next) {
@@ -87,6 +97,8 @@ export function createFakeModel(options: Record<string, unknown>) {
       focused = path
     },
     getFocusedItem: () => (focused && known(focused) ? handle(focused) : null),
+    getVisibleCount: () => visibleRows.length,
+    getVisibleRows: (start: number, end: number) => visibleRows.slice(start, end),
     getSelectedPaths: () => [...selected],
     getItem: (path: string) => (known(path) ? handle(path) : null),
     subscribe(listener: () => void) {
@@ -95,6 +107,12 @@ export function createFakeModel(options: Record<string, unknown>) {
         listeners.delete(listener)
         calls.unsubscribes++
       }
+    },
+    /** Drive the model as the tree would after the user expands/collapses
+     *  directories: install the visible row window and notify subscribers. */
+    simulateVisibleRows(rows: VisibleRow[]) {
+      visibleRows = rows
+      for (const listener of listeners) listener()
     },
     /** Drive the model as the tree would after a user selects rows. */
     simulateSelection(focusedPath: string | null, selection: string[] = focusedPath ? [focusedPath] : []) {


### PR DESCRIPTION
## Summary

In the chat sidebar's pinned Files tab, opening a file collapses the whole tree and clears the filter box, because the tab mounts only while active: focusing the opened file's tab unmounts `FilesHomePanel → FileBrowserRail → PierreWorkspaceTree → TreeImpl`, and the tree model is created per mount with nothing capturing or restoring expansion. The filter reset was an explicit `setQuery('')` in the rail's open handler. The sibling All/Changed mode and rail width already survive this remount (module-scope variable / `localStorage`); this change gives expansion and the filter the same treatment. The mount-only-active policy itself is deliberate and untouched.

Closes #9653

## What changed

- **New `website/src/pierre/treeExpansionMemory.ts`** — remembers expanded directory paths per `projectDir`: a module-scope map for the page session, mirrored to ONE `localStorage` key (`mc-files-tree-expanded`, a `{dir: paths}` record) so a page reload keeps it. Bounded on both layers: 20 project dirs (least-recently-written evicted) × 500 paths per dir, and every storage access is failure-tolerant (private mode / quota / corrupted JSON degrade to session-only or empty, never a crash).
- **`website/src/pierre/PierreWorkspaceTreeImpl.tsx`** — a new opt-in `persistExpansion` prop. Restore passes `resetPaths(paths, { initialExpandedPaths })` with the remembered set filtered to directories present in the payload; capture subscribes to the model and snapshots expanded directory rows (the library's canonical trailing directory slash is stripped so capture and restore compare equal). Capture is skipped while a search is active (search expansion is transient), when the model holds zero rows (a transient empty payload must not erase memory), and — as an O(1) pre-filter — when the visible count is unchanged, so focus/selection/git-status notifications never pay the row scan. A remembered directory absent from the current payload (truncated payload, branch switch) is carried forward rather than erased. Expansion is keyed by path, so a `project-tree` refetch with fresh node ids cannot invalidate it. `changed` mode is untouched (starts fully open by design).
- **`website/src/pages/chat/FileBrowserRail.tsx`** — the filter query is hoisted to a module-scope map keyed by `projectDir` (session-only on purpose: a stale filter surviving a reload would hide the tree with no visible reason), capped at 20 entries, rehydrated on an in-place `projectDir` change, and a cleared filter frees its slot. The `setQuery('')` in the open handler is removed.
- **`website/src/pierre/tree.tsx`** — a persisting host remounts the impl per `projectDir` (plus the existing per-mode key) so an in-place project switch cannot leak one project's expansion into another's view or remembered set. Hosts that do not opt in keep the mode-only key.
- **Other hosts unaffected**: `FolderPanel` (the other `PierreWorkspaceTree` host) does not pass `persistExpansion` and keeps byte-identical behavior — pinned by a test.

## ⚠️ Deliberate contract change

**Opening a file no longer clears the filter.** The previous test `opens a plain file in All mode and drops the query` asserted the old contract; it is rewritten to `…and keeps the query`. This is the reporter's core ask: opening several files from one filtered result without re-typing the filter. Escape and the X button still clear it (tests untouched).

## Accepted trade-offs (documented in code comments)

- A directory expanded under a collapsed ancestor is not visible and drops out of the remembered set; re-expanding the ancestor is what the user does on return anyway.
- The `localStorage` mirror write is synchronous per real expansion change (user-paced, deduped upstream; one stringify of a 20×500-capped record is far below frame budget).
- A genuinely deleted directory is carried forward until the 500-path cap truncates it — the cost of never being able to tell "deleted" from "temporarily absent beyond the payload truncation cap".

## Visual delta

<!-- no-visual-delta -->
**Why no screenshot:** no markup, styling, or rendered pixels change — this is state persistence across remounts, so every individual frame is identical to main; the behavior is pinned by 13 new/rewritten vitest cases instead.

## Adversarial review (pre-push)

- Rounds: 4 (two model-pinned blind lanes: GPT mirror + Opus mirror, read-only, contract+artifact only)
- Findings: 15 total — 8 fixed (including a test-masked restore no-op from the library's trailing-slash canonical directory paths, a transient-empty-payload memory erasure, a cross-project state leak on in-place `projectDir` change, and a deterministically failing test), 3 documented trade-offs, 4 noise/out-of-scope
- Final round: PASS / PASS

## Before you upgrade

Nothing required. No migration: a missing or invalid `localStorage` value falls back to the current collapsed-by-default behavior.

## Pattern harvest

Rule candidate: when persisting or restoring state through a third-party model's row/path API, the test mock must emit the library's CANONICAL shape (here: `@pierre/trees` materializes directory row paths with a trailing slash) — a hand-authored slash-less mock kept every test green while the restore was a total no-op in production. Verify the shape against the vendored `dist/` source and note the verified version beside the mock.
