### PR TITLE
refactor(acp): route escaped-child probes through platform_compat

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -24,7 +24,6 @@ import logging
 import os
 import re
 import shutil
-import signal
 import stat
 import subprocess as subprocess_mod
 import sys
@@ -3400,14 +3399,15 @@ def _kill_escaped_children(child_pids: dict[int, int | None] | dict[int, ChildRe
     POSIX-only sweep: it cleans up children that reparented out of the killed
     process group (e.g. MCP servers). On Windows there are no process groups —
     ``kill_process_tree`` already used ``taskkill /T`` to walk the whole child
-    tree — so there is nothing left to sweep, and the raw ``os.kill`` /
-    ``signal.SIGKILL`` below are unavailable there. No-op on win32.
+    tree — so there is nothing left to sweep, and the POSIX signal APIs are
+    unavailable there. No-op on win32.
     """
     if platform_compat.IS_WINDOWS:
         return
     for cpid in reversed(list(child_pids.keys())):
         try:
-            os.kill(cpid, 0)  # still alive?
+            if not platform_compat.pid_exists(cpid):
+                continue  # gone — nothing to sweep
             record = child_pids.get(cpid)
             # Support both old (int|None) and new (tuple) record shapes
             if isinstance(record, tuple):
@@ -3420,7 +3420,7 @@ def _kill_escaped_children(child_pids: dict[int, int | None] | dict[int, ChildRe
             ):
                 logger.debug("Skipping PID %d — not our process (recycled?)", cpid)
                 continue
-            os.kill(cpid, signal.SIGKILL)
+            platform_compat.kill_pid(cpid, platform_compat.SIGKILL)
             logger.debug("Killed escaped child PID %d", cpid)
         except (ProcessLookupError, OSError):
             pass

--- a/test/test_windows_kill_probe_audit.py
+++ b/test/test_windows_kill_probe_audit.py
@@ -50,15 +50,6 @@ pytestmark = pytest.mark.xdist_group(name="tree_scan_test_windows_kill_probe_aud
 # ``file::function`` sites allowed to keep a raw signal-0 probe, with the reason
 # it can never run on Windows. Keep this list SHORT and each entry justified.
 GATED_PROBES: dict[str, str] = {
-    # POSIX-only sweep of children that reparented out of the killed process
-    # group. Guarded by an `if platform_compat.IS_WINDOWS: return` on the first
-    # line of the body, and moot there anyway: kill_process_tree already uses
-    # `taskkill /T` to walk the whole child tree, so nothing is left to sweep.
-    # The function docstring states this.
-    "acp/client.py::_kill_escaped_children": (
-        "explicit `if platform_compat.IS_WINDOWS: return` early-out; "
-        "process groups do not exist on Windows"
-    ),
     # platform_compat IS the shim — its POSIX branch is the real implementation
     # that every other caller is supposed to route through, and it is reached
     # only under `if IS_POSIX`.


### PR DESCRIPTION
## Problem / Motivation

`_kill_escaped_children` (`src/kiro_crew/acp/client.py`) is the POSIX-only sweep that SIGKILLs ACP children which survived `killpg` because they reparented out of the killed process group; MCP servers are the usual case. When a session tears down, this is the code that walks the recorded child PIDs in reverse, confirms each one is still ours, and kills the survivors. Until this PR it did both of its process operations with raw syscalls: a liveness probe via `os.kill(cpid, 0)` and the kill itself via `os.kill(cpid, signal.SIGKILL)`.

Every other liveness and kill site in `src/kiro_crew` routes those two operations through `platform_compat` (`pid_exists`, `kill_pid`, `kill_process_tree`), per the helper table in `docs/system-specs/common/platform-compat.md` and the cross-platform rule in `AGENTS.md`. This function was the one remaining exception, and the tree carried that fact explicitly: `test_windows_kill_probe_audit.py` is a whole-tree tripwire that fails on any raw `os.kill(pid, 0)` outside its `GATED_PROBES` allowlist, and that allowlist carried a justified entry for exactly this function.

## Why it matters

The raw probe here was never live-dangerous. The function returns on its first line on Windows (there are no process groups there, and `kill_process_tree` has already walked the tree with `taskkill /T`), and signal-0 as a probe is idiomatic on POSIX. So this is not a bug fix, and I want to be upfront that the observable POSIX behavior before and after is the same. The cost of the exemption was maintenance, in three places.

The allowlist is only honest if its entries stay accurate. The justification text for this entry had to keep describing the guard on the first line of the function body forever; if someone later restructures `_kill_escaped_children`, that comment silently rots while the exemption keeps working. `test_allowlist_has_no_stale_entries` exists because of a sharper worry the file states plainly: a stale-looking name in the allowlist is what would give cover to a future probe that reuses it. And the added-line CI gate only inspects lines a PR adds, so a probe arriving through a file move or a rebase is invisible to it; the whole-tree tripwire is the real net, and every raw probe outside the shim weakens what that net can claim.

With this change, `GATED_PROBES` shrinks to its floor: the two entries for `platform_compat`'s own POSIX branches, which are the real implementations every other caller is supposed to route through. The invariant the tripwire can now prove is the clean one: raw signal-0 exists only inside the shim itself.

## What changed (motivation → approach → change)

Symptom: one function bypasses the shim the rest of the tree uses. Root cause: it was grandfathered past the shim, and its exemption documented why that was tolerable instead of fixing it. The change is two call sites and one allowlist edit.

- the liveness probe `os.kill(cpid, 0)` becomes `platform_compat.pid_exists(cpid)`, with a `continue` when it reports the pid gone (previously the probe raised `ProcessLookupError` and the handler skipped the pid; same outcome, no exception round-trip)
- the kill `os.kill(cpid, signal.SIGKILL)` becomes `platform_compat.kill_pid(cpid, signal.SIGKILL)`; the POSIX branch of `kill_pid` is a plain `os.kill` that propagates the same exceptions, so the existing `except (ProcessLookupError, OSError)` handler is untouched
- the `GATED_PROBES` entry for `acp/client.py::_kill_escaped_children` is removed; the tripwire's stale-entry test requires the exemption and the code change to travel together, which is why they share a commit

No new imports were needed (`platform_compat` was already in the file for the `IS_WINDOWS` early return), and the docstring line about the raw `os.kill` / `signal.SIGKILL` below now describes the POSIX signal APIs instead.

Two alternatives, and why I did not take them:

- Leave the function grandfathered. It works, and the tripwire holds. But the allowlist would permanently carry an entry whose only job is to explain why this one function may bypass the rule everything else follows, and the file's own stale-entry test exists precisely because names in that list are risky. Retiring the entry is the point.
- Route only the probe and keep the raw SIGKILL. The tripwire audits only the signal-0 form, so that would pass every gate while leaving the function half on the shim and half off it. Routing both makes the sweep uniformly shim-routed for no extra diff.

One behavioral nuance I want to disclose rather than bury: on the rare EPERM path, the old probe raised `PermissionError`, the handler skipped the pid, and the child survived untouched. `pid_exists` reports "exists but unsignalable" as `True`, so the sweep now runs the identity check (start-time token and recorded basename, both deny-by-default) before deciding. If the child verifies as ours but the kill is still denied, `kill_pid` raises and the same handler swallows it. The observable outcome in every branch is the same: a process we cannot signal does not get killed by this sweep.

## Tests

The tripwire is the regression lock for the allowlist half:

- `python -m pytest test/test_windows_kill_probe_audit.py` — 4 passed: `test_no_ungated_signal_zero_probe` (no raw probe outside the allowlist anywhere in the tree), `test_allowlist_has_no_stale_entries` (passes only because the exemption and the probe left together), `test_gated_sites_carry_a_written_justification`, and the `apps/backend.py::_pid_alive` regression pin

Everything else that can run on this machine:

- `python -m pytest test/test_process_tree.py` — 20 passed, 5 skipped. This file owns the function's contracts, including `test_kill_escaped_children_windows_noop`, which runs the changed function on Windows and asserts the early return. Its `TestKillEscapedChildren` class (dead-pid handling, reverse order, allowlist skip) monkeypatches `os.kill` globally and still passes, because `platform_compat` calls through the same module object; those cases execute for real in the Linux CI shards
- `python -m pytest test/test_platform_compat.py` — 290 passed, 47 skipped (the skips are the shim's POSIX legs, not exercised on a Windows checkout)
- `python -m pytest test/test_acp_client.py -k "KillEscaped or ChildPids or IsOurChild or ReadBasename or escaped"` — 6 passed, 13 skipped (POSIX-only classes)
- `python -m pytest test/test_acp_offload.py` — 2 passed, 1 skipped (the offload path patches the sweep wholesale; confirms nothing about the call shape changed for its callers)
- `mypy src/kiro_crew/acp/client.py` — clean; `black --check` and `flake8` clean on both touched files

I ran this on Windows, so I have not executed the sweep's POSIX loop myself; the Linux CI shards will be the first real execution of the changed loop, and every assertion that could run here ran green.

## Manual verification

There is no user-visible surface, so nothing to click. If a reviewer wants one observation on Linux: run a session whose agent spawns an MCP server that ends up in a different process group, stop the session, and the debug log shows `Killed escaped child PID <pid>` at the same point it did before this PR, now via the shim. On Windows the sweep still returns on its first line, which the no-op test pins.

## Screenshots / video

Not applicable; there is no rendering or UI difference to capture. Happy to add a debug-log capture if that is useful.

## Related Issues

No dedicated issue. This works the same seam as #10121, which routes the two gateway-stop kill sites (`cli_server._stop`, `dashboard/port_reclaim`) through `platform_compat`; that PR and this one are independent and touch disjoint files. After both land, every process liveness and kill call in `src/kiro_crew` outside the shim itself goes through `platform_compat`.

## Checklist

- [x] Existing tests pass, and the tripwire allowlist was tightened in the same commit to lock the change
- [x] Self-review completed; the change follows the established `platform_compat` shim pattern rather than inventing a new seam
- [x] Documentation — N/A: the helper table in `docs/system-specs/common/platform-compat.md` already mandates `pid_exists` for liveness and `kill_pid` for kills; the code now matches it, so there is nothing to update
- [x] No secrets, credentials, or internal references in the diff