### PR TITLE
fix(updater): resolve restart executable before apply

### DIFF
--- a/docs/request-for-change/rfc-update-architecture.md
+++ b/docs/request-for-change/rfc-update-architecture.md
@@ -43,8 +43,12 @@ cannot make yet, so superseded trees stay as manual recovery targets.
 `cli.sh` repoints the stable link at the legacy tree after its own installs,
 so the link always names the last-installed version whichever writer ran.
 Gateway restarts resolve their interpreter through the stable link
-(`respawn_executable`), which is the `updates.py` launch path from §3's list;
-the service-unit and macOS-launcher rewrites, the in-app Apply now ships WITH its OQ7 step-up: the SPA's
+(`respawn_executable`), which is the `updates.py` launch path from §3's list.
+Dashboard apply handlers load that resolver before an update can replace the
+running install tree and pass it to the restart helper. A plain restart loads
+the resolver when invoked.
+The service-unit and macOS-launcher rewrites remain separate. The in-app Apply
+now ships WITH its OQ7 step-up: the SPA's
 Update button arms a pending request (`POST /api/update/arm`; single-use
 nonce, TTL 10 min, written owner-only to the data home and never returned to
 the SPA), and `kirocrew update approve` on the gateway host presents the

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import aiohttp
@@ -1415,7 +1416,9 @@ async def _venv_pip_install(proj: str, state: DashboardState) -> bool:
     return rc == 0
 
 
