### PR TITLE
fix(test): render gateway --help in-process for the --seed flag check

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -112,7 +112,6 @@
 6 test/test_sandbox_argv.py
 1 test/test_sandbox_probe.py
 9 test/test_security.py
-1 test/test_seed.py
 1 test/test_ship_report_issues.py
 2 test/test_source_launcher.py
 3 test/test_spawn_exec_shim.py

--- a/test/test_seed.py
+++ b/test/test_seed.py
@@ -8,7 +8,6 @@ regression guard for unknown fixture names. Non-empty target, main-home guardrai
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -16,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from conftest import make_dir_link, requires_symlinks
-from kiro_crew import pinned_fs
+from kiro_crew import cli, pinned_fs
 from kiro_crew import seed as seed_mod
 
 # A test here spawns a real `python -m kiro_crew gateway --help` child interpreter;
@@ -194,57 +193,45 @@ def test_seed_cmd_exit_code_on_unset(
     assert err.startswith("seed: error:")
 
 
-def test_seed_cli_flag_registered(tmp_path: Path) -> None:
-    """``kirocrew gateway --help`` mentions ``--seed FIXTURE``.
+def test_seed_cli_flag_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``kirocrew gateway --help`` documents ``--seed FIXTURE``.
 
-    Tracer-bullet acceptance from the ticket: prove the CLI
-    wiring end-to-end. In Phase 1.A the seed primitive is invoked as
-    ``kirocrew gateway --seed <fixture>`` (it seeds ``$KIROCREW_HOME``
-    and THEN continues into the gateway event loop) — we can't let the
-    subprocess actually run because ``run_gateway`` is a long-lived
-    server. ``--help`` exits 0 after printing usage, which is enough to
-    verify the flag is registered and the seed_cmd wiring imports clean.
+    The seed primitive is invoked as ``kirocrew gateway --seed <fixture>``: it
+    seeds ``$KIROCREW_HOME`` and THEN continues into the gateway event loop, so
+    the flag has to be registered on the ``gateway`` subparser specifically.
+    ``--seed`` is registered TWICE in the CLI — once here and once on ``pod
+    up`` — so this renders the gateway subcommand's own help rather than
+    searching the whole parser, which would still pass if this registration
+    were deleted.
+
+    ``cli.main()`` builds the parser and argparse answers ``--help`` by printing
+    usage and raising ``SystemExit(0)``, which is the in-process equivalent of
+    the exit code a child process would report. The environment is pinned
+    because ``main()`` reads it before parsing: ``KIROCREW_PORT`` is validated
+    (and exits 1 when unparseable), ``KIROCREW_PROJECT_DIR`` short-circuits a
+    filesystem probe for the project root, and the two sandbox markers are
+    popped outright. ``ensure_utf8_console`` is stubbed because it reconfigures
+    the interpreter's stdout on Windows, which would disturb pytest's capture.
     """
-    repo_root = Path(__file__).resolve().parent.parent
-    import os as _os
+    monkeypatch.setattr(cli.platform_compat, "ensure_utf8_console", lambda: None)
+    monkeypatch.delenv("KIROCREW_PORT", raising=False)
+    monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(Path(__file__).resolve().parent.parent))
+    # main() pops these; let monkeypatch own them so the caller's values return.
+    monkeypatch.setenv("KIROCREW_SANDBOX_ACTIVE", "")
+    monkeypatch.setenv("KIROCREW_SANDBOX_LEVEL", "")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["kirocrew", "gateway", "--help"])
 
-    env = {**_os.environ, "HOME": str(tmp_path)}
-    # Preserve user site-packages: overriding HOME loses ~/.local/lib/pythonX.Y
-    # where deps like croniter/cron_descriptor live when not system-installed.
-    real_home = _os.environ.get("HOME", "")
-    if real_home:
-        import site
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
 
