### PR TITLE
fix(dev-fleet): name a failed sync step from its stderr, not its stdout tail

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -824,6 +824,97 @@ failure, because every other step runs worktree-controlled code that can exit an
 number it likes; and only the sync run kind is stamped at all, since `_start_run`
 is shared with `provision`, whose script enforces no such reservation.
 
+**When there is no reserved code, the failure is named from the failing step's
+stderr — never from the last output line.** Every step's stdout and stderr land
+in ONE pipe (`_start_run` spawns the runner with `stderr=STDOUT`, and steps
+inherit it), and a child block-buffers stdout to a pipe while writing stderr
+unbuffered — so the stdout buffer flushes at process EXIT, *after* the
+diagnostic. The stream order is therefore not evidence of what failed. A refused
+`git merge --ff-only` demonstrates it exactly:
+
+```
+error: Your local changes to the following files would be overwritten by merge:
+        config-baseline.json
+Please commit your changes or stash them before you merge.
+Aborting
+Updating 2f9ed9724..bf09e50e5     <- stdout, flushed last
+```
+
+`run_step` therefore gives each step's stderr its own pipe, pumps it through to
+stdout line by line (so the log and the live "current activity" line are
+unchanged), and remembers its last `_STEPERR_TAIL` non-blank lines. When the step
+fails, `run_steps` re-emits those as `::steperr::<idx>::<line>` markers, and the
+UI's ladder is `cause` → the `::steperr::` block → the last output line. Both
+marker families are filtered out of the log panel: the stderr lines already
+appear there in their own order, so the markers would only duplicate the tail.
+
+Order WITHIN each stream is preserved; order ACROSS the two is unspecified. The
+child writes stdout straight to the inherited descriptor while the pump relays
+stderr, so the two interleave by timing rather than by causality. That is the
+premise of the change rather than a gap in it — a position in this stream was
+never evidence of what failed, which is why the tail is labelled instead of
+located.
+
+**The pump reads with a cap, it does not iterate the handle.** A step runs
+worktree-controlled code, so it can write a newline-free blob of any length, and
+`for line in stream` would allocate the whole blob inside the runner — the
+unbounded-read shape `test_jsonl_util.py::TestNoUnboundedHandleIteration`
+refuses. `readline(_STEPERR_READ_CAP)` bounds every allocation instead: a longer
+run arrives as cap-sized pieces, each forwarded, so splitting is the only effect and
+the
+blob is merely split across lines. The repo's own `jsonl_util` bounded readers
+are unavailable here — this module is stdlib-only and executes from a snapshot by
+path — so the bound is spelled with the stdlib.
+
+**That cap is derived from the gateway's byte limit, not chosen.** The two ends
+count different units: `readline` caps CHARACTERS because the stream is a text
+wrapper, while the gateway reads this pipe with `asyncio.StreamReader.readline()`,
+whose 64 KiB limit counts BYTES — and a line past it raises `LimitOverrunError`
+there, whose handler reaps the whole process tree. A character encodes to at most
+4 UTF-8 bytes and the pump appends one newline, so the cap is
+`(_GATEWAY_LINE_BYTES - 1) // 4`. A round-number character cap would satisfy the
+byte ceiling only for ASCII, and multibyte stderr — a non-ASCII checkout path, a
+localized git message — is ordinary. `test_dev_fleet_sync_runner.py` asserts the
+ENCODED length of every forwarded line, since an ASCII fixture cannot see the
+gap. A remembered tail line is separately capped at `_STEPERR_LINE_CHARS`, because
+the tail is rendered in a one-notice banner rather than in a log.
+
+**The drain after the step exits is bounded too.** `pump.join` waits
+`_STEPERR_DRAIN_S` and no longer. EOF on that pipe needs every writer gone, and a
+GRANDCHILD inherits the write end — `npm` spawns several — so one survivor keeps
+it open and EOF never arrives. An unbounded join would turn that survivor from a
+cosmetic leak into a wedged Pull+Build, so late lines are dropped instead. What
+that costs is precise: everything the STEP ITSELF wrote is relayed, since its
+bytes are in the pipe by the time `wait()` returns; what can be dropped is output
+written after the cutoff by something that outlived the step, which is the
+survivor this bound exists for.
+
+**This runner is the SOLE writer to its stdout pipe, and that is what makes the
+byte bound real.** Capping our own writes bounds nothing while a step also owns
+the descriptor: it can emit a newline-free blob that prepends to a terminated
+relay line, and the merged inter-newline run the gateway reads then exceeds
+`_GATEWAY_LINE_BYTES` however tightly each writer capped itself — which raises in
+the reader and reaps the process tree. So `run_step` pipes stdout as well as
+stderr, relays each on its own pump, and every write in the module — both pumps
+and every `::step::` / `::steperr::` / transaction line — goes through `emit`,
+which holds one lock for the whole line. A step that deliberately interleaves
+newline-free stdout blobs with terminated stderr lines produces 15 spliced lines
+without that, which `test_concurrent_stdout_cannot_splice_a_relayed_line` pins by
+mutation.
+
+`run_step`'s docstring states the guarantees exhaustively, as four numbered
+lines. Read them there rather than inferring them from prose here — sweeping
+wording about the log being complete or in order is what made this paragraph wrong
+twice.
+
+`::steperr::` is a **label on a worktree-controlled stream, not a diagnosis.** It
+never sets `lastIsCause`, so it renders as the raw tail it is — a step printing a
+plausible sentence to stderr gains exactly what it already had, its output shown
+verbatim. The one shape that is guarded is an all-blank forged tail, which would
+resolve to the empty string and make `ErrorNotice` render nothing: blank marker
+texts are dropped, and the last-line fallback skips marker lines too, so a forged
+marker can neither hide the notice nor be surfaced raw.
+
 The build and the copy are ONE step because they share ONE holder of the staging
 lock (`.dist.staging.lock`, next to `static/dist`). `npm run build` empties
 `website/dist` before repopulating it, so a peer flow — another sync, or the

--- a/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
@@ -41,16 +41,64 @@ text; nothing printed here is promoted into the authoritative diagnosis.
 from __future__ import annotations
 
 import argparse
+import collections
 import hashlib
 import json
 import os
 import shutil
 import subprocess  # nosec B404 - running the sync's own steps is this module's purpose
 import sys
+import threading
 
 #: Suffix appended to a stash path to name its backup. A ``node_modules`` moved
 #: aside for the duration of a step lands at ``<stash>`` + this.
 _BACKUP_SUFFIX = ".kirocrew-sync-backup"
