### PR TITLE
docs: sweep stale icacls rationale from test/ and docs/ (#7002)

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -386,13 +386,19 @@ It runs **twice**, once before `sqlite3.connect` and once after. The first call
 is what stops the schema migrations running against a file another local user
 can still write; the second covers whatever SQLite has just created.
 
-The Windows cost is up to 11 `icacls` spawns per init — one for the directory
-plus one per file on each of the two passes, and a file that does not exist
-still spawns (icacls exits non-zero and the caller warns). That is more than it
-sounds and still cheap in context: once per workspace per process, beside the
-`sqlite3.connect`, the migrations and the FAISS index load already in that
-function — and `context.get_memory_for` caches the store and is reached from a
-worker thread, not the gateway event loop.
+The Windows cost is up to 11 in-process DACL operations per init — one for the
+directory plus one per file on each of the two passes; a file that does not
+exist is skipped by an existence check rather than paid for. Each per-file
+write costs roughly 0.24 ms. The directory write is priced differently: its
+inheritable grants propagate to every descendant object, so a directory whose
+DACL does not yet match pays about 0.24 ms per object in the tree — seconds on
+a large data home — once, to repair it. On every later boot the descriptor
+already matches and the write is skipped after an O(1) probe
+(`windows_acl.owner_only_dacl_matches`). That is cheap in context: once per
+workspace per process, beside the `sqlite3.connect`, the migrations and the
+FAISS index load already in that function — and `context.get_memory_for`
+caches the store and is reached from a worker thread, not the gateway event
+loop.
 
 It is fail-soft (warn, keep going), which is the contract `restrict_to_owner`
 documents for its callers: memory being unavailable is a supported degraded

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -2305,8 +2305,9 @@ like this transaction's own work.
   field when `.env` is empty, so a crash between the two writes would otherwise
   resurrect a revoked credential on the next restart, and the copy sits in
   agent-readable `config.json`. Both writes go through `asyncio.to_thread`:
-  the atomic write fsyncs, and the owner-only lockdown shells out to `icacls`
-  on Windows, neither of which may block the gateway loop.
+  the atomic write fsyncs, and the owner-only lockdown's Windows DACL write
+  can block on a network volume round-trip, neither of which may block the
+  gateway loop.
 
 ## Telegram channel
 

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1169,7 +1169,7 @@ complete, and the keystone floor closes the whole class).
   world-readable file: 0o600 on POSIX, owner-only DACL on Windows. On a
   lockdown failure `atomic_write` raises by default (the same fail-loud
   contract the other keystone writers in `apps/builtins/*` use for their
-  `policy_store.py` and `secrets.py`), so a transient icacls failure cannot
+  `policy_store.py` and `secrets.py`), so a transient lockdown failure cannot
   leave the ceiling under the inherited parent DACL.
   `_reload_live_hooks` splices the new opt-out fields onto the live
   `HookManager` (preserving its flat hook keys) so the change enforces without

--- a/test/test_atomic_write_capabilities.py
+++ b/test/test_atomic_write_capabilities.py
@@ -183,7 +183,7 @@ def test_a_failing_lockdown_leaves_no_temp_and_no_target(tmp_path, monkeypatch):
 
 
 def _failing_restrict(monkeypatch):
-    """Make the owner-only lockdown fail the way a read-only FS or icacls would."""
+    """Make the owner-only lockdown fail the way a read-only FS or a DACL write failure would."""
 
     def _boom(path, **_kw):
         raise OSError("cannot set DACL")

--- a/test/test_builtin_app_lifecycle.py
+++ b/test/test_builtin_app_lifecycle.py
@@ -176,7 +176,7 @@ class TestSyncBuiltinConfig:
         assert cfg.read_text(encoding="utf-8") == before
 
     def test_async_call_sites_offload_off_the_event_loop(self):