-        user_site = site.getusersitepackages()
-        if isinstance(user_site, str) and _os.path.isdir(user_site):
-            existing_pp = env.get("PYTHONPATH", "")
-            if existing_pp:
-                env["PYTHONPATH"] = user_site + _os.pathsep + existing_pp
-            else:
-                env["PYTHONPATH"] = user_site
-    # Guard against trailing separator when PYTHONPATH is unset — a trailing
-    # ":" on POSIX adds CWD to sys.path, which would import unexpected
-    # modules depending on where pytest runs.
-    existing_pypath = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = str(repo_root / "src") + (
-        _os.pathsep + existing_pypath if existing_pypath else ""
-    )
-    env["KIROCREW_PROJECT_DIR"] = str(repo_root)
-
-    result = subprocess.run(
-        [sys.executable, "-m", "kiro_crew", "gateway", "--help"],
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert result.returncode == 0, (
-        f"expected exit 0 from --help, got {result.returncode}\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
+    assert exit_info.value.code == 0, f"expected exit 0 from --help, got {exit_info.value.code}"
+    help_text = capsys.readouterr().out
     # The flag must be registered and documented.
-    assert "--seed" in result.stdout
-    assert "FIXTURE" in result.stdout
+    assert "--seed" in help_text
+    assert "FIXTURE" in help_text
 
 
 # ------------------------------------------------------------------

--- a/test/test_seed.py
+++ b/test/test_seed.py
@@ -18,11 +18,6 @@ from conftest import make_dir_link, requires_symlinks
 from kiro_crew import cli, pinned_fs
 from kiro_crew import seed as seed_mod
 
-# A test here spawns a real `python -m kiro_crew gateway --help` child interpreter;
-# pin the module to a dedicated xdist worker so concurrent cold-starts under -n auto
-# don't starve each other / blow the 30s timeout. Requires --dist loadgroup.
-pytestmark = pytest.mark.xdist_group(name="subprocess_spawn")
-
 
 def test_seed_empty_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``kirocrew seed --fixture empty`` writes fixture.yaml into $KIROCREW_HOME."""


### PR DESCRIPTION
## What is the problem?

`test/test_seed.py::test_seed_cli_flag_registered` spawns `python -m kiro_crew gateway --help` as a child interpreter under a hard `timeout=30`. On `Backend Tests (Windows) (3)` that ceiling is reached often enough to red unrelated pull requests.

Measured, not assumed. Of the 18 most recent `ci.yml` runs whose Windows shard 3 actually concluded, 8 failed, and **6 of those 8 were this test** raising `subprocess.TimeoutExpired`. It landed on six different branches — `feat/crew-container-runtime`, `feat/autonudge-egress-hardening`, `fix/reset-skip-if-busy`, `fix/mdnb-vault-toolbar-overlap`, `feat/telegram-configurable-base-url`, `feat/unlink-session-surfaces`. The same branch both failed (run 34694827476) and passed (run 34697292326), so it is non-deterministic rather than a defect someone introduced. Most `main` runs are cancelled as superseded and carry no verdict, which is why the sample is 18 rather than 150.

## Why this issue matters to the user

The user here is any contributor whose PR draws a red Windows shard they did not cause. A flake costs more than the bug it hides: it teaches people to re-run a red shard without reading it, which is exactly the habit that lets a real Windows regression through. Windows also runs `--max-worker-restart=0`, so a shard that dies reports fewer tests than it collected — a red there is worth reading, and this test was training people not to.

## How our fix solves it

Symptom to cause:

1. The test fails with `subprocess.TimeoutExpired` after 30 seconds.
2. The command itself is not slow. On an idle Linux box it costs **0.61s median** over 8 runs — 12ms of interpreter start, ~0.47s importing the CLI graph, the rest argparse. The 30s ceiling already carried roughly 50x headroom.
3. So the bound is not marginally too small; it is being blown by starvation on a `windows-latest` runner saturated by `-n auto` workers. The failing test ran on `popen-gw3`, and the module's `xdist_group` pin only serialises cold starts *within* its own group — it does nothing about the other workers driving the same 4-core runner.
4. That tail is not measurable from CI logs. The suite runs `--durations=5`, and `--verbose` plus `-q` cancel to verbosity 0, so a passing test's duration is never printed. A 30s failure establishes that the stall exceeded 30s, not whether it was 31s or 300s. Raising the number would therefore be an underived guess of the same class that just failed.
5. The property the test owns does not need a process at all. It is a parser property: the `gateway` subparser registers `--seed` with a `FIXTURE` metavar. `cli.main()` builds that parser and argparse answers `--help` by printing usage and raising `SystemExit(0)`, which is the in-process equivalent of the child's exit code.

The test now renders the same help text in-process. The call phase drops from 0.61s to **0.02s** and no longer depends on how loaded the runner is.

`main()` reads the environment before it parses, so the test pins all four of those inputs with `monkeypatch`: `KIROCREW_PORT` (validated, and exits 1 when unparseable), `KIROCREW_PROJECT_DIR` (short-circuits a filesystem probe for the project root), and the two sandbox markers `main()` pops outright. `ensure_utf8_console` is stubbed because it reconfigures the interpreter's stdout on Windows, which would disturb pytest's capture. `SystemExit(0)` is raised inside `parse_args()`, strictly before `maybe_reexec`, `seed_cmd`, `ensure_data_home()` and `_setup_cli_logging`, so nothing writes to `$HOME` or `$KIROCREW_HOME` and no logging state leaks. Driving `cli.main()` in-process is an established pattern here — about ten sibling test files already do it, one specifically to exercise the `KIROCREW_SANDBOX_ACTIVE` pop.

**What this gives up, stated plainly.** The process boundary also proved two things incidentally: that `python -m kiro_crew` works as a module entry point, and that the CLI import graph loads in a *fresh* interpreter. In-process, `kiro_crew.cli` is already imported by the pytest session, so a cold-only import error would be missed here. That is not a net loss of coverage, because `test/test_cli_lazy_imports.py` exists for exactly this and is collected on Windows: it spawns a fresh interpreter asserting `import kiro_crew.cli` exits 0, and spawns `python -m kiro_crew mcp-core` / `mcp-cron` through a full MCP `initialize` + `tools/list` handshake. The exit-code assertion is not given up — `SystemExit(0)` is asserted directly.

One thing the change tightens. `--seed` is registered twice, on `gateway` (`cli.py:1347`) and on `pod up` (`cli.py:1890`). Rendering the gateway subcommand's own help means deleting the gateway registration fails the test, where a search of the whole parser would still have passed on `pod up`'s copy.

**Second commit, named rather than bundled.** `test_seed.py` carried `pytestmark = xdist_group(name="subprocess_spawn")` at module scope, whose stated reason was the single child spawn. With the spawn gone the pin serialises all 49 collected items in the file onto one worker for a constraint none of them has, so it is **removed rather than moved** — moving it would preserve a constraint that no longer exists. This is a separate commit because it is a separate concern from the flake fix. `test_config_baseline.py` still uses the group name, so the group stays in use.

`.github/subprocess-encoding-baseline.txt` loses its `1 test/test_seed.py` entry: that baseline is shrink-only, and removing the file's last `subprocess.run` made the recorded count stale. `check_subprocess_encoding.py` fails on the stale entry, so the prune belongs in the commit that caused it.

## What tests we did

- `test/test_seed.py` — 49 passed serially, and 49 passed under `-n 2 --dist loadgroup`, which is the distribution mode CI uses. The parallel run is the evidence for dropping the group pin.
- **Mutation-verified in both directions.** Changing the gateway `metavar` from `FIXTURE` to `MUTANT` fails the test. Deleting the entire gateway `--seed` registration while leaving `pod up --seed` in place also fails it — that is the check that the assertion targets the right parser and is not vacuous.
- `test/test_cli_lazy_imports.py` — 43 passed, confirming the coverage this change leans on is real and green rather than assumed.
- Gate floor: 36 gates green, including `mypy src/kiro_crew/`, `flake8`, `isort`, the baselined `black` gate, `check_comment_history.py`, `check_subprocess_encoding.py`, `check_brand_name.py`, `check_changelog_history.py` and `docs-lint.sh`.
- Local review: both pinned lanes reported **no findings** on this head — `gpt-5.6-sol` and `claude-opus-4.8`, briefed from `codex-review.yml` and `claude-review.yml` verbatim rather than from hand-written charters.
- Not run locally: the full backend suite. `run_scoped_tests.py` escalates to all ~62k backend tests on any `test/` change; CI runs it on the merge ref.

## Pattern harvest

**This shape recurs — it is not a one-off**, which I checked rather than asserted. A test that wraps a hard ceiling around a child interpreter paying the full package import graph exists at three sites, and two besides this one are collected on Windows and still carry `timeout=30`:

- `test/test_pod_scenarios_command.py:49` — `-m kiro_crew pod scenarios`, `timeout=30`.
- `test/test_config_baseline.py:43` — spawns a script that imports the package, `timeout=30`.
- `test/test_sandbox_argv.py` carries the same `subprocess_spawn` group and the same "blow the 30s timeout" comment, but sits in `test/windows-collect-ignore.txt`, so it cannot hit this.

For contrast, `test/test_dev_fleet_app.py:6683` runs `-m kiro_crew --help` at `timeout=90` — but it is Windows-excluded, so it is not evidence that 90 survives there.

Two rule candidates, in order of how much they buy.

Rule candidate: semgrep
Pattern: in `test/`, a `subprocess.run` / `Popen` / `check_output` whose argv is `[sys.executable, "-m", <package>, ...]` — or a script that imports the package — carrying a `timeout=` below 60. A child spawn's ceiling is a diagnostic device, not a runtime prediction: `docs/system-specs/common/testing-conventions.md` already says to "make it generous and keep it well under `--timeout`", so that a breach lands as a named assertion instead of a dead worker. `timeout=30` against Windows' `--timeout=180` is not generous, and the two sites above inherit the same defect. There is no shared helper for spawning a child interpreter in tests, so each site picks its own number — that absence is what lets the value drift, and it is why a lint rule beats fixing the numbers one at a time.

Rule candidate: review-prompt
Pattern: a test that spends a cold child-interpreter start to assert a *registration* or *parser* property. A child interpreter proves process-level facts — the module entry point, cold import cleanliness — and those deserve a dedicated test, which this repo already has in `test_cli_lazy_imports.py`. Paying a cold start to check a flag's metavar buys nothing and imports the whole contention surface, so a reviewer should ask which of the two kinds of property a spawn is there for.

I am not changing those two sites here; this PR fixes the one that is actively reddening other people's builds. They are a follow-up.

Also worth separating out, and deliberately not done here: `gateway --help` loads `aiohttp` (119ms), the Discord intent probe (62ms), `jsonschema` (40ms) and `slack_sdk` (32ms), none of which help render usage. Trimming that would be worth doing against the existing lazy-import ratchet, but it cannot fix this flake — shaving 0.3s does not save a run that stalls past 30 seconds.

---

no linked issue: a search of open and closed issues for `test_seed_cli_flag_registered` and for Windows `TimeoutExpired` returned nothing for this test, so there is no ticket to close. The failure was found by reading `Backend Tests (Windows) (3)` logs directly across recent runs; the run and job IDs cited above are the record. Issue #9455 names the same job but a different test (`test_playwright_cli_installer`).
