### PR TITLE
fix(config): require jsonschema in installed packages

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -808,6 +808,12 @@ prevent. `test_default_emitted_section_keys_are_all_recognized` guards
 Loads config from disk. Merges `config.local.json` overlay if present.
 Returns defaults if file is missing or invalid.
 
+The installed package declares `jsonschema` as a core runtime dependency so
+schema validation runs outside development environments too. The import guard
+still lets an incomplete or manually damaged install load, but that fallback
+must not be treated as the normal packaged behavior. Generated package metadata
+is tested to ensure the validator is required without the `dev` extra.
+
 **Hot-path cache.** `load()` is called per message / per request on several hot
 paths. The expensive work — reading `config.json` (+ `config.local.json`),
 `json.loads`, `_deep_merge`, and the full `jsonschema.validate` — is cached as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,14 +41,9 @@ dev = [
     "mypy==1.14.1",
     "black==26.3.1",
     "isort==6.0.0",
-    # Not a dev TOOL. kiro_crew.config.validation imports jsonschema behind a
-    # try/except and returns the config unvalidated when the import fails, so a
-    # run without it exercises none of the schema-validation path and silently
-    # SKIPS the 11 tests that cover it (pytest scores a skip as a pass). It is
-    # declared here so those guards actually run. Whether jsonschema should also
-    # be a runtime dependency -- making validation always-on for users rather
-    # than opt-in-by-accident -- is a separate, user-visible call and is
-    # deliberately not made here.
+    # Keep CI on a pinned version of the runtime config validator. The runtime
+    # dependency is declared separately in setup.cfg so packaged installs do
+    # not silently skip schema checks when dev extras are absent.
     "jsonschema==4.26.0",
     # Same shape as jsonschema above, and the same reason. PyJWT ships in the
     # optional `teams` extra, which CI never installs, so `test_teams_client.py`'s

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,10 @@ install_requires =
     # pathspec's GitIgnoreSpec is the maintained implementation of gitignore
     # matching semantics (negation, dir-only patterns, last-match-wins).
     pathspec>=0.12
+    # Config validation runs on every installed gateway, not only in a source
+    # checkout with dev extras. Without this dependency the optional import in
+    # config.validation silently skips schema checks on malformed config.
+    jsonschema>=4.26,<5
     numpy>=1.21,<3
     snowballstemmer>=1.0
     # Windows ships no IANA tz database, so stdlib zoneinfo.ZoneInfo() raises

--- a/test/test_config_validation.py
+++ b/test/test_config_validation.py
@@ -9,11 +9,36 @@ global.
 from __future__ import annotations
 
 import logging
+import subprocess
+import sys
+from email.parser import Parser
+from pathlib import Path
 
 import pytest
 
 from kiro_crew.config import loader as _loader_module
 from kiro_crew.config import validation
+
+
+def test_published_metadata_requires_config_validator(tmp_path: Path) -> None:
+    """A wheel install must bring the validator that the loader calls at runtime."""
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "setup.py", "egg_info", "--egg-base", str(tmp_path)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    metadata = Parser().parsestr(
+        (tmp_path / "kirocrew.egg-info" / "PKG-INFO").read_text(encoding="utf-8")
+    )
+    requirements = metadata.get_all("Requires-Dist", [])
+    assert any(
+        req.lower().startswith("jsonschema") and "extra" not in req.partition(";")[2].lower()
+        for req in requirements
+    ), requirements
 
 
 class TestConfigCache:


### PR DESCRIPTION
## Problem / Motivation

A normal Kiro Crew installation does not declare jsonschema, even though config validation imports it at runtime. When the import fails, validate_config_data returns without schema checks, so malformed or deprecated config can pass silently. Development installs hide the gap because the dev extra pins jsonschema.

## Why it matters

Installed users can receive different config-validation behavior from contributors running tests. The fallback keeps an incomplete install running, but it should not be the normal packaged behavior.

## What changed (motivation → approach → change)

Declare jsonschema as a core runtime dependency compatible with the version pinned for development. Keep the import fallback for incomplete or damaged installs. Update the config spec and the development-dependency comment. A generated PKG-INFO regression checks that the dependency is required without any extra.

## Tests

- Red-before: generated package metadata contained jsonschema only with an extra == "dev" marker, so the new runtime-dependency assertion failed.
- Green-after: test_config_validation.py 34 passed, including the generated metadata check.
- Black, flake8, documentation lint, brand gate, and diff check pass.

## Manual verification

N/A — setuptools-generated package metadata and the focused config-validation suite cover the contract.

## Related Issues

Addresses #9753.

## Pattern harvest

Rule candidate: review-prompt.
Pattern: a guarded runtime import can silently disable required validation when its dependency exists only in development extras.

## Checklist

- [x] One Conventional Commit
- [x] Existing focused tests pass and regression coverage added
- [x] Self-review completed
- [x] Configuration system spec updated
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. Do not invent CLA text. -->