-        """The helper does file I/O and, on Windows, spawns icacls via
+        """The helper does file I/O and, on Windows, a DACL write via
         restrict_to_owner — its async callers must never run it on the loop
         (no-blocking-call-on-event-loop). Any bare direct call (statement,
         assignment, or nested argument) is a violation; a dispatched form never

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -1135,7 +1135,8 @@ class TestRunTask:
         self, taskrunner_env, tmp_path, monkeypatch
     ) -> None:
         """``VectorMemoryStore.init()`` must honour its caller contract:
-        the Windows path shells out to icacls, so an async caller offloads it
+        it is blocking file IO whose Windows DACL writes can block on a
+        network volume round-trip, so an async caller offloads it
         via ``asyncio.to_thread`` instead of freezing the loop. Ordering is
         asserted too: init must COMPLETE before ``_run_task`` wires the embed
         hooks (a fire-and-forget offload would reorder them). The sibling

--- a/test/test_denied_commands_api.py
+++ b/test/test_denied_commands_api.py
@@ -967,9 +967,9 @@ def test_write_denied_state_does_not_fall_back_to_chmod_safe(
     def _spy(path, *args, **kwargs):
         if Path(str(path)).resolve() == config_file.resolve():
             captured["called"] = True
-        # No-op: don't run real atomic_write (which would shell out to icacls
-        # on Windows and may fail in the test sandbox). The audit pin is on
-        # routing, not on the lockdown step itself.
+        # No-op: don't run real atomic_write (which would apply a real
+        # owner-only lockdown on Windows and may fail in the test sandbox).
+        # The audit pin is on routing, not on the lockdown step itself.
 
     import asyncio
 

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -4873,10 +4873,11 @@ def _stage_a_cutover(monkeypatch, tmp_path):
 async def test_cutover_unwind_runs_off_the_event_loop(monkeypatch, tmp_path):
     """The rollback must not block the loop.
 