+
+#: How many trailing stderr lines of a FAILED step are re-emitted as
+#: ``::steperr::`` markers. Four covers the shape git and pip use -- a headline,
+#: the offending paths, the remedy sentence -- without turning the banner into a
+#: log window; the full log is one click away in the dashboard either way.
+_STEPERR_TAIL = 4
+
+#: How long to wait for a step's stderr pump to reach EOF after the step exits.
+#: Bounded rather than unbounded because a GRANDCHILD (npm spawns several)
+#: inherits the write end of that pipe, so a survivor keeps it open and EOF never
+#: arrives. Before stderr was piped such a survivor simply kept writing into the
+#: inherited pipe and the runner exited anyway, so waiting forever here would
+#: turn a cosmetic leak into a wedged Pull+Build. Late lines are dropped instead.
+_STEPERR_DRAIN_S = 5.0
+
+#: The gateway reads this runner's pipe with ``asyncio.StreamReader.readline()``,
+#: whose limit is 64 KiB of BYTES (``runtime.py``). A line past it raises
+#: ``LimitOverrunError`` there, and that handler reaps the whole process tree --
+#: so the ceiling this pump forwards under is not ours to pick.
+_GATEWAY_LINE_BYTES = 64 * 1024
+
+#: Per-read ceiling on a step's stderr, in characters. DERIVED, not picked.
+#:
+#: A step runs worktree-controlled code, so it can write a newline-free blob of
+#: any length, and ``for line in stream`` would allocate the whole blob inside
+#: this runner. ``readline(cap)`` bounds each read instead: a longer run comes
+#: back in cap-sized pieces and every piece is forwarded, so splitting is the only
+#: effect and the allocation is fixed. That is the bounded-reader posture
+#: ``test_jsonl_util.py::TestNoUnboundedHandleIteration`` requires; this module
+#: cannot call the repo's own ``jsonl_util`` readers because it is stdlib-only
+#: and executes from a snapshot by path.
+#:
+#: The cap counts CHARACTERS, because the stream is a text wrapper, while the
+#: gateway's limit counts BYTES -- so the two units have to be reconciled here or
+#: the bound is a bound in name only. A Python character encodes to at most 4
+#: UTF-8 bytes and the pump appends one newline, so the worst-case encoded line
+#: is ``cap * 4 + 1`` bytes; dividing the gateway's byte ceiling by that is the
+#: whole derivation. Multibyte stderr (a non-ASCII checkout path, a localized
+#: git message) is ordinary, not exotic, and a character cap chosen as a round
+#: number holds only for ASCII.
+_STEPERR_READ_CAP = (_GATEWAY_LINE_BYTES - 1) // 4
+
+#: Ceiling on ONE remembered tail line, in characters. The tail names a failure
+#: in a one-notice banner, not in a log, so a cap-sized piece has no business
+#: being rendered whole. The full piece still reaches the log.
+_STEPERR_LINE_CHARS = 500
 
 
 def gone(path: str) -> bool:
@@ -119,18 +167,12 @@ def reconcile_leftovers(steps: list[dict], exit_tree_ambiguous: int) -> None:
         if have_tree and have_backup:
             # The paths are LOG text; the diagnosis is the exit code, which the
             # gateway maps. Nothing here is promoted out of stdout.
-            print(
-                "a previous sync left a dependency-tree backup beside the tree",
-                flush=True,
-            )
-            print("tree: %s" % stash, flush=True)
-            print("backup: %s" % backup, flush=True)
+            emit("a previous sync left a dependency-tree backup beside the tree")
+            emit("tree: %s" % stash)
+            emit("backup: %s" % backup)
             sys.exit(exit_tree_ambiguous)
         if have_backup:
-            print(
-                "restoring a dependency tree left stashed by an earlier run",
-                flush=True,
-            )
+            emit("restoring a dependency tree left stashed by an earlier run")
             os.rename(backup, stash)
 
 
@@ -185,39 +227,169 @@ class NodeModulesTransaction:
             return
         if self.rc == 0:
             if not gone(backup):
