### PR TITLE
fix(config): surface automatic default adoption

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -475,6 +475,11 @@ parsed field still EQUALS `old_default`, so a value the loader clamped or coerce
 keeps the loader's correction. A key the `config.local.json` overlay supplies is
 cleared on disk but left alone in memory: the overlay is the operator's live choice.
 
+After the config write succeeds, the loader warns at the default log level for each
+adopted key, naming the removed value and the `kirocrew config set` command that
+restores it. A deferred or failed write emits no adoption notice. The warning
+describes the stored value without claiming to know whether the operator chose it.
+
 `stt.provider` is deliberately absent from `SUPERSEDED_DEFAULTS` even though its
 default moved to `local`: `_validated_stt_provider` coerces a retired value at
 parse time, so the stored value never wins and there is no *default* for an

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -819,11 +819,6 @@ def _apply_document_migrations(
             if recorded_adoptions is not None:
                 recorded_adoptions.extend(fresh)
             if drop_drifted_keys(data, fresh):
-                logger.info(
-                    "config: adopted the current default for %s — the stored value "
-                    "was a superseded default this install never chose",
-                    ", ".join(fresh),
-                )
                 changed = True
 
     return changed
@@ -4521,6 +4516,15 @@ class KiroCrewConfig:
                 by_key = {e.dotted_key: e for e in adoptable}
                 for key in confirmed_adoptions:
                     entry = by_key.get(key)
+                    if entry is not None:
+                        logger.warning(
+                            "config: adopted current default for %s; removed stored value %r. "
+                            "To restore it: kirocrew config set %s %s",
+                            key,
+                            entry.old_default,
+                            key,
+                            entry.old_default,
+                        )
                     if entry is not None and not _overlay_supplies(local_data, key):
                         _adopt_in_memory(cfg, key, entry.old_default)
             elif needs_migration:

--- a/test/test_config_superseded_defaults.py
+++ b/test/test_config_superseded_defaults.py
@@ -977,7 +977,7 @@ def test_the_running_config_never_diverges_from_the_stored_one(tmp_path, monkeyp
     assert "subagent_timeout_secs" not in _on_disk(tmp_path).get("agent", {})
 
 
-def test_a_failed_write_keeps_the_value_and_does_not_re_adopt_later(tmp_path, monkeypatch):
+def test_a_failed_write_keeps_the_value_and_does_not_re_adopt_later(tmp_path, monkeypatch, caplog):
     """The chosen side of an unavoidable two-file window, pinned end to end.
 
     ``config.json`` and the sidecar have no shared transaction, so exactly one of two
@@ -999,11 +999,13 @@ def test_a_failed_write_keeps_the_value_and_does_not_re_adopt_later(tmp_path, mo
         raise OSError("no space left on device")
 
     monkeypatch.setattr(L, "_write_migration_backup", _fail_backup)
-    failed = KiroCrewConfig.load()
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        failed = KiroCrewConfig.load()
 
     # Nothing was destroyed, and memory did not run ahead of the file.
     assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
     assert failed.agent.subagent_timeout_secs == 1800
+    assert not any("adopted current default" in r.getMessage() for r in caplog.records)
 
     monkeypatch.undo()
     _point_home(tmp_path, monkeypatch)
@@ -1059,13 +1061,19 @@ def test_load_adopts_the_stale_timeout_on_disk_and_in_memory(tmp_path, monkeypat
     _point_home(tmp_path, monkeypatch)
     _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
 
-    with caplog.at_level(logging.INFO, logger=L.__name__):
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
         cfg = KiroCrewConfig.load()
 
     assert cfg.agent.subagent_timeout_secs == 10800
     assert "subagent_timeout_secs" not in _on_disk(tmp_path).get("agent", {})
     assert SD.adopted_superseded() == {"agent.subagent_timeout_secs": 1800}
-    assert any("adopted the current default" in r.getMessage() for r in caplog.records)
+    notices = [
+        r.getMessage() for r in caplog.records if "adopted current default" in r.getMessage()
+    ]
+    assert len(notices) == 1
+    assert "agent.subagent_timeout_secs" in notices[0]
+    assert "1800" in notices[0]
+    assert "kirocrew config set agent.subagent_timeout_secs 1800" in notices[0]
 
 
 def test_a_deliberately_chosen_value_survives_the_adoption(tmp_path, monkeypatch):
@@ -1162,9 +1170,17 @@ def test_the_load_does_not_tell_the_operator_to_fix_what_it_just_fixed(
     with caplog.at_level(logging.WARNING, logger=L.__name__):
         KiroCrewConfig.load()
 
-    warnings = " ".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
-    assert "forward_declared_env" in warnings
-    assert "subagent_timeout_secs" not in warnings
+    drift_warnings = " ".join(
+        r.getMessage()
+        for r in caplog.records
+        if "still hold a superseded default" in r.getMessage()
+    )
+    assert "forward_declared_env" in drift_warnings
+    assert "subagent_timeout_secs" not in drift_warnings
+    assert any(
+        "adopted current default for agent.subagent_timeout_secs" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 def test_a_failed_ledger_write_aborts_the_adoption(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

On upgrade, Kiro Crew can remove a stored timeout that matches a superseded default. That changes config.json, but the adoption notice is logged at INFO, below the default WARNING level. Operators see no notice or undo command, while the message also claims to know they never chose the old value.

## Why it matters

An automatic write to an operator-owned configuration file should be visible and reversible. The prior message can also appear before the config write is confirmed.

## What changed (motivation → approach → change)

Emit a WARNING only after the adoption reaches disk, naming each removed numeric value and the exact config set command that restores it. Remove the ungrounded provenance claim. Keep the marker-first one-shot migration and the existing in-memory adoption unchanged. Document the notice contract.

## Tests

- Red-before: the focused adoption regression failed because no WARNING-level notice contained the key, removed value, and undo command.
- Green-after: 69 config superseded-default tests passed, 3 platform skips; one existing symlink replacement test was deselected because it fails on this non-admin Windows host (the same pre-existing test defect is recorded in #10082).
- A failed migration write emits no adoption notice.
- Black (py310), flake8, documentation lint, and diff check pass.

## Manual verification

N/A — the persisted config, warning level/content, and failed-write behavior are covered by deterministic tests.

## Related Issues

Refs #10082. This PR addresses its operator-visible notice; the separate ledger, downgrade, and test-cleanup follow-ups remain scoped to that issue.

## Pattern harvest

Not generalizable: this notice belongs to the two auto-adopted timeout defaults and their marker-first two-file migration. The focused regression pins the successful-write notice and failed-write silence.

## Checklist

- [x] One Conventional Commit
- [x] Existing focused tests pass and regression coverage added
- [x] Self-review completed
- [x] Configuration system spec updated
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. Do not invent CLA text. -->