-    restore() ends in restrict_to_owner, which shells out to icacls on Windows,
-    and svc.rollback() rewrites the service definition. Run inline, an unwind
-    would stall every other gateway request for the duration of a subprocess, so
-    it has to reach the executor like the write it is undoing.
+    restore() ends in restrict_to_owner, whose Windows DACL write can block on
+    a network volume round-trip, and svc.rollback() rewrites the service
+    definition. Run inline, an unwind would stall every other gateway request
+    for the duration of that blocking file IO, so it has to reach the executor
+    like the write it is undoing.
     """
     wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
     ptr_dir = tmp_path / "ptr"

--- a/test/test_feishu_config_handlers.py
+++ b/test/test_feishu_config_handlers.py
@@ -100,7 +100,7 @@ def test_save_persists_credentials_and_config(tmp_path: Path, monkeypatch) -> No
     assert f"FEISHU_APP_SECRET={APP_SECRET}" in env_text
     if os.name != "nt":
         # POSIX-only: group/other must hold no bits on a file carrying secrets.
-        # Windows locks the same file down with an ACL (icacls) instead, where
+        # Windows locks the same file down with an owner-only ACL instead, where
         # st_mode reports 0o666 no matter what the ACL says -- so asserting mode
         # bits there tests a mechanism the platform does not use.
         assert (env.stat().st_mode & 0o077) == 0

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -667,8 +667,9 @@ class TestRedactAndStoreResolution:
 
 # ---------------------------------------------------------------------------
 # _get_vector_store_async — the standalone fallback's ``init()`` must
-# never run on the event loop (VectorMemoryStore's caller contract: the
-# Windows path shells out to icacls and would freeze the loop for seconds).
+# never run on the event loop (VectorMemoryStore's caller contract: init is
+# blocking file IO whose Windows DACL writes can block on a network volume
+# round-trip and would freeze the loop).
 # ---------------------------------------------------------------------------
 
 

--- a/test/test_icacls_rationale_guard.py
+++ b/test/test_icacls_rationale_guard.py
@@ -1,0 +1,142 @@
+"""Present-tense icacls-subprocess rationale is banned under test/ and docs/.
+
+The Windows owner-only lockdown is an in-process DACL write
+(``windows_acl.apply_owner_only``); no lockdown path spawns an ``icacls``
+subprocess. A comment or spec sentence that explains the lockdown as an
+``icacls`` subprocess is therefore wrong, and this rationale is load-bearing:
+it tells a reader why a test fake exists, why an async caller offloads a
+write, and what a lockdown failure can look like. A prose-only contract
+drifts, so this guard makes the drift a CI failure.
+
+Scope is ``test/`` and ``docs/``; ``src/`` and ``scripts/`` carry their own
+conventions (``windows_acl.py`` legitimately uses icacls syntax as DACL
+vocabulary). Legitimate mentions stay, by an explicit keep-list: files that
+spawn or parse ``icacls`` as a verification or measurement tool, reference its
+syntax as vocabulary, or record past-tense history. The keep-list is itself
+pinned from both sides: a file on it must still mention icacls (so retired
+entries are removed), and the pattern is exercised against seeded stale and
+legitimate shapes (so a regex edit that silently stops matching turns the
+guard off loudly).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Present-tense claims that the lockdown reaches ``icacls``. The union covers
+#: every phrasing the three sweeps actually found -- including the backtick- and
+#: quote-wrapped variants (``shells out to ``icacls````) that a plain
+#: "shells out to icacls" grep misses.
+_STALE_RATIONALE = re.compile(r"""(?ix)
+    (?<! used\ to\ )
+    (?: shells? \s+ out \s+ to | spawns? | runs | needs )
+        \s+ (?: an? \s+ )? [`'"]{0,2} icacls
+    | [`'"]{0,2} icacls [`'"]{0,2} \s+ (?: subprocess | spawns? \b | grants? \b )
+    | [`'"]{0,2} icacls [`'"]{0,2} \s+ via \b
+    """)
+
+#: Files whose icacls mentions are deliberate, with the reason each stays.
+_KEEP = {
+    # Spawns ``icacls <path>`` on Windows to VERIFY the applied DACL, and
+    # parses realistic icacls dump/argv shapes on every platform.
+    "test/test_platform_compat.py",
+    # References icacls flag syntax as DACL vocabulary next to the in-process
+    # constants it documents.
+    "test/test_windows_acl.py",
+    # Measured ``icacls /deny`` + ``icacls /remove:d`` as an unprivileged
+    # measurement tool; icacls is the subject, not the lockdown mechanism.
+    "test/test_computer_use_launch.py",
+    "docs/system-specs/modules/computer-use.md",
+    # Past-tense history: why the helper skips absent files dates from when
+    # the lockdown WAS an icacls subprocess.
+    "test/test_config_rmw_preserves_settings.py",
+    # Comparative reference: the in-process write measured against the
+    # equivalent icacls invocation.
+    "docs/guides/windows-install.md",
+    # This guard: carries the stale shapes as seeded test data.
+    "test/test_icacls_rationale_guard.py",
+}
+
+
+def _scan() -> list[str]:
+    hits: list[str] = []
+    for tree in ("test", "docs"):
+        for path in sorted((_REPO_ROOT / tree).rglob("*")):
+            if not path.is_file() or path.suffix not in {".py", ".md"}:
+                continue
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            if rel in _KEEP:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if _STALE_RATIONALE.search(line):
+                    hits.append(f"{rel}:{lineno}: {line.strip()}")
+    return hits
+
+
+def test_no_stale_icacls_subprocess_rationale_under_test_or_docs() -> None:
+    """Zero present-tense icacls-subprocess claims outside the keep-list."""
+    assert _scan() == [], (
+        "stale icacls-subprocess rationale found; the lockdown has been "
+        "in-process (windows_acl.apply_owner_only). Rewrite the "
+        "rationale to the still-true reason (blocking file IO; the Windows "
+        "DACL write can block on a network volume round-trip -- see "
+        "restrict_to_owner's docstring), or add a keep-list entry with a "
+        "reason if the mention is genuinely deliberate."
+    )
+
+
+def test_keep_list_entries_still_mention_icacls() -> None:
+    """A keep-list entry for a file with no icacls mention is dead -- prune it."""
+    stale_entries = []
+    for rel in sorted(_KEEP):
+        path = _REPO_ROOT / rel
+        if not path.is_file():
+            stale_entries.append(f"{rel} (file gone)")
+            continue
+        if "icacls" not in path.read_text(encoding="utf-8", errors="replace").lower():
+            stale_entries.append(f"{rel} (no icacls mention left)")
+    assert stale_entries == []
+
+
+@pytest.mark.parametrize(
+    "seeded",
+    [
+        "the lockdown shells out to icacls",
+        "restrict_to_owner spawns ``icacls`` on Windows",
+        "the real one shells out to ``icacls``, which cannot succeed here",
+        "on Windows it runs icacls instead",
+        "and on Windows an `icacls` subprocess",
+        "up to 11 `icacls` spawns per init",
+        "the Windows ACL path needs icacls",
+        "spawns icacls via restrict_to_owner",
+        "its icacls grants carry no (OI)(CI)",
+    ],
+)
+def test_the_pattern_matches_the_stale_shapes(seeded: str) -> None:
+    """Seeded violations keep the guard armed: every shape a sweep fixed."""
+    assert _STALE_RATIONALE.search(seeded)
+
+
+@pytest.mark.parametrize(
+    "legitimate",
+    [
+        'raise OSError("icacls failed")',
+        'raise OSError("icacls unavailable")',
+        "OSError('icacls: transient failure')",
+        "the equivalent of icacls /inheritance:r",
+        "against 313 ms for the equivalent `icacls` invocation",
+        "then re-read it via icacls to",
+        "icacls <file> /deny <me>:(WD)",
+        "the lockdown used to shell out to `icacls`, a blocking subprocess",
+        "PROTECTED_DACL is what replaces icacls' /inheritance:r",
+    ],
+)
+def test_the_pattern_ignores_legitimate_mentions(legitimate: str) -> None:
+    """Fake error strings, syntax vocabulary, measurement uses, past tense."""
+    assert not _STALE_RATIONALE.search(legitimate)