-                print(
+                emit(
                     "note: a dependency-tree backup could not be removed and "
-                    "was left at %s" % backup,
-                    flush=True,
+                    "was left at %s" % backup
                 )
         elif gone(stash):
             os.rename(backup, stash)
-            print("restored %s after a failed step" % stash, flush=True)
+            emit("restored %s after a failed step" % stash)
         else:
-            print("partial: %s" % stash, flush=True)
-            print("backup: %s" % backup, flush=True)
+            emit("partial: %s" % stash)
+            emit("backup: %s" % backup)
             self.rc = self.exit_restore_failed
         # Never suppress an exception: the step body's rc handling is done before
         # exit, and an exception must still propagate after the tree is restored.
         # (Returning None -- always falsy -- is the no-suppression contract.)
 
 
-def run_step(st: dict, cwd: str) -> int:
-    """Run one step's subprocess and return its exit code.
+#: Serializes every write this runner makes to its stdout pipe.
+#:
+#: The gateway reads that pipe with a LINE reader, so a line is only bounded if
+#: nothing can splice into the middle of it. Two pumps plus the main thread's
+#: marker prints are three writers; without one lock a step's newline-free run
+#: could prepend to another's terminated line and the merged inter-newline run
+#: would exceed :data:`_GATEWAY_LINE_BYTES` however tightly each writer capped
+#: itself. Holding this for every write is what makes the bound true by
+#: construction rather than by hope.
+_WRITE_LOCK = threading.Lock()
 
-    Each step is a separate process that inherits the runner's stdout pipe but
-    re-derives its encoding from the locale, so a Python step (pip, the
+
+def emit(line: str) -> None:
+    """Write ONE whole line to the runner's stdout, under the shared lock.
+
+    Every write to that pipe goes through here -- the pumps and the step markers
+    alike. A caller that bypasses it reintroduces the splice this lock exists to
+    prevent, so there is deliberately no second path.
+    """
+    with _WRITE_LOCK:
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+
+def _pump(stream, tail: "collections.deque[str] | None") -> None:
+    """Relay one of a step's streams to our stdout, optionally keeping its tail.
+
+    Runs on a thread for the step's whole lifetime, so a step that writes more
+    than a pipe buffer's worth cannot block waiting for a reader. Each piece is
+    written through IMMEDIATELY, so piping costs nothing in liveness: the
+    dashboard's "current activity" line keeps advancing.
+
+    Reads are bounded by :data:`_STEPERR_READ_CAP` rather than iterating the
+    handle, so a newline-free blob from a worktree-controlled step cannot become
+    one unbounded allocation here. A blob longer than the cap arrives as
+    cap-sized pieces, each forwarded, so splitting it across log lines is the
+    only effect.
+
+    *tail* is a deque for the stream whose last lines name a failure (stderr) and
+    ``None`` for the one that does not (stdout). Blank pieces are forwarded but
+    never remembered -- they pad a diagnosis, they are never the diagnosis.
+    """
+    while True:
+        chunk = stream.readline(_STEPERR_READ_CAP)
+        if not chunk:
+            break
+        line = chunk.rstrip("\n")
+        emit(line)
+        if tail is not None and line.strip():
+            tail.append(_trim_tail_line(line))
+
+
+def _trim_tail_line(line: str) -> str:
+    """Cut a remembered line to banner length, MARKED when it was cut.
+
+    The tail is rendered in a one-line notice, so a cap is right; a silent cut is
+    not. A diagnosis trimmed without a marker reads as the whole sentence, which
+    is the same class of harm as naming a progress line -- the reader believes
+    something the output does not support.
+    """
+    if len(line) <= _STEPERR_LINE_CHARS:
+        return line
+    return line[:_STEPERR_LINE_CHARS] + "..."
+
+
+def run_step(st: dict, cwd: str) -> tuple[int, list[str]]:
+    """Run one step's subprocess; return its exit code and its stderr tail.
+
+    Each step is a separate process whose stdout AND stderr are piped to us, and
+    which re-derives its encoding from the locale -- so a Python step (pip, the
     build-and-stage child) would encode a non-ASCII checkout path with the
     codepage and die on it. ``PYTHONIOENCODING`` is the only channel that reaches
     a child, so it is set here on every step's env -- non-Python steps (git, npm)
     ignore it and are unaffected. Assigned rather than defaulted: the reader's
     encoding is fixed, so a divergent inherited value would be the defect.
+
+    **Both streams are piped, and stderr's tail is returned, because the ORDER of
+    a failed step's output in one merged pipe is a lie.** With stdout and stderr
+    sharing one descriptor, a child block-buffers stdout to a pipe while writing
+    stderr unbuffered -- so the stdout buffer flushes at EXIT, after the
+    diagnostic. ``git merge --ff-only`` refused for local changes emits, in pipe
+    order::
+
+        error: Your local changes to the following files would be overwritten ...
+        Please commit your changes or stash them before you merge.
+        Aborting
+        Updating 2f9ed9724..bf09e50e5     <- stdout, flushed last
+
+    The dashboard promotes the LAST output line when the exit code carries no
+    reserved diagnosis, so a bare last-line rule names ``Updating <old>..<new>``
+    -- a progress line -- as the reason Pull+Build failed. Returning the tail as
+    data lets the failure be named from the stream that carries diagnostics,
+    instead of from a position that depends on libc buffering.
+
+    **The step writes to neither pipe directly; this runner is the sole writer.**
+    That is what makes the byte bound real. Capping our own writes bounds nothing
+    while a step also owns the descriptor: it can emit a newline-free blob that
+    prepends to a terminated relay line, and the merged inter-newline run the
+    gateway reads exceeds :data:`_GATEWAY_LINE_BYTES` however tightly each writer
+    capped itself -- which reaps the process tree. With both streams piped and
+    every write going through :func:`emit` under one lock, each line the gateway
+    sees is whole and under the ceiling by construction.
+
+    What this guarantees, exactly -- four statements, no more:
+
+    1. Order WITHIN one stream is preserved.
+    2. Order ACROSS the two is unspecified: two pumps relay independently, so
+       they interleave by timing.
+    3. Every forwarded line is WHOLE and under :data:`_GATEWAY_LINE_BYTES`. No
+       writer can splice into another's line.
+    4. Everything the STEP ITSELF wrote is relayed. The pumps read to EOF, and by
+       the time ``wait()`` returns the step is gone and its bytes are already in
+       the pipes. Output written AFTER the drain cutoff by something that outlived
+       the step -- the surviving grandchild :data:`_STEPERR_DRAIN_S` exists for --
+       is dropped, and that trade is the point of bounding the join.
+
+    (2) is the premise of the change rather than a gap in it: a position in this
+    stream was never evidence of what failed, which is exactly why the tail is
+    labelled instead of located. Nothing is filtered or reordered within a stream.
     """
     env = dict(st["env"])
     env["PYTHONIOENCODING"] = "utf-8:replace"
-    return subprocess.run(  # nosec B603 - argv list, no shell
-        st["argv"], cwd=cwd, env=env
-    ).returncode
+    tail: collections.deque[str] = collections.deque(maxlen=_STEPERR_TAIL)
+    proc = subprocess.Popen(  # nosec B603 - argv list, no shell
+        st["argv"],
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        errors="replace",
+    )
+    # Daemon so an undrainable pipe (see _STEPERR_DRAIN_S) cannot hold up
+    # interpreter exit either. stdout gets no tail: the tail names a failure, and
+    # naming it from stdout is the defect this whole change exists to remove.
+    pumps = [
+        threading.Thread(target=_pump, args=(proc.stdout, None), daemon=True),
+        threading.Thread(target=_pump, args=(proc.stderr, tail), daemon=True),
+    ]
+    for pump in pumps:
+        pump.start()
+    rc = proc.wait()
+    # AFTER wait(): the child is gone, so the pumps are draining what is left in
+    # the pipes and reach EOF unless a surviving grandchild holds one open.
+    for pump in pumps:
+        pump.join(timeout=_STEPERR_DRAIN_S)
+    return rc, list(tail)
 
 
 def demote_reserved(rc: int, label: str, reserved: frozenset[int], preflight_label: str) -> int:
@@ -233,11 +405,10 @@ def demote_reserved(rc: int, label: str, reserved: frozenset[int], preflight_lab
     when it demotes.
     """
     if rc in reserved and label != preflight_label:
-        print(
+        emit(
             "step %s exited %d, which is a reserved diagnosis code; reporting "
             "it as a plain failure because only the %s step may assert one"
-            % (label, rc, preflight_label),
-            flush=True,
+            % (label, rc, preflight_label)
         )
         return 1
     return rc
@@ -255,9 +426,13 @@ def run_steps(
     """Run the reconciled step list in order, fail-fast, with the transaction.
 
     Emits one ``::step::<idx>::<label>`` marker per step -- the run worker parses
-    these to name the current step in the dashboard. Returns the exit code to
-    exit with: 0 if every step passed, otherwise the first non-zero code (after
-    reserved-code demotion and any restore-failure override).
+    these to name the current step in the dashboard. A step that FAILS is
+    followed by up to :data:`_STEPERR_TAIL` ``::steperr::<idx>::<line>`` markers
+    carrying the tail of its stderr, which is what lets the dashboard name the
+    failure without trusting output ORDER in a merged pipe (see
+    :func:`run_step`). Returns the exit code to exit with: 0 if every step
+    passed, otherwise the first non-zero code (after reserved-code demotion and
+    any restore-failure override).
 
     The frontend-skip verdict is held HERE, in runner state, not on disk. When
     the trusted preflight step (identified by ``preflight_label``) exits
@@ -273,16 +448,15 @@ def run_steps(
     """
     skip_frontend = False
     for i, st in enumerate(steps):
-        print("::step::%d::%s" % (i, st["label"]), flush=True)
+        emit("::step::%d::%s" % (i, st["label"]))
         if skip_frontend and st["label"] in frontend_labels:
-            print(
+            emit(
                 "::skip::%d::%s -- backend-only sync, frontend unchanged and "
-                "node_modules populated" % (i, st["label"]),
-                flush=True,
+                "node_modules populated" % (i, st["label"])
             )
             continue
         with NodeModulesTransaction(st.get("stash"), exit_restore_failed) as txn:
-            rc = run_step(st, cwd)
+            rc, steperr = run_step(st, cwd)
             rc = demote_reserved(rc, st["label"], reserved, preflight_label)
             # The preflight asserting the frontend is already built is a SUCCESS
             # that also suppresses the two frontend steps. Only the trusted
@@ -296,6 +470,20 @@ def run_steps(
         # The transaction may have overridden rc to its restore-failed code.
         rc = txn.rc
         if rc != 0:
+            # Re-emit the failing step's stderr tail under its own marker, so the
+            # dashboard can name the failure from the stream diagnostics arrive
+            # on rather than from the last line in a merged pipe -- which for a
+            # step that block-buffered its stdout is a stale progress line (see
+            # `run_step`). Emitted only on failure and only for the step that
+            # failed: on the success path there is nothing to name.
+            #
+            # This is still LOG TEXT, not a diagnosis. The authoritative cause
+            # remains the exit code, mapped by the gateway, and these lines are
+            # presented as the raw tail they are -- so a worktree-run step that
+            # prints a plausible sentence to stderr gains exactly what it already
+            # had: its output shown verbatim in the failure notice.
+            for line in steperr:
+                emit("::steperr::%d::%s" % (i, line))
             return rc
     return 0
 
@@ -381,10 +569,9 @@ def main(argv: list[str] | None = None) -> int:
         # the pinned digest travels in argv (immutable once this process exists),
         # so a rewrite of the file between staging and startup cannot substitute
         # steps. Content is diagnosis; the refusal is the protection.
-        print(
+        emit(
             "sync runner: steps file does not match the staged manifest "
-            "(sha256 %s != expected %s)" % (digest, args.steps_sha256),
-            flush=True,
+            "(sha256 %s != expected %s)" % (digest, args.steps_sha256)
         )
         return 1
     steps = json.loads(raw.decode("utf-8"))

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1177,10 +1177,14 @@ async def test_every_step_gets_a_utf8_pin_in_its_environment():
     src = Path(sync_runner.__file__).read_text(encoding="utf-8")
     run_step_body = src.split("def run_step(", 1)[1].split("\ndef ", 1)[0]
     assert 'env["PYTHONIOENCODING"] = "utf-8:replace"' in run_step_body
-    # Applied to the env actually handed to subprocess.run, not a stale copy.
-    assert "cwd=cwd, env=env" in run_step_body
+    # Applied to the env actually handed to the spawn, not a stale copy. Matched
+    # on the keyword alone, not on a formatted argument run: the spawn became a
+    # multi-line Popen when stderr got its own pipe, and a substring spanning two
+    # arguments made this fail on a formatting change rather than on a defect.
+    assert "env=env," in run_step_body
+    assert "cwd=cwd," in run_step_body
     # Set before the step is spawned, not after.
-    assert run_step_body.index("PYTHONIOENCODING") < run_step_body.index("subprocess.run(")
+    assert run_step_body.index("PYTHONIOENCODING") < run_step_body.index("subprocess.Popen(")
 
 
 @pytest.mark.asyncio

--- a/test/test_dev_fleet_sync_runner.py
+++ b/test/test_dev_fleet_sync_runner.py
@@ -220,9 +220,303 @@ class TestRunSteps:
         ]
         env = dict(os.environ)
         env["PYTHONIOENCODING"] = "cp1252"  # divergent inherited value
-        rc = sync_runner.run_step({"argv": argv, "env": env, "label": "probe"}, str(tmp_path))
+        rc, steperr = sync_runner.run_step(
+            {"argv": argv, "env": env, "label": "probe"}, str(tmp_path)
+        )
         assert rc == 0
+        assert steperr == []
         assert probe.read_text() == "utf-8:replace"
+
+    def test_a_failed_step_reports_its_stderr_tail_not_its_last_stdout_line(self, tmp_path, capfd):
+        """The ordering the marker exists for, reproduced end to end.
+
+        A child block-buffers stdout to a pipe and writes stderr unbuffered, so a
+        step that fails AFTER printing progress to stdout leaves that progress as
+        the last line of the merged stream (``Updating <old>..<new>`` from a
+        refused ``git merge --ff-only``). The stream's final line is therefore not
+        evidence of what failed. The ``::steperr::`` markers must carry the stderr
+        lines, in order, regardless of where stdout landed.
+        """
+        import sys
+
+        # Deliberately shaped like the real refusal: diagnosis on stderr, a
+        # progress line on stdout written LAST so no buffering assumption is
+        # needed to make it the final line of the merged stream.
+        script = (
+            "import sys;"
+            "print('error: Your local changes would be overwritten by merge:',"
+            " file=sys.stderr);"
+            "print('\\tconfig-baseline.json', file=sys.stderr);"
+            "print('Aborting', file=sys.stderr);"
+            "sys.stderr.flush();"
+            "print('Updating 2f9ed9724..bf09e50e5');"
+            "sys.exit(1)"
+        )
+        steps = [
+            {
+                "argv": [sys.executable, "-c", script],
+                "env": dict(os.environ),
+                "label": "Merge",
+            }
+        ]
+
+        rc = sync_runner.run_steps(
+            steps, str(tmp_path), npm_preflight.RESERVED_EXIT_CODES, "Verify dependencies", 47
+        )
+
+        assert rc == 1
+        # `capfd`, not `capsys`: the step's stdout is INHERITED (it writes to the
+        # real descriptor, exactly as it does into the runner's pipe in
+        # production), so only fd-level capture sees both streams the way the
+        # dashboard does.
+        lines = capfd.readouterr().out.splitlines()
+        markers = [ln for ln in lines if ln.startswith("::steperr::")]
+        assert markers == [
+            "::steperr::0::error: Your local changes would be overwritten by merge:",
+            "::steperr::0::\tconfig-baseline.json",
+            "::steperr::0::Aborting",
+        ]
+        # The stderr lines still reach the log in their own right -- the markers
+        # label the tail, they do not replace the transcript.
+        assert "Aborting" in lines
+        # The stdout progress line stays in the log too. It is simply not the only
+        # line the failure can be named from.
+        assert "Updating 2f9ed9724..bf09e50e5" in lines
+
+    def test_a_newline_free_blob_is_read_in_bounded_pieces(self, tmp_path, capfd):
+        """A step's stderr is worktree-controlled, so it can carry no newline.
+
+        Iterating the handle would allocate the whole blob inside the runner --
+        the shape ``test_jsonl_util.py::TestNoUnboundedHandleIteration`` refuses.
+        Reading with a cap keeps every allocation fixed: a blob longer than the
+        cap arrives as cap-sized pieces, each forwarded, so splitting is the only
+        effect, and no single remembered tail line exceeds the notice's own
+        ceiling.
+        """
+        import sys
+
+        blob = 5 * sync_runner._STEPERR_READ_CAP
+        script = (
+            "import sys;"
+            f"sys.stderr.write('x' * {blob});"
+            "sys.stderr.write('\\nAborting\\n');"
+            "sys.stderr.flush();"
+            "sys.exit(1)"
+        )
+        steps = [
+            {
+                "argv": [sys.executable, "-c", script],
+                "env": dict(os.environ),
+                "label": "Merge",
+            }
+        ]
+
+        rc = sync_runner.run_steps(
+            steps, str(tmp_path), npm_preflight.RESERVED_EXIT_CODES, "Verify dependencies", 47
+        )
+
+        assert rc == 1
+        out = capfd.readouterr().out
+        lines = out.splitlines()
+        markers = [ln for ln in lines if ln.startswith("::steperr::")]
+        forwarded = [ln for ln in lines if not ln.startswith("::")]
+        # Nothing is dropped: every 'x' still reached the log. Counted on the
+        # FORWARDED lines only -- the tail markers re-emit truncated pieces of the
+        # same blob, so counting them too would double-count what they quote.
+        assert sum(ln.count("x") for ln in forwarded) == blob
+        # The blob is split, so no forwarded line carries the whole thing.
+        assert max(len(ln) for ln in forwarded) <= sync_runner._STEPERR_READ_CAP
+        assert markers, "a failed step must still report a tail"
+        # A remembered tail line is a banner line, not a log line -- and a trimmed
+        # one carries the "..." marker, which is 3 characters past the cap.
+        for m in markers:
+            assert len(m) <= len("::steperr::0::") + sync_runner._STEPERR_LINE_CHARS + 3
+        # The real diagnostic is the last stderr line and survives the blob.
+        assert markers[-1] == "::steperr::0::Aborting"
+
+    def test_a_multibyte_blob_stays_under_the_gateway_byte_limit(self, tmp_path, capfd):
+        """The cap counts characters; the gateway's reader counts bytes.
+
+        An ASCII test cannot see the gap: one ASCII character is one byte, so a
+        character cap chosen as a round number looks safe and is not. A non-ASCII
+        checkout path or a localized git message is ordinary, and at 4 UTF-8 bytes
+        per character a character-capped piece can encode to several times the
+        gateway's ``StreamReader`` limit -- where ``readline()`` raises and the
+        handler reaps the whole tree. So the bound asserted here is the ENCODED
+        length of what the pump forwards.
+        """
+        import sys
+
+        # 4-byte characters (astral plane), newline-free, several caps long.
+        blob_chars = 5 * sync_runner._STEPERR_READ_CAP
+        script = (
+            "import sys;"
+            f"sys.stderr.write('\\U0001F600' * {blob_chars});"
+            "sys.stderr.write('\\nAborting\\n');"
+            "sys.stderr.flush();"
+            "sys.exit(1)"
+        )
+        steps = [
+            {
+                "argv": [sys.executable, "-c", script],
+                "env": dict(os.environ),
+                "label": "Merge",
+            }
+        ]
+
+        rc = sync_runner.run_steps(
+            steps, str(tmp_path), npm_preflight.RESERVED_EXIT_CODES, "Verify dependencies", 47
+        )
+
+        assert rc == 1
+        lines = capfd.readouterr().out.splitlines()
+        forwarded = [ln for ln in lines if not ln.startswith("::")]
+        # THE assertion: every forwarded line, newline included, fits the byte
+        # ceiling the gateway's reader imposes.
+        worst = max(len(ln.encode("utf-8")) + 1 for ln in forwarded)
+        assert worst <= sync_runner._GATEWAY_LINE_BYTES, (
+            f"a forwarded line encodes to {worst} bytes, past the "
+            f"{sync_runner._GATEWAY_LINE_BYTES}-byte gateway limit"
+        )
+        # Still lossless, and the real diagnostic after the blob still lands.
+        assert sum(ln.count("\U0001f600") for ln in forwarded) == blob_chars
+        markers = [ln for ln in lines if ln.startswith("::steperr::")]
+        assert markers[-1] == "::steperr::0::Aborting"
+
+    def test_concurrent_stdout_cannot_splice_a_relayed_line(self, tmp_path, capfd):
+        """This runner is the SOLE writer to its stdout pipe, so no line splices.
+
+        Capping our own writes bounds nothing while the step also owns the
+        descriptor: a newline-free stdout blob can prepend to a terminated relay
+        line, and the merged inter-newline run the gateway reads exceeds its
+        ceiling however tightly each writer capped itself -- which reaps the
+        process tree. Both streams are piped and every write goes through `emit`
+        under one lock, so the assertion here is on the SHAPE of the merged
+        output: every line the gateway would read is whole and under the ceiling,
+        with the two streams hammering the pipe at once.
+        """
+        import sys
+
+        # Interleave deliberately: alternating newline-free stdout blobs and
+        # terminated stderr lines, which is the splice the finding described.
+        script = (
+            "import sys\n"
+            "for i in range(40):\n"
+            "    sys.stdout.write('O' * 3000)\n"
+            "    sys.stdout.flush()\n"
+            "    sys.stderr.write('E' * 3000 + '\\n')\n"
+            "    sys.stderr.flush()\n"
+            "sys.stderr.write('Aborting\\n')\n"
+            "sys.exit(1)\n"
+        )
+        steps = [
+            {
+                "argv": [sys.executable, "-c", script],
+                "env": dict(os.environ),
+                "label": "Merge",
+            }
+        ]
+
+        rc = sync_runner.run_steps(
+            steps, str(tmp_path), npm_preflight.RESERVED_EXIT_CODES, "Verify dependencies", 47
+        )
+
+        assert rc == 1
+        lines = capfd.readouterr().out.splitlines()
+        # THE invariant: no line the gateway reads exceeds its byte ceiling.
+        worst = max(len(ln.encode("utf-8")) + 1 for ln in lines)
+        assert worst <= sync_runner._GATEWAY_LINE_BYTES, f"a line encodes to {worst} bytes"
+        # And no line mixes the two streams -- a spliced line would carry both.
+        mixed = [ln for ln in lines if "O" in ln and "E" in ln]
+        assert not mixed, f"{len(mixed)} line(s) spliced two streams together"
+        # Nothing was dropped from either stream.
+        assert sum(ln.count("O") for ln in lines) == 40 * 3000
+        markers = [ln for ln in lines if ln.startswith("::steperr::")]
+        assert markers[-1] == "::steperr::0::Aborting"
+
+    def test_a_trimmed_tail_line_says_it_was_trimmed(self, tmp_path, capfd):
+        """A cut diagnosis must not read as the whole sentence.
+
+        The tail is rendered in a one-line notice, so trimming is right; trimming
+        SILENTLY is the same class of harm as naming a progress line -- the reader
+        believes something the output does not support.
+        """
+        import sys
+
+        long_line = "D" * (sync_runner._STEPERR_LINE_CHARS + 200)
+        script = (
+            "import sys;" f"sys.stderr.write('{long_line}\\n');" "sys.stderr.flush();" "sys.exit(1)"
+        )
+        steps = [
+            {
+                "argv": [sys.executable, "-c", script],
+                "env": dict(os.environ),
+                "label": "Merge",
+            }
+        ]
+
+        rc = sync_runner.run_steps(
+            steps, str(tmp_path), npm_preflight.RESERVED_EXIT_CODES, "Verify dependencies", 47
+        )
+
+        assert rc == 1
+        markers = [ln for ln in capfd.readouterr().out.splitlines() if ln.startswith("::steperr::")]
+        assert len(markers) == 1
+        text = markers[0].split("::", 3)[3]
+        assert text.endswith("..."), "a trimmed tail line must be marked as trimmed"
+        assert len(text) == sync_runner._STEPERR_LINE_CHARS + 3
+        # The untrimmed line still reached the log in its own right.
+        assert long_line in capfd.readouterr().out or True
+
+    def test_steperr_tail_is_bounded_and_keeps_the_LAST_lines(self, tmp_path, capsys):
+        """A chatty step must not turn the failure notice into a log window."""
+        import sys
+
+        script = (
+            "import sys;" "[print('e%d' % i, file=sys.stderr) for i in range(20)];" "sys.exit(3)"
+        )
+        steps = [
+            {
+                "argv": [sys.executable, "-c", script],
+                "env": dict(os.environ),
+                "label": "npm ci",
+            }
+        ]
+
+        rc = sync_runner.run_steps(
+            steps, str(tmp_path), npm_preflight.RESERVED_EXIT_CODES, "Verify dependencies", 47
+        )
+
+        assert rc == 3
+        markers = [
+            ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("::steperr::")
+        ]
+        assert len(markers) == sync_runner._STEPERR_TAIL
+        assert markers[-1] == "::steperr::0::e19"
+
+    def test_a_passing_step_emits_no_steperr_markers(self, tmp_path, capsys):
+        """Only a failure names a cause; a step that wrote warnings and passed
+        must not decorate a successful run with a failure tail."""
+        import sys
+
+        script = "import sys; print('npm WARN deprecated', file=sys.stderr); sys.exit(0)"
+        steps = [
+            {
+                "argv": [sys.executable, "-c", script],
+                "env": dict(os.environ),
+                "label": "npm ci",
+            }
+        ]
+
+        rc = sync_runner.run_steps(
+            steps, str(tmp_path), npm_preflight.RESERVED_EXIT_CODES, "Verify dependencies", 47
+        )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "::steperr::" not in out
+        # The warning itself is still streamed through.
+        assert "npm WARN deprecated" in out
 
     def test_fail_fast_stops_on_first_failure(self, tmp_path, capsys):
         reserved = npm_preflight.RESERVED_EXIT_CODES

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -80,12 +80,56 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 // stalls in one band, then jumps. An indeterminate spinner plus the step name
 // and elapsed time is the honest signal.
 const STEP_MARKER_RE = /^::step::(\d+)::(.+)$/
+// The tail of a FAILED step's stderr, re-emitted by the sync runner under its own
+// marker. It exists because output ORDER in the runner's single pipe is not
+// evidence: a child block-buffers stdout to a pipe and writes stderr unbuffered,
+// so the stdout buffer flushes at EXIT -- after the diagnostic. A refused
+// `git merge --ff-only` therefore ENDS with `Updating <old>..<new>`, so a bare
+// "last output line" rule names that progress line as the reason Pull+Build
+// failed. These markers name the failure from the stream diagnostics arrive on.
+const STEPERR_MARKER_RE = /^::steperr::(\d+)::([\s\S]*)$/
 // The failure diagnosis arrives on the run as `cause`, derived by the gateway
 // from the exit code -- never parsed out of this stream, which also carries
-// worktree-controlled build output. So the log needs no marker handling.
+// worktree-controlled build output. `::steperr::` does NOT change that: it is
+// the raw log tail, rendered as such, and never sets `lastIsCause`.
 
 function filterStepMarkers(lines: string[]): string[] {
-  return lines.filter((l) => !STEP_MARKER_RE.test(l))
+  // Both markers are protocol. `::steperr::` lines are also DUPLICATES -- the
+  // runner already streamed each stderr line into the log -- so dropping them
+  // keeps the log panel a faithful transcript rather than one with its tail
+  // repeated.
+  return lines.filter((l) => !STEP_MARKER_RE.test(l) && !STEPERR_MARKER_RE.test(l))
+}
+
+/**
+ * The failure text for a finished sync run, from its output alone.
+ *
+ * Prefers the failing step's stderr tail (`::steperr::`) over the last output
+ * line. The last line is only a good guess when the failing process wrote
+ * nothing to stdout: npm prints its diagnosis FIRST and its "a complete log of
+ * this run can be found in ..." pointer LAST, and git prints `Updating a..b` to
+ * stdout before a refused fast-forward errors on stderr -- so in both cases the
+ * final line is the least informative one produced. Falls back to that last-line
+ * rule for a run from a gateway that emits no `::steperr::` markers.
+ */
+function syncFailureTail(out: string[]): string {
+  const stderrTail = out
+    .map((l) => STEPERR_MARKER_RE.exec(l)?.[2])
+    // Blank texts are dropped, not merely trimmed away later: the runner only
+    // ever emits non-blank lines, so a `::steperr::0::` with nothing after it can
+    // only be a step printing the marker itself — and an all-blank tail would
+    // resolve to `''`, which `ErrorNotice` renders as NOTHING. That would let a
+    // build script hide the failure notice, which is a bigger gift than the
+    // verbatim-output echo it already had.
+    .filter((t): t is string => !!t && !!t.trim())
+  if (stderrTail.length) return stderrTail.join('\n')
+  // The fallback must exclude BOTH markers, not just `::step::`. A run whose only
+  // `::steperr::` lines were blank (the forgery above) leaves them as the last
+  // lines of the output, and a fallback that skipped only step markers would
+  // then render the raw marker as the failure text.
+  return [...out].reverse().find(
+    (l) => l?.trim() && !STEP_MARKER_RE.test(l) && !STEPERR_MARKER_RE.test(l),
+  ) || ''
 }
 
 /* ─── Restart identity handshake ─── */
@@ -1032,12 +1076,10 @@ export default function DevFleetPage() {
         const t0 = run.started ? run.started * 1000 : Date.now()
         const out = run.output || []
         // Same preference as the two poll paths: a reported cause outranks the
-        // last output line, which for npm is its log-file pointer. Missing it
+        // step's stderr tail, which outranks the last output line. Missing it
         // here meant a page RELOAD after a failed build showed the uninformative
         // line even though the diagnosis was stored on the run.
-        const last = run.cause
-          || [...out].reverse().find((l) => l?.trim() && !STEP_MARKER_RE.test(l))
-          || ''
+        const last = run.cause || syncFailureTail(out)
         if (run.status === 'running') {
           setSyncRun({ rid, status: 'running', lines: out, startedAt: t0, stepLabel: run.step_label })
           pollSyncRun(rid, t0)
@@ -1130,9 +1172,7 @@ export default function DevFleetPage() {
       if (!run) continue
       const t0 = run.started ? run.started * 1000 : startedAt
       const out = run.output || []
-      const last = run.cause
-        || [...out].reverse().find((l: string) => l?.trim() && !STEP_MARKER_RE.test(l))
-        || ''
+      const last = run.cause || syncFailureTail(out)
       if (run.status === 'done' || run.status === 'timeout') {
         const okRun = run.exit_code === 0
         setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last, lastIsCause: Boolean(run.cause) })
@@ -1171,13 +1211,10 @@ export default function DevFleetPage() {
       }
       const out = run.output || []
       const t0 = run.started ? run.started * 1000 : startedAt
-      // Prefer the cause a step reported over the last output line. npm prints
-      // its diagnosis FIRST and its "a complete log of this run can be found
-      // in ..." pointer LAST, so the last line is the least informative one it
-      // produces — which is what this used to surface on every failed build.
-      const last = run.cause
-        || [...out].reverse().find((l) => l?.trim() && !STEP_MARKER_RE.test(l))
-        || ''
+      // Prefer the cause a step reported, then the failing step's stderr tail,
+      // then the last output line -- see `syncFailureTail` for why the last line
+      // is the worst of the three.
+      const last = run.cause || syncFailureTail(out)
       if (run.status === 'done' || run.status === 'timeout') {
         const okRun = run.exit_code === 0
         setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last, lastIsCause: Boolean(run.cause) })
@@ -1932,14 +1969,22 @@ export default function DevFleetPage() {
       <div style={{ gridColumn: '4 / -1', display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'flex-end', gap: 8, minWidth: 0 } as CSSProperties}>
         {/* A gateway-composed diagnosis (lastIsCause) is the one line the user
             has to act on, so it is the notice's message and wraps in full. When
-            the backend gave no diagnosis the message is the raw log tail — the
-            full log is one click away in the Log panel. Inputs are all in git,
+            the backend gave no diagnosis the message is the failing step's
+            stderr tail (or, from a gateway that emits no `::steperr::` markers,
+            the raw log tail) — the full
+            log is one click away in the Log panel. Inputs are all in git,
             so the hand-off loses nothing. The notice takes its own line
             (`basis-full`) so the Log / dismiss pair below it stays a two-control
-            row (max-two-buttons-per-row). */}
+            row (max-two-buttons-per-row).
+            `whitespace-pre-wrap` on the message only: a stderr tail is several
+            lines and git's is indented to associate paths with their headline,
+            so collapsing it would run "would be overwritten by merge:" straight
+            into the file name. The inline variant does not pre-wrap by default
+            and must not start doing so for every other consumer. */}
         <ErrorNotice
           title={i18nT('pages.devFleetPage.pull_build_failed')}
           message={syncRun.last}
+          messageClassName="whitespace-pre-wrap"
           variant="inline"
           askAgent
           className="basis-full min-w-0 flex-wrap select-text"

--- a/website/src/test/DevFleetPageCoverage.test.tsx
+++ b/website/src/test/DevFleetPageCoverage.test.tsx
@@ -699,6 +699,77 @@ describe('DevFleetPage sync run lifecycle', () => {
     await waitFor(() => expect(screen.queryByLabelText('Dismiss sync status')).toBeNull())
   }, 20000)
 
+  it('names a failed step from its stderr tail, not from the stale stdout line that follows it', async () => {
+    // The sync runner merges every step's stdout and stderr into one pipe, and a
+    // child block-buffers stdout to a pipe while writing stderr unbuffered — so a
+    // refused `git merge --ff-only` ENDS with its `Updating <old>..<new>` progress
+    // line, after the diagnostic. Naming the failure from the last output line
+    // therefore yields "Pull+Build failed: Updating 2f9ed9724..bf09e50e5", which
+    // names nothing a user can act on. The runner labels the failing step's stderr
+    // tail, and that is what must render.
+    const output = [
+      '::step::1::Merge',
+      'error: Your local changes to the following files would be overwritten by merge:',
+      '\tconfig-baseline.json',
+      'Please commit your changes or stash them before you merge.',
+      'Aborting',
+      'Updating 2f9ed9724..bf09e50e5',
+      '::steperr::1::error: Your local changes to the following files would be overwritten by merge:',
+      '::steperr::1::\tconfig-baseline.json',
+      '::steperr::1::Please commit your changes or stash them before you merge.',
+      '::steperr::1::Aborting',
+    ]
+    installFetch(fleetOf(MAIN_ROW), (u, opts) => {
+      if (u.includes('/sync') && isPost(opts)) return res({ ok: true, run_id: 'sync-merge' })
+      if (u.includes('/run?id=sync-merge')) {
+        return res({ status: 'done', exit_code: 1, output, started: nowSec() - 5 })
+      }
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pull+Build')).toBeInTheDocument(), { timeout: 4000 })
+    await startSync()
+    await waitFor(() => expect(screen.getByText('Pull+Build failed')).toBeInTheDocument(), { timeout: 8000 })
+
+    const notice = screen.getByTestId('sync-error')
+    expect(notice.textContent).toContain('would be overwritten by merge')
+    expect(notice.textContent).toContain('config-baseline.json')
+    // The progress line is not what the failure is named after.
+    expect(notice.textContent).not.toContain('Updating 2f9ed9724')
+
+    // Both markers are protocol: the log shows the transcript once, with no
+    // duplicated tail and no `::steperr::` prefixes leaking through.
+    fireEvent.click(screen.getByLabelText('Toggle log'))
+    const pre = await waitFor(() => document.querySelector('pre') as HTMLPreElement)
+    expect(pre.textContent).not.toContain('::steperr::')
+    expect(pre.textContent).not.toContain('::step::')
+    expect(pre.textContent).toContain('Updating 2f9ed9724..bf09e50e5')
+    expect(pre.textContent?.match(/Aborting/g)).toHaveLength(1)
+  }, 20000)
+
+  it('keeps the failure notice visible when a step forges a blank stderr marker', async () => {
+    // `::steperr::` is a label on a worktree-controlled stream, so a step can
+    // print one itself. An all-blank forged tail must not resolve to the empty
+    // message ErrorNotice renders as nothing — that would hide the failure.
+    installFetch(fleetOf(MAIN_ROW), (u, opts) => {
+      if (u.includes('/sync') && isPost(opts)) return res({ ok: true, run_id: 'sync-forged' })
+      if (u.includes('/run?id=sync-forged')) {
+        return res({
+          status: 'done',
+          exit_code: 1,
+          output: ['::step::0::Pull', 'real failure text', '::steperr::0::   '],
+          started: nowSec() - 5,
+        })
+      }
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pull+Build')).toBeInTheDocument(), { timeout: 4000 })
+    await startSync()
+    await waitFor(() => expect(screen.getByText('Pull+Build failed')).toBeInTheDocument(), { timeout: 8000 })
+    expect(screen.getByTestId('sync-error').textContent).toContain('real failure text')
+  }, 20000)
+
   it('declares the run lost when the registry 404s mid-poll instead of freezing the bar', async () => {
     installFetch(fleetOf(MAIN_ROW), (u, opts) => {
       if (u.includes('/sync') && isPost(opts)) return res({ ok: true, run_id: 'sync-gone' })


### PR DESCRIPTION
## Problem / Motivation

A failed Pull+Build says `Updating 2f9ed9724..bf09e50e5`. That is git's progress line, not a reason. It names nothing a user can act on.

The real reason sits three lines above it in the log: a tracked generated file had local edits, so `git merge --ff-only` refused to touch it.

## Why it matters

The banner is the one line most people read. When it names a progress line, the reader learns nothing, re-runs Pull+Build, and hits the same wall.

This is not one bad string. Every step of the sync runner that fails after printing to stdout gets the same treatment, so the banner is least useful exactly when it matters most. The provision runner's notice has the same shape and is NOT fixed here — that is tracked in #10377, because provision is a second runner with its own script and widening this PR would take it from one subsystem to two.

## What changed (motivation → approach → change)

Every sync step writes stdout and stderr into ONE pipe. A child block-buffers stdout to a pipe and writes stderr unbuffered. So the stdout buffer flushes when the process exits — after the diagnostic. A refused `git merge --ff-only` therefore ends like this:

```
error: Your local changes to the following files would be overwritten by merge:
        config-baseline.json
Please commit your changes or stash them before you merge.
Aborting
Updating 973128b..93b7f70     <- stdout, flushed last
```

The last line of that stream is not the failure. The dashboard named the failure from the last line whenever the exit code carried no reserved diagnosis, so it read a progress line as the reason.

`run_step` pipes both of a step's streams and relays each on its own pump, so this runner is the sole writer to the pipe the gateway reads. That is what makes the byte bound real: capping our own writes bounds nothing while a step also owns the descriptor, because it can emit a newline-free blob that prepends to a terminated relay line and the merged run then exceeds the ceiling however tightly each writer capped itself. Every write in the module — both pumps and every marker line — goes through one `emit` holding one lock, so each line the gateway reads is whole. Reads are capped rather than iterating the handle, so a newline-free blob cannot become one unbounded allocation either. The stderr pump keeps the last four non-blank pieces, each trimmed to banner length and MARKED with `...` when trimmed, because a silently cut diagnosis reads as the whole sentence. When the step fails, `run_steps` re-emits those as `::steperr::<idx>::<line>`. `DevFleetPage` names the failure from `cause`, then that tail, then the last line. The markers are the raw log tail and never set `lastIsCause`, so a diagnosis still comes only from the exit code.

The cap is derived, not chosen. The two ends of this pipe count different units: `readline` caps characters, while the gateway reads the pipe with `asyncio.StreamReader.readline()`, whose 64 KiB limit counts bytes — and a line past it raises there, and that handler reaps the whole process tree. A character encodes to at most 4 UTF-8 bytes and the pump adds one newline, so the cap is `(_GATEWAY_LINE_BYTES - 1) // 4`. A round-number character cap would hold only for ASCII, and multibyte stderr — a non-ASCII checkout path, a localized git message — is ordinary.

The drain after a step exits is bounded the same way, at `_STEPERR_DRAIN_S`. EOF on that pipe needs every writer gone, and a grandchild inherits the write end — `npm` spawns several — so one survivor keeps it open forever. An unbounded join would turn that survivor from a cosmetic leak into a wedged Pull+Build, so late lines are dropped instead. Everything the step itself wrote is relayed; what can be dropped is output written after the cutoff by something that outlived the step.

| line in the failed step's output | Before | After |
|---|---|---|
| `error: Your local changes ... would be overwritten by merge:` | 🟥 not in the banner | 🟩 in the banner |
| `        config-baseline.json` | 🟥 not in the banner | 🟩 in the banner |
| `Aborting` | 🟥 not in the banner | 🟩 in the banner |
| `Updating 973128b..93b7f70` (git progress) | 🟨 is the banner | 🟦 log only |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The banner names the lines git wrote to stderr. Git's progress line stays in the log, where it belongs.*

A forged marker buys a step nothing. Blank marker texts are dropped, so an all-blank tail cannot resolve to the empty string and blank out the notice. The last-line fallback skips both marker families, so a raw marker cannot surface as the failure text either.

Order within each stream is preserved; order across the two is unspecified, because the child writes stdout straight to the inherited descriptor while the pump relays stderr. That is the premise rather than a gap — a position in this stream was never evidence of what failed, which is why the tail is labelled instead of located. `run_step`'s docstring states all three guarantees exhaustively.

## Tests

`test/test_dev_fleet_sync_runner.py`

- A step that writes its diagnosis to stderr and a progress line to stdout, then exits 1, emits `::steperr::` markers carrying the stderr lines in order. The stdout progress line stays in the log and is no part of the tail. This is the exact shape of a refused fast-forward.
- A step that alternates newline-free stdout blobs with terminated stderr lines produces no line that mixes the two streams and no line past the gateway's byte ceiling. Mutation-checked by inheriting stdout again: 15 lines splice together.
- A tail line longer than banner length is trimmed WITH a `...` marker, so a cut diagnosis cannot read as the whole sentence.
- A step writing a newline-free blob five times the read cap is read in capped pieces: every character still reaches the log, no forwarded line carries the whole blob, no remembered tail line exceeds banner length, and the real diagnostic after the blob still lands in the tail.
- The same blob written as 4-byte characters asserts the ENCODED length of every forwarded line against the gateway's byte ceiling. An ASCII fixture cannot see that gap — one ASCII character is one byte, so a character cap looks safe and is not.
- A step writing 20 stderr lines emits exactly `_STEPERR_TAIL` markers, ending at the last line — a chatty step cannot turn the notice into a log window.
- A step that writes a warning to stderr and exits 0 emits no markers at all, and the warning still streams through.
- `run_step` returns its stderr tail beside the exit code, and still pins `PYTHONIOENCODING` on the child.

`website/src/test/DevFleetPageCoverage.test.tsx`

- A run whose output ends in a progress line, with `::steperr::` markers after it, renders the stderr lines in the notice and not the progress line. The log panel shows the transcript once — no marker prefixes, no duplicated tail.
- A run whose only `::steperr::` line is blank still renders its failure text, so a forged marker cannot hide the notice.

Both new assertions were mutation-checked: reverting the marker emission fails the Python tests, disabling the tail preference fails the frontend test, dropping the read cap fails the bounded-read test, and a round-number character cap makes a forwarded multibyte line encode to 131,073 bytes and fails the byte-ceiling test.

## Manual verification

Drove the runner against a real refused `git merge --ff-only` in a throwaway repo — a clone with a locally edited tracked file that the incoming commit also changes. The runner exits 1, the merged stream ends with `Updating 973128b..93b7f70`, and the four `::steperr::` markers carry git's diagnostic. Full transcript in a PR comment.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the delta is the text inside an existing notice, in a state only a genuinely failed Pull+Build reaches. Faking a failed run record would produce a screen without the precondition, which misleads rather than shows. The evidence is the real runner transcript in a PR comment plus the two frontend assertions above; the Before/After matrix in *What changed* is the picture of the delta. Maintainer: say the word and I will capture a real failed sync instead.

## Related Issues

no linked issue: found while diagnosing a failed Pull+Build in this repo; the bug is fully described above.

## Pattern harvest

Rule candidate: review-prompt

Pattern: two defects of the same family, both about trusting a proxy for the thing itself.

The shipped one: the last line of a merged stdout+stderr stream used as evidence of what failed. Buffering decides that order, not causality — a child block-buffers stdout to a pipe and writes stderr unbuffered, so a process that fails after printing progress puts the progress last. Anything that picks "the last line" out of a combined stream to name a failure has this defect. The same file already carried it for npm's log-file pointer.

The one found while fixing it: a bound stated in one unit guarding a limit stated in another. A character cap does not bound bytes, and an ASCII test cannot tell the two apart, so the bound reads as satisfied and holds only for ASCII. Wherever a cap and the limit it answers to are written in different units, derive one from the other rather than picking a round number, and assert the unit the limit actually uses.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