-async def _restart_gateway(state: DashboardState) -> bool:
+async def _restart_gateway(
+    state: DashboardState, *, resolver: Callable[[], str] | None = None
+) -> bool:
     """Save state, close sessions, and exec the same Python process once.
 
     Restart is a process-wide transition.  Two callers must never both drain
@@ -1436,12 +1439,13 @@ async def _restart_gateway(state: DashboardState) -> bool:
         # other install shape the resolver answers ``sys.executable``.
         # Offloaded: the resolver walks the venv's sibling directory, which is
         # synchronous filesystem I/O this loop must not wait on.
-        # Imported here, not at module scope: this module loads on the gateway
-        # boot path, and the updater subsystems are needed only when an
-        # update/restart actually runs (no-new-work-on-gateway-boot-path).
-        from kiro_crew.platform.wheel_engine import respawn_executable
+        # Applying callers import the resolver before the install can replace
+        # their import tree. A plain restart has no apply, so load it here.
+        if resolver is None:
+            from kiro_crew.platform.wheel_engine import respawn_executable
 
-        exe = await asyncio.to_thread(respawn_executable)
+            resolver = respawn_executable
+        exe = await asyncio.to_thread(resolver)
         if not os.path.isfile(exe) or not os.access(exe, os.X_OK):
             state.push_update_progress("error", "Cannot restart: invalid Python executable path")
             return False
@@ -1497,6 +1501,7 @@ async def api_update_apply(request: web.Request) -> web.Response:
     # run the built-in mechanism their own policy excluded. A dashboard token
     # proves who the caller is, not that this host may update by git.
     from kiro_crew.platform.update_provider import apply_policy_update
+    from kiro_crew.platform.wheel_engine import respawn_executable
 
     applied = await apply_policy_update()
     if applied is not None:
@@ -1512,7 +1517,7 @@ async def api_update_apply(request: web.Request) -> web.Response:
                 },
                 status=500,
             )
-        await _restart_gateway(state)
+        await _restart_gateway(state, resolver=respawn_executable)
         return web.json_response({"ok": True, "status": "updating"})
 
     proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
@@ -1769,7 +1774,7 @@ async def api_update_apply(request: web.Request) -> web.Response:
 
             # Restart: save history + clean up sessions then exec the same process.
             logger.info("Update complete — saving history and cleaning up before restart")
-            await _restart_gateway(state)
+            await _restart_gateway(state, resolver=respawn_executable)
         except Exception:
             logger.exception("Update failed")
             state.push_update_progress("failed", "Update failed — check logs")
@@ -2541,7 +2546,11 @@ async def api_update_approve(request: web.Request) -> web.Response:
     from kiro_crew.platform import update_stepup
     from kiro_crew.platform.update_layout import cdn_bases as _cdn
     from kiro_crew.platform.update_layout import cdn_bases_are_safe as _cdn_safe
-    from kiro_crew.platform.wheel_engine import WheelUpdateError, apply_wheel_update
+    from kiro_crew.platform.wheel_engine import (
+        WheelUpdateError,
+        apply_wheel_update,
+        respawn_executable,
+    )
 
     # A policy-defined command provider OWNS updates on this host, and its
     # commands never read the built-in mechanism this endpoint drives. Checked
@@ -2669,7 +2678,7 @@ async def api_update_approve(request: web.Request) -> web.Response:
             return
         logger.info("In-app wheel update to v%s promoted; restarting", pending.version)
         await _audit("success", resources=f"v{pending.version} promoted")
-        await _restart_gateway(state)
+        await _restart_gateway(state, resolver=respawn_executable)
 
     task = asyncio.create_task(_apply())
     state._background_tasks.add(task)

--- a/test/test_gateway_restart_uses_respawn_executable.py
+++ b/test/test_gateway_restart_uses_respawn_executable.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard.handlers import updates as dashboard_updates
 from kiro_crew.slack import gateway as gw
 from kiro_crew.slack.gateway import GatewayOrchestrator
 
@@ -188,6 +189,36 @@ class TestResolverIsLoadedBeforeTheApply:
             "prune. Resolve the interpreter with wheel_engine.respawn_executable() "
             "(imported before the apply step) and pass it as executable=."
         )
+
+
+class TestDashboardResolverIsLoadedBeforeTheApply:
+    @pytest.mark.parametrize(
+        ("method", "apply_names"),
+        [
+            ("api_update_apply", {"apply_policy_update", "_venv_pip_install"}),
+            ("api_update_approve", {"apply_wheel_update"}),
+        ],
+    )
+    def test_import_precedes_every_apply(self, method, apply_names):
+        tree = ast.parse(inspect.getsource(dashboard_updates))
+        fn = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == method
+        )
+        imports = TestResolverIsLoadedBeforeTheApply._resolver_import_lines(fn)
+        assert len(imports) == 1, f"{method}: expected one resolver import, got {imports}"
+        applies = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id in apply_names
+        ]
+        assert applies, f"{method}: no apply reference found"
+        assert imports[0] < min(
+            applies
+        ), f"{method}: resolver import at line {imports[0]} follows apply at {min(applies)}"
 
 
 class TestAutoApplyWheelUpdate:

--- a/test/test_update_stepup.py
+++ b/test/test_update_stepup.py
@@ -529,7 +529,8 @@ class TestApproveEndpoint:
 
         restarted: list[object] = []
 
-        async def fake_restart(state: object) -> bool:
+        async def fake_restart(state: object, *, resolver: object) -> bool:
+            assert resolver is wheel_engine.respawn_executable
             restarted.append(state)
             return True
 
@@ -595,7 +596,7 @@ class TestApproveEndpoint:
 
         restarted: list[object] = []
 
-        async def fake_restart(state: object) -> bool:
+        async def fake_restart(state: object, *, resolver: object) -> bool:
             restarted.append(state)
             return True
 

--- a/test/test_update_venv_detection.py
+++ b/test/test_update_venv_detection.py
@@ -348,7 +348,10 @@ class TestApiUpdateApplyVenvDispatch:
             pip_called.append(True)
             return True
 
-        async def fake_restart(s):
+        async def fake_restart(s, *, resolver):
+            from kiro_crew.platform.wheel_engine import respawn_executable
+
+            assert resolver is respawn_executable
             restart_called.append(True)
 
         monkeypatch.setattr(


### PR DESCRIPTION
## Problem / Motivation

Dashboard update handlers imported `respawn_executable` only inside the restart helper, after applying an update. An out-of-band installer can replace the active virtualenv during apply, so the post-apply import can fail and leave the gateway stopped.

## Why it matters

Users can complete an update while the gateway never restarts, requiring manual recovery.

## What changed (motivation → approach → change)

The resolver is now imported before each dashboard apply path and passed into `_restart_gateway`; plain restart requests retain the lazy fallback. The update architecture RFC documents this ordering contract.

## Tests

- Red-before: the new AST ordering checks failed for both dashboard apply handlers because neither imported the resolver before apply.
- Green-after: `94 passed, 1 skipped` across gateway restart, update step-up, venv detection, and channel/restart tests.
- `flake8`, Black, docs lint, brand gate, and `git diff --check` pass.

## Manual verification

N/A — unit and static coverage exercise the affected apply and restart paths.

## Related Issues

Fixes #8953

## Pattern harvest

Rule candidate: review-prompt — any updater that may replace its import tree must resolve restart dependencies before applying the replacement.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