--- a/test/test_mcp_gateway_oversize.py
+++ b/test/test_mcp_gateway_oversize.py
@@ -121,7 +121,7 @@ class TestSpillToFile:
             wrong: list[str] = []
             monkeypatch.setattr(pc, "restrict_dir_to_owner", lambda p: calls.append(str(p)))
             # The file-shaped helper must NOT be what a directory goes through:
-            # its icacls grants carry no (OI)(CI), so spilled payloads written
+            # its grants carry no (OI)(CI), so spilled payloads written
             # into the directory afterwards would not inherit the lockdown.
             monkeypatch.setattr(pc, "restrict_to_owner", lambda p: wrong.append(str(p)))
         loose = tmp_path / "mcp_spill"

--- a/test/test_mcp_gateway_prewarm.py
+++ b/test/test_mcp_gateway_prewarm.py
@@ -72,7 +72,8 @@ def test_flush_persists_when_os_fchmod_is_absent(
     The attribute is deleted rather than the test being run on Windows, so the
     guard executes on the matrix that actually runs it. ``IS_POSIX`` is flipped
     too so the Windows DACL branch is taken, and ``restrict_to_owner`` is stubbed
-    because the real one shells out to ``icacls``, which cannot succeed here --
+    because the real one applies a Windows ACL through ``advapi32``, which cannot
+    succeed here --
     the stub doubles as the assertion that the DACL is applied to the TEMP file,
     before any content is written.
     """

--- a/test/test_mcp_gateway_transport.py
+++ b/test/test_mcp_gateway_transport.py
@@ -883,8 +883,9 @@ def test_installing_the_pipe_factory_twice_is_a_noop(
 
 # --- prepare_dir must not run on the event loop -------------------------------
 
-# ``prepare_dir`` -> ``platform_compat.make_owner_only_dir`` shells out to
-# ``icacls`` on Windows with a multi-second timeout. Both call sites are
+# ``prepare_dir`` -> ``platform_compat.make_owner_only_dir`` is blocking file
+# IO whose Windows DACL write can block on a network volume round-trip. Both
+# call sites are
 # coroutines, so an inline call stalls the loop it runs on -- for the manager
 # that is the live gateway's loop (a dashboard toggle freezes chat turns and the
 # liveness heartbeat), and for the daemon it is the loop already serving its

--- a/test/test_refresh_tokens.py
+++ b/test/test_refresh_tokens.py
@@ -522,7 +522,7 @@ def test_tr_u_17_persistence_file_mode_0600(tmp_path: Path):
 @pytest.mark.skipif(
     os.name == "nt",
     reason="injects the failure via platform_compat.os.chmod, which only "
-    "restrict_to_owner's POSIX branch calls (Windows shells out to icacls)",
+    "restrict_to_owner's POSIX branch calls (Windows applies a DACL in-process)",
 )
 def test_a_failed_lockdown_still_persists_the_reuse_record(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/test/test_review_fixes.py
+++ b/test/test_review_fixes.py
@@ -148,8 +148,9 @@ class TestEnvPermissions:
 
     def test_env_permission_repair_is_posix_only(self, tmp_path: object, monkeypatch) -> None:
         """On Windows the chmod is a silent no-op for ACLs, and the real
-        lockdown (platform_compat.restrict_to_owner) spawns icacls — a
-        blocking subprocess this loop-reachable reader must never run. The
+        lockdown (platform_compat.restrict_to_owner) is a DACL write that
+        can block on a network volume round-trip — a cost this
+        loop-reachable reader must never pay. The
         repair must not even attempt a chmod there: Windows enforcement lives
         where the file is written (setup wizard, dashboard credential
         writers), all off the loop."""

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -1301,7 +1301,8 @@ class TestHmacKeyManagementExtras:
         """A restrict_to_owner failure must not crash SecurityEventLog init.
 
         The chmod test above only exercises the POSIX arm of
-        ``restrict_to_owner``; on Windows it runs icacls instead, so this
+        ``restrict_to_owner``; on Windows it applies an owner-only DACL
+        in-process instead, so this
         variant injects the failure at ``restrict_to_owner`` itself — the seam
         ``atomic_write`` calls on every platform — pinning that
         ``restrict_on_error="warn"`` keeps key creation fail-soft.

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -3676,8 +3676,9 @@ def test_the_audit_write_does_not_run_on_the_event_loop(tmp_path, monkeypatch):
     """Constructing the SEL must not happen on the loop.
 
     `log_tool_invocation` only enqueues, but the FIRST `sel()` of a process
-    constructs the log -- trust-dir creation, key validation, and on Windows an
-    `icacls` subprocess. This can genuinely be that first call, because
+    constructs the log -- trust-dir creation, key validation, and on Windows a
+    DACL write that can block on a network volume round-trip. This can genuinely
+    be that first call, because
     `sel_audit_middleware` logs AFTER `await handler(...)`: on a fresh gateway the
     first authenticated request constructs the log inside whatever handler runs
     first.

--- a/test/test_skill_trust_store.py
+++ b/test/test_skill_trust_store.py
@@ -1080,7 +1080,7 @@ class TestCachedPathsCannotEscapeAfterVetting:
 
     @pytest.mark.skipif(
         platform_compat.IS_WINDOWS,
-        reason="POSIX mode bits; the Windows ACL path needs icacls and is asserted there",
+        reason="POSIX mode bits; the Windows ACL path applies a DACL in-process and is asserted there",
     )
     def test_the_trust_dir_is_owner_only_on_posix(self, project):
         """The directory, not just the store file, must be owner-only.

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -700,10 +700,9 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # NOT subprocess spawns: the AST heuristic matches ``asyncio.run`` (attr
         # ``run`` on base ``asyncio``). These four TEST functions drive Code Review
         # Sage's ``_save_runs`` coroutine to completion without a running loop --
-        # the registry write is a coroutine because its owner-only lockdown spawns
-        # ``icacls`` on Windows and so must be offloaded off the event loop (that
-        # real spawn is ``platform_compat.py::restrict_to_owner``, allowlisted
-        # below). No child process is created here and nothing is
+        # the registry write is a coroutine because it is blocking file IO that
+        # must be offloaded off the event loop (see the offload rationale on
+        # ``_write_runs``). No child process is created here and nothing is
         # agent-influenced: every run record in these tests is a literal dict.
         # Same classification as the other ``asyncio.run`` sites in this list.
         "apps/builtins/code_review_sage/tests/test_backend_routes.py"

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -868,10 +868,10 @@ class TestSchemaInit:
     ) -> None:
         """A file that does not exist is skipped by a check, not by catching.
 
-        On Windows ``restrict_to_owner`` shells out, so a missing path raises plain
-        ``OSError`` (icacls exits non-zero) rather than ``FileNotFoundError`` -- which
-        only ever comes from the POSIX ``os.chmod``. Catching alone therefore spawned
-        a futile ``icacls`` per absent file and logged a false "may be readable by
+        On Windows ``restrict_to_owner``'s DACL write raises plain ``OSError``
+        for a missing path rather than ``FileNotFoundError`` -- which only ever
+        comes from the POSIX ``os.chmod``. Catching alone therefore paid a futile
+        lockdown attempt per absent file and logged a false "may be readable by
         other users" warning for each, twice per init. Asserting on what reaches the
         helper pins the check itself, which is observable on both platforms; a mode or
         DACL assertion could not distinguish the two implementations.
@@ -3380,8 +3380,9 @@ class TestAsyncInitOffloadGuard:
     """AST guard for blocking ``VectorMemoryStore`` lifecycle calls.
 
     An ``async def`` must never call ``init()`` or ``close()`` inline. The
-    Windows init path shells out to icacls, and close serializes on the same
-    store lock as ordinary database operations, so either can freeze the event
+    init path is blocking file IO whose Windows DACL writes can block on a
+    network volume round-trip, and close serializes on the same store lock
+    as ordinary database operations, so either can freeze the event
     loop. Async callers offload via ``asyncio.to_thread`` / ``run_in_executor``
     (which take the callable UNCALLED, so they never trip this guard).
 

--- a/test/test_whatsapp_client.py
+++ b/test/test_whatsapp_client.py
@@ -1023,8 +1023,9 @@ def test_an_undecodable_source_costs_the_preview_not_the_reply():
 
 
 def test_session_store_permissions_are_applied_off_the_loop(monkeypatch):
-    """On Windows these resolve a SID and shell out to `icacls`, so running them
-    inline would put a subprocess on the one gateway event loop.
+    """On Windows these resolve a SID and write a DACL that can block on a
+    network volume round-trip, so running them inline would block the one
+    gateway event loop.
     """
     import inspect
 


### PR DESCRIPTION
## Problem / Motivation

Comments and spec sentences under `test/` and `docs/` still explain the Windows owner-only lockdown as an `icacls` subprocess. That subprocess is gone: since #5266, `platform_compat.restrict_to_owner` applies the DACL in-process through `advapi32`. The two earlier sweeps (#6530, #6998) rewrote this stale rationale in `src/` and `scripts/`, but both were scoped away from `test/` and `docs/`, so those trees kept telling the old story.

## Why it matters

These are load-bearing reasons, not decoration. They tell a reader why a test fake exists, why an async caller offloads a write, and what a lockdown failure can look like. A reason that names a mechanism that no longer exists sends the next engineer hunting for a subprocess that is not there — and can justify the wrong fix. Three sweeps for one removed subprocess also show that prose alone does not stay correct.

## What changed (motivation → approach → change)

The issue's grep pattern finds 8 sites, but it misses mentions wrapped in backticks or quotes (for example ``shells out to `icacls` ``) and possessive attributions ("its icacls grants"). A full audit of every `icacls` mention under `test/` and `docs/` found 22 stale sites across 18 test files and 3 docs.

Each stale site now states the still-true reason, in the wording #6530 and #6998 established: the lockdown is blocking file IO, and its Windows DACL write can block on a network volume round-trip (callers that cannot afford that ask `windows_acl.volume_is_local` first). Where `icacls` was the only stated reason, the comment now gives the true one instead of inventing detail. One comment in `test/test_spawn_audit.py` was doubly stale — it pointed at an allowlist entry for `restrict_to_owner` that no longer exists — and was corrected with it. Legitimate mentions stay untouched: tests that spawn or parse `icacls` to verify a DACL, measurement uses, DACL-syntax vocabulary, and past-tense history.

A new guard test, `test/test_icacls_rationale_guard.py`, pins the class at zero hits under `test/` and `docs/`, with an explicit keep-list naming each deliberate mention and why it stays. Its pattern covers the backtick and quote variants the issue's grep missed, so the sweep cannot regress a fourth time by the same route.

## Tests

- `test/test_icacls_rationale_guard.py` (new): asserts zero present-tense icacls-subprocess claims under `test/` and `docs/` outside the keep-list; asserts every keep-list entry still mentions `icacls` (so retired entries are pruned); seeded-shape parametrized cases pin the pattern against every stale phrasing the three sweeps fixed and against the legitimate shapes it must ignore.
- `test/test_refresh_tokens.py` re-run in full after its `skipif` reason string changed: 63 passed, collection intact.
- All 19 touched test files run locally: green (one pre-existing failure in `test/test_dev_fleet_app.py` reproduces identically on pristine `main` — host-environment, unrelated to this diff).

## Manual verification

N/A — comment/doc-only diff plus one self-contained guard test; unit coverage is sufficient. Full local gates run: black gate, subprocess-encoding check, isort, flake8, mypy (1457 files clean), docs lint, and the full backend suite (100115 passed; every red file reproduces on pristine `main` with zero overlap with this diff).

## Screenshots / video

N/A — no user-visible change: comments, documentation prose, and a test.

## Related Issues

Closes #7002

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
