### PR TITLE
fix: answer webhook tool permission requests via the hook gate (#9790)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -183,7 +183,6 @@ src/kiro_crew/dashboard/handlers/artifacts.py
 src/kiro_crew/dashboard/handlers/ask_question.py
 src/kiro_crew/dashboard/handlers/discover.py
 src/kiro_crew/dashboard/handlers/files.py
-src/kiro_crew/dashboard/handlers/hooks.py
 src/kiro_crew/dashboard/handlers/kiro_usage_api.py
 src/kiro_crew/dashboard/handlers/knowledge.py
 src/kiro_crew/dashboard/handlers/mcp.py

--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 def _sel():
     """Late-binding _sel() for test monkeypatch compatibility."""
     import kiro_crew.dashboard.handlers as _pkg  # noqa: F811
+
     return _pkg.sel()
 
 
@@ -63,6 +64,7 @@ def _store_failure_guard(handler):
     reads to the operator as a gateway fault rather than "your store needs
     repair" — becomes the shared, machine-readable response.
     """
+
     @functools.wraps(handler)
     async def _guarded(request: web.Request) -> web.Response:
         try:
@@ -147,11 +149,13 @@ async def api_kiro_hooks(request: web.Request) -> web.Response:
                 # Context-aware redact(): runs the exfil-URL + credential passes
                 # and applies a loaded companion's extra regexes (so an internal
                 # token in a hook command is scrubbed on this egress surface too).
-                tagged.append({
-                    "command": redact(e.get("command") or ""),
-                    "matcher": redact(e.get("matcher") or ""),
-                    "source": "bundled" if key in bundled_keys else "user",
-                })
+                tagged.append(
+                    {
+                        "command": redact(e.get("command") or ""),
+                        "matcher": redact(e.get("matcher") or ""),
+                        "source": "bundled" if key in bundled_keys else "user",
+                    }
+                )
         if tagged:
             result[event] = tagged
     return web.json_response({"hooks": result})
@@ -512,9 +516,7 @@ def _verify_hook_token(request: web.Request) -> str | None:
     )
 
 
-def _verify_hook_signature(
-    request: web.Request, token_id: str, raw_body: bytes
-) -> str | None:
+def _verify_hook_signature(request: web.Request, token_id: str, raw_body: bytes) -> str | None:
     """Verify the request signature for *token_id*. ``None`` means accepted.
 
     Any other return value is the ``SIG_ERR_*`` string naming the cause, used
@@ -557,9 +559,7 @@ def _installed_agent_names() -> set[str]:
     return {agent.name for agent in list_agents()}
 
 
-async def _json_object(
-    request: web.Request, *, default_empty: bool = False
-) -> dict | None:
+async def _json_object(request: web.Request, *, default_empty: bool = False) -> dict | None:
     """Parse a JSON **object** body. ``None`` means answer 400.
 
     ``await request.json()`` happily returns a list, string or number for a body
@@ -629,7 +629,8 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
             error="webhook store unreadable",
         )
         return web.json_response(
-            {"error": "inbound webhooks are unavailable", "code": "webhooks_unavailable"}, status=503
+            {"error": "inbound webhooks are unavailable", "code": "webhooks_unavailable"},
+            status=503,
         )
     if not switch_on:
         _sel().log_api_access(
@@ -661,7 +662,9 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
             source="webhook",
             error="auth failures throttled",
         )
-        return web.json_response({"error": "too many failed attempts", "code": "auth_throttled"}, status=429)
+        return web.json_response(
+            {"error": "too many failed attempts", "code": "auth_throttled"}, status=429
+        )
 
     # Identify the bearer before reading a body. This route bypasses dashboard
     # auth, so an unknown caller must not be able to allocate even the bounded
@@ -683,7 +686,8 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
             error="webhook store unreadable",
         )
         return web.json_response(
-            {"error": "inbound webhooks are unavailable", "code": "webhooks_unavailable"}, status=503
+            {"error": "inbound webhooks are unavailable", "code": "webhooks_unavailable"},
+            status=503,
         )
     if not token_id:
         throttled = webhooks.record_auth_failure(source)
@@ -710,9 +714,7 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
     source_entry: dict[str, object] | None = None
     if token_id != webhooks.LEGACY_TOKEN_ID:
         try:
-            source_entry = await asyncio.to_thread(
-                webhooks.token_store().entry_for, token_id
-            )
+            source_entry = await asyncio.to_thread(webhooks.token_store().entry_for, token_id)
         except webhooks.WebhookStoreUnreadable:
             return web.json_response(
                 {"error": "inbound webhooks are unavailable", "code": "webhooks_unavailable"},
@@ -729,9 +731,7 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
                 resources=f"token:{token_id}",
                 error="webhook source revoked during admission",
             )
-            return web.json_response(
-                {"error": "unauthorized", "code": "unauthorized"}, status=401
-            )
+            return web.json_response({"error": "unauthorized", "code": "unauthorized"}, status=401)
         if source_entry.get("enabled", True) is False:
             _sel().log_api_access(
                 caller=source,
@@ -762,17 +762,21 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
         raw_body = await _read_hook_body(request)
     except _HookBodyTooLarge:
         return web.json_response(
-            {"error": f"request body exceeds {_HOOK_BODY_MAX_BYTES} bytes", "code": "body_too_large"}, status=413
+            {
+                "error": f"request body exceeds {_HOOK_BODY_MAX_BYTES} bytes",
+                "code": "body_too_large",
+            },
+            status=413,
         )
     except Exception:
-        return web.json_response({"error": "could not read request body", "code": "body_unreadable"}, status=400)
+        return web.json_response(
+            {"error": "could not read request body", "code": "body_unreadable"}, status=400
+        )
 
     # A valid bearer proves who; the signature proves the body and defeats
     # replay. Failures feed the SAME per-source throttle as a bad bearer — a
     # signature-guessing flood is the same abuse shape as a token-guessing one.
-    sig_error = await asyncio.to_thread(
-        _verify_hook_signature, request, token_id, raw_body
-    )
+    sig_error = await asyncio.to_thread(_verify_hook_signature, request, token_id, raw_body)
     if sig_error:
         throttled = webhooks.record_auth_failure(source)
         _sel().log_api_access(
@@ -819,23 +823,34 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
     # mistake into a 500. Same for sessionKey and its .startswith() below.
     raw_message = body.get("message", "")
     if not isinstance(raw_message, str):
-        return web.json_response({"error": "message must be a string", "code": "message_not_a_string"}, status=400)
+        return web.json_response(
+            {"error": "message must be a string", "code": "message_not_a_string"}, status=400
+        )
     message = raw_message.strip()
     if not message:
-        return web.json_response({"error": "message required", "code": "message_required"}, status=400)
+        return web.json_response(
+            {"error": "message required", "code": "message_required"}, status=400
+        )
     if len(message) > _HOOK_MESSAGE_MAX_LEN:
         return web.json_response(
-            {"error": f"message exceeds {_HOOK_MESSAGE_MAX_LEN} chars", "code": "message_too_long"}, status=400
+            {"error": f"message exceeds {_HOOK_MESSAGE_MAX_LEN} chars", "code": "message_too_long"},
+            status=400,
         )
 
     session_key = body.get("sessionKey", "")
     if not isinstance(session_key, str):
-        return web.json_response({"error": "sessionKey must be a string", "code": "session_key_not_a_string"}, status=400)
+        return web.json_response(
+            {"error": "sessionKey must be a string", "code": "session_key_not_a_string"}, status=400
+        )
     if not session_key:
         session_key = f"hook:default:{int(time.time())}"
     if not session_key.startswith(_HOOK_SESSION_PREFIX):
         return web.json_response(
-            {"error": f"sessionKey must start with '{_HOOK_SESSION_PREFIX}'", "code": "session_key_prefix_invalid"}, status=400
+            {
+                "error": f"sessionKey must start with '{_HOOK_SESSION_PREFIX}'",
+                "code": "session_key_prefix_invalid",
+            },
+            status=400,
         )
 
     name = body.get("name", "Webhook")
@@ -845,10 +860,14 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
         # non-string raises there, the notification and Slack DM never run, and
         # the ephemeral session is already reset — the turn's output is gone
         # while the run history says it was delivered.
-        return web.json_response({"error": "name must be a string", "code": "name_not_a_string"}, status=400)
+        return web.json_response(
+            {"error": "name must be a string", "code": "name_not_a_string"}, status=400
+        )
     requested_agent = body.get("agent", "") or None
     if requested_agent is not None and not isinstance(requested_agent, str):
-        return web.json_response({"error": "agent must be a string", "code": "agent_not_a_string"}, status=400)
+        return web.json_response(
+            {"error": "agent must be a string", "code": "agent_not_a_string"}, status=400
+        )
     deliver = body.get("deliver", True)
     try:
         timeout_secs = max(
@@ -856,7 +875,10 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
             min(int(body.get("timeoutSeconds", _HOOK_TIMEOUT_DEFAULT)), _HOOK_TIMEOUT_MAX),
         )
     except (ValueError, TypeError):
-        return web.json_response({"error": "timeoutSeconds must be an integer", "code": "timeout_not_an_integer"}, status=400)
+        return web.json_response(
+            {"error": "timeoutSeconds must be an integer", "code": "timeout_not_an_integer"},
+            status=400,
+        )
 
     mapped_agent = str(source_entry.get("agent") or "") if source_entry else ""
     if mapped_agent and requested_agent and requested_agent != mapped_agent:
@@ -974,7 +996,10 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
             detail=f"Rejected: {_HOOK_MAX_CONCURRENT} concurrent runs already in flight",
         )
         return web.json_response(
-            {"error": f"hook capacity reached ({_HOOK_MAX_CONCURRENT})", "code": "capacity_reached"},
+            {
+                "error": f"hook capacity reached ({_HOOK_MAX_CONCURRENT})",
+                "code": "capacity_reached",
+            },
             status=429,
         )
 
@@ -1017,11 +1042,26 @@ async def api_hooks_agent(request: web.Request) -> web.Response:
     return web.json_response({"status": "accepted", "sessionKey": session_key})
 
 
+# The permission-request event kind, spelled locally: the agent-sdk-boundary
+# gate forbids ADDING an ACP/providers import edge in application code, and
+# kiro_crew.agent_sdk does not re-export the event vocabulary yet, so naming
+# the wire constant here would grow exactly the edge the gate ratchets down.
+# The spelling is pinned against the source of truth by the regression tests,
+# which compare it to the real event object's kind.
+_EVENT_PERMISSION_REQUEST_KIND = "permission_request"
+
+
 async def _run_hook_inner(
     state: DashboardState, session_key: str, message: str, agent: str | None
 ) -> str:
     """Inner agent turn — called within timeout wrapper."""
+    from kiro_crew import name_grant
     from kiro_crew.context import _neutralize_structural_markers, session_store_for_turn
+    from kiro_crew.hooks import (  # noqa: F811  # circular import
+        TOOL_AUTO_APPROVE,
+        TOOL_DENY,
+        identity_grant_covers_child,
+    )
     from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK  # noqa: F811
 
     memory_store = await session_store_for_turn(state.context_builder, session_key)
@@ -1036,7 +1076,11 @@ async def _run_hook_inner(
         # Off-loop: build_message embeds the episodic query (blocking urllib).
         full_message, _ = await run_in_embed_pool(
             state.context_builder.build_message,
-            message, is_new, session_key, agent=agent, resumed=resumed,
+            message,
+            is_new,
+            session_key,
+            agent=agent,
+            resumed=resumed,
             provider_type=KiroCrewConfig.load().agent.provider,
             memory_store=memory_store,
         )
@@ -1061,6 +1105,139 @@ async def _run_hook_inner(
     async for event in client.stream(full_message):
         if event.kind == EVENT_TEXT_CHUNK:
             result_text += event.text
+        elif event.kind == _EVENT_PERMISSION_REQUEST_KIND:
+            # Webhook turns are headless and their payload is untrusted
+            # external input, so the default is DENY. An unanswered request
+            # stalls the provider until the _run_hook_agent timeout fires and
+            # the watchdog reports the turn as cancelled by the user. Route
+            # the request through the same hook gate every other headless
+            # runner uses (task_planner, llm_helpers, subagent_manager) and
+            # approve ONLY on the gate's affirmative TOOL_AUTO_APPROVE:
+            # TOOL_ALLOW means "ask the user" on interactive surfaces, and
+            # with no approver here it fails closed.
+            decision = None
+            deny_error = "no_hook_store"
+            hooks_gate = getattr(state.context_builder, "hooks", None)
+            if hooks_gate is not None:
+                try:
+                    decision = hooks_gate.on_tool_call(
+                        event.title,
+                        session_key=session_key,
+                        agent=agent or "",
+                        tool_kind=event.tool_kind,
+                        raw_params=event.raw_tool_params,
+                        diff_path=event.diff_path,
+                        command=event.shell_command,
+                        is_shell=event.is_shell,
+                        mcp_server_name=event.mcp_server_name,
+                        mcp_tool_name=event.tool_name,
+                        mcp_identity_trusted=event.mcp_identity_trusted,
+                    )
+                except Exception:
+                    # A raising gate must not leave the request unanswered --
+                    # an unanswered request is the exact stall this branch
+                    # exists to fix. No verdict is no positive authorization.
+                    logger.exception("webhook hook gate failed for %s", session_key)
+                    decision = None
+                    deny_error = "gate_error"
+                else:
+                    deny_error = (
+                        "hook_deny" if decision.action == TOOL_DENY else "no_interactive_approver"
+                    )
+            approve = False
+            if decision is not None and decision.action == TOOL_AUTO_APPROVE:
+                approve = True
+                if event.child_low_fidelity and not identity_grant_covers_child(decision, event):
+                    # A backend-child request whose security context is
+                    # unverified: every hook auto-approve except the
+                    # identity-keyed grant read the forgeable, agent-authored
+                    # title, so the dashboard runner and the subagent manager
+                    # both downgrade it. Headless there is no approval card to
+                    # downgrade to, so the downgrade is deny.
+                    approve = False
+                    deny_error = "child_low_fidelity"
+            if approve:
+                # An auto-approve tier is a statement about a PROGRAM name,
+                # and the shell re-resolves that name through a PATH that can
+                # lead with agent-writable directories. Verify it
+                # unconditionally, as every name-grant surface does at the
+                # point of honour; with no approver to downgrade to, a
+                # withheld grant denies (same as llm_helpers headless).
+                _ng_refusal = await name_grant.refusal_for_event(event)
+                if _ng_refusal is not None:
+                    logger.warning(
+                        "declining a webhook hook auto-approve: %s",
+                        _ng_refusal.log_text,
+                    )
+                    name_grant.log_decline(
+                        source="webhook",
+                        session_key=session_key,
+                        agent=agent or "kirocrew",
+                        event=event,
+                        refusal=_ng_refusal,
+                        tier="hook_auto_approve",
+                        sel_factory=_sel,
+                    )
+                    approve = False
+                    deny_error = "name_grant_headless_reject"
+            if approve:
+                # Audit-or-deny: this surface runs unattended, so an
+                # auto-approve that cannot be audited must not run.
+                # critical=True writes synchronously and re-raises on a
+                # filesystem failure; audit BEFORE the wire call so a
+                # transport failure cannot skip the audit either (the stated
+                # invariant in llm_helpers / backend-security-controls).
+                try:
+                    # critical=True writes synchronously (open/write/flush)
+                    # and this is the branch's common path: off-loop it so an
+                    # SEL disk stall cannot pause every gateway task.
+                    await asyncio.to_thread(
+                        functools.partial(
+                            _sel().log_tool_invocation,
+                            session_key=session_key,
+                            agent=agent or "kirocrew",
+                            tool_name=event.title or "unknown",
+                            tool_kind=event.tool_kind,
+                            outcome="auto_approved",
+                            source="webhook",
+                            request_id=str(event.request_id),
+                            critical=True,
+                        )
+                    )
+                except Exception:
+                    logger.exception("webhook auto-approve audit failed; denying %s", session_key)
+                    # The decision itself must not vanish from SEL: hand the
+                    # denial to the ordinary (batched) writer best-effort,
+                    # naming the audit failure as the reason.
+                    try:
+                        _sel().log_tool_invocation(
+                            session_key=session_key,
+                            agent=agent or "kirocrew",
+                            tool_name=event.title or "unknown",
+                            tool_kind=event.tool_kind,
+                            outcome="denied",
+                            source="webhook",
+                            request_id=str(event.request_id),
+                            error="audit_write_failed",
+                        )
+                    except Exception:
+                        logger.debug("denial record after audit failure also failed", exc_info=True)
+                    await client.reject_tool(event.request_id)
+                else:
+                    await client.approve_tool(event.request_id)
+            else:
+                # Audit the denial BEFORE rejecting, for the same reason.
+                _sel().log_tool_invocation(
+                    session_key=session_key,
+                    agent=agent or "kirocrew",
+                    tool_name=event.title or "unknown",
+                    tool_kind=event.tool_kind,
+                    outcome="denied",
+                    source="webhook",
+                    request_id=str(event.request_id),
+                    error=deny_error,
+                )
+                await client.reject_tool(event.request_id)
         elif event.kind == EVENT_COMPLETE:
             _complete_event = event
             break
@@ -1177,9 +1354,7 @@ async def _run_hook_agent(
             # with no handler, so a raising notifier lost the result AND skipped
             # the Slack attempt that might still have succeeded.
             try:
-                state.notify(
-                    "hook", title, result_text[:2000], meta={"session_key": session_key}
-                )
+                state.notify("hook", title, result_text[:2000], meta={"session_key": session_key})
                 destinations.append("notifications")
             except Exception:
                 logger.exception("Hook agent: notification delivery failed")
@@ -1359,9 +1534,9 @@ def _delete_hook_context(hook_id: str) -> bool:
         target = hook_id
         if target not in raw:
             matches = [
-                k for k in raw
-                if _is_context_registration(raw[k])
-                and _redact_hook_identifier(k) == hook_id
+                k
+                for k in raw
+                if _is_context_registration(raw[k]) and _redact_hook_identifier(k) == hook_id
             ]
             if len(matches) != 1:
                 return False
@@ -1388,7 +1563,9 @@ async def api_webhooks_switch(request: web.Request) -> web.Response:
         return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     enabled = body.get("enabled")
     if not isinstance(enabled, bool):
-        return web.json_response({"error": "enabled must be a boolean", "code": "enabled_not_a_boolean"}, status=400)
+        return web.json_response(
+            {"error": "enabled must be a boolean", "code": "enabled_not_a_boolean"}, status=400
+        )
 
     try:
         stored = await asyncio.to_thread(webhooks.token_store().set_switch, enabled)
@@ -1445,9 +1622,7 @@ async def api_webhooks(request: web.Request) -> web.Response:
     # would each be a context switch, and a snapshot taken under one call is also
     # internally consistent rather than interleaved with a concurrent token edit.
     try:
-        tokens, switch_on, contexts, runs = await asyncio.to_thread(
-            _webhooks_snapshot
-        )
+        tokens, switch_on, contexts, runs = await asyncio.to_thread(_webhooks_snapshot)
     except webhooks.WebhookStoreUnreadable as exc:
         # Reads refuse rather than reporting an empty store, so the page gets a
         # named error it can show instead of an unhandled 500 that looks like a
@@ -1496,7 +1671,11 @@ async def api_webhook_token_create(request: web.Request) -> web.Response:
     require_signature = body.get("require_signature", True)
     if not isinstance(require_signature, bool):
         return web.json_response(
-            {"error": "require_signature must be a boolean", "code": "require_signature_not_a_boolean"}, status=400
+            {
+                "error": "require_signature must be a boolean",
+                "code": "require_signature_not_a_boolean",
+            },
+            status=400,
         )
     agent = body.get("agent")
     if not isinstance(agent, str) or not agent.strip():
@@ -1509,12 +1688,18 @@ async def api_webhook_token_create(request: web.Request) -> web.Response:
     except Exception:
         logger.warning("webhook destination-agent discovery failed", exc_info=True)
         return web.json_response(
-            {"error": "destination agent could not be verified", "code": "agent_discovery_unavailable"},
+            {
+                "error": "destination agent could not be verified",
+                "code": "agent_discovery_unavailable",
+            },
             status=503,
         )
     if agent not in installed_agents:
         return web.json_response(
-            {"error": "destination agent is not installed", "code": "destination_agent_unavailable"},
+            {
+                "error": "destination agent is not installed",
+                "code": "destination_agent_unavailable",
+            },
             status=400,
         )
     try:
@@ -1562,7 +1747,10 @@ async def api_webhook_token_update(request: web.Request) -> web.Response:
             error="legacy credential is config-managed",
         )
         return web.json_response(
-            {"error": "the legacy credential is config-managed", "code": "legacy_credential_in_config"},
+            {
+                "error": "the legacy credential is config-managed",
+                "code": "legacy_credential_in_config",
+            },
             status=400,
         )
     body = await _json_object(request)
@@ -1572,25 +1760,36 @@ async def api_webhook_token_update(request: web.Request) -> web.Response:
     unknown = sorted(set(body) - allowed)
     if unknown or not body:
         return web.json_response(
-            {"error": "patch may only contain agent, enabled, or label", "code": "invalid_source_patch"},
+            {
+                "error": "patch may only contain agent, enabled, or label",
+                "code": "invalid_source_patch",
+            },
             status=400,
         )
     if "agent" in body:
         agent = body["agent"]
         if not isinstance(agent, str) or not agent.strip():
-            return web.json_response({"error": "agent is required", "code": "agent_required"}, status=400)
+            return web.json_response(
+                {"error": "agent is required", "code": "agent_required"}, status=400
+            )
         agent = agent.strip()
         try:
             installed_agents = await asyncio.to_thread(_installed_agent_names)
         except Exception:
             logger.warning("webhook destination-agent discovery failed", exc_info=True)
             return web.json_response(
-                {"error": "destination agent could not be verified", "code": "agent_discovery_unavailable"},
+                {
+                    "error": "destination agent could not be verified",
+                    "code": "agent_discovery_unavailable",
+                },
                 status=503,
             )
         if agent not in installed_agents:
             return web.json_response(
-                {"error": "destination agent is not installed", "code": "destination_agent_unavailable"},
+                {
+                    "error": "destination agent is not installed",
+                    "code": "destination_agent_unavailable",
+                },
                 status=400,
             )
     else:
@@ -1740,8 +1939,7 @@ async def api_webhook_test(request: web.Request) -> web.Response:
             {
                 "ok": False,
                 "error": (
-                    f"Cannot mint a probe token ({exc}). Revoke an unused "
-                    "token and try again."
+                    f"Cannot mint a probe token ({exc}). Revoke an unused " "token and try again."
                 ),
                 "code": "probe_credential_mint_failed",
             },
@@ -1774,9 +1972,7 @@ async def api_webhook_test(request: web.Request) -> web.Response:
         "Authorization": f"Bearer {raw}",
         "Content-Type": "application/json",
         webhooks.TIMESTAMP_HEADER: str(timestamp),
-        webhooks.SIGNATURE_HEADER: webhooks.sign_payload(
-            signing_secret, timestamp, body_bytes
-        ),
+        webhooks.SIGNATURE_HEADER: webhooks.sign_payload(signing_secret, timestamp, body_bytes),
     }
     status = 0
     error = ""

--- a/test/test_webhook_permission_requests.py
+++ b/test/test_webhook_permission_requests.py
@@ -1,0 +1,336 @@
+"""Webhook turns must ANSWER tool permission requests, not sit on them.
+
+``_run_hook_inner`` consumed only ``EVENT_TEXT_CHUNK`` / ``EVENT_COMPLETE``, so
+an ``EVENT_PERMISSION_REQUEST`` was never approved or rejected: the provider
+waited for a decision that never came, the turn idled into the
+``_run_hook_agent`` timeout, and the watchdog reported it as cancelled by the
+user. These tests drive the real ``_run_hook_inner`` with a fake client whose
+stream yields a permission request followed by a complete event and lock in
+the headless contract shared with every other non-interactive runner:
+
+- deny by default (no hook gate, or a gate verdict that would ASK a user on an
+  interactive surface) — ``reject_tool`` awaited exactly once with the
+  request id, and the denial SEL-audited with ``source="webhook"`` BEFORE the
+  wire call;
+- approve only on the gate's affirmative ``TOOL_AUTO_APPROVE``;
+- the turn still returns promptly with its text instead of hitting the
+  timeout path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from kiro_crew import name_grant
+from kiro_crew.acp.types import (
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    AcpEvent,
+    TurnUsage,
+)
+from kiro_crew.dashboard.handlers import usage
+from kiro_crew.dashboard.handlers.hooks import (
+    _EVENT_PERMISSION_REQUEST_KIND,
+    _run_hook_inner,
+)
+from kiro_crew.hooks import TOOL_ALLOW, TOOL_AUTO_APPROVE, TOOL_DENY, ToolHookResult
+
+_REQUEST_ID = "perm-req-9790"
+
+# Far above any plausible test runtime, far below the 300s production
+# timeout: a turn that answers the request finishes in milliseconds, so
+# tripping this bound means the request was left unanswered.
+_PROMPT_BOUND_S = 10
+
+
+def _permission_event(**overrides: object) -> AcpEvent:
+    defaults: dict = dict(
+        kind=EVENT_PERMISSION_REQUEST,
+        title="Run a tool",
+        tool_kind="execute",
+        request_id=_REQUEST_ID,
+    )
+    defaults.update(overrides)
+    return AcpEvent(**defaults)
+
+
+class _FakeClient:
+    """Stand-in for the ACP client: one permission request, then complete."""
+
+    def __init__(self, permission_event: AcpEvent | None = None) -> None:
+        self.approved: list[str | int] = []
+        self.rejected: list[str | int] = []
+        self._permission_event = permission_event or _permission_event()
+        # read_effective_agent / _resolve_model walk the wrapper chain for these.
+        self._agent = "kirocrew"
+        self._model = "claude-test"
+
+    async def stream(self, _message: str):
+        yield AcpEvent(kind=EVENT_TEXT_CHUNK, text="hello ")
+        yield self._permission_event
+        yield AcpEvent(kind=EVENT_TEXT_CHUNK, text="world")
+        yield AcpEvent(kind=EVENT_COMPLETE, usage=TurnUsage(duration_ms=0, credits=1.0))
+
+    async def approve_tool(self, request_id, *, always: bool = False) -> None:
+        self.approved.append(request_id)
+
+    async def reject_tool(self, request_id) -> None:
+        self.rejected.append(request_id)
+
+
+class _FakeSessions:
+    def __init__(self, client: _FakeClient) -> None:
+        self._client = client
+
+    async def get_or_create(self, _session_key: str, agent: str | None = None):
+        # is_new=False so _run_hook_inner skips context building (no embed pool).
+        return (self._client, False, False)
+
+    def record_success(self, _session_key: str) -> None:
+        pass
+
+
+class _FakeGate:
+    def __init__(self, result: ToolHookResult | Exception) -> None:
+        self._result = result
+        self.calls: list[dict] = []
+
+    def on_tool_call(self, tool_name: str, **kwargs) -> ToolHookResult:
+        self.calls.append({"tool_name": tool_name, **kwargs})
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+class _FakeContextBuilder:
+    """Only what the permission branch reads; falsy-safe conversation_log."""
+
+    conversation_log = None
+
+    def __init__(self, gate: _FakeGate) -> None:
+        self.hooks = gate
+
+
+class _FakeState:
+    def __init__(self, client: _FakeClient, context_builder=None) -> None:
+        self.sessions = _FakeSessions(client)
+        self.context_builder = context_builder
+
+
+class _RecordingSel:
+    def __init__(self) -> None:
+        self.tool_rows: list[dict] = []
+
+    def log_tool_invocation(self, **kwargs) -> None:
+        self.tool_rows.append(kwargs)
+
+    def __getattr__(self, _name):  # any other SEL surface: ignore
+        return lambda *a, **k: None
+
+
+def _drive(monkeypatch, gate_action: str | None, *, gate_result=None, event=None):
+    """Run one webhook turn; return (client, sel, gate, result_text)."""
+    sel = _RecordingSel()
+    # _sel() in handlers/hooks.py resolves through the handlers package's
+    # late-binding sel() exactly for this patch point.
+    import kiro_crew.dashboard.handlers as handlers_pkg
+
+    monkeypatch.setattr(handlers_pkg, "sel", lambda: sel)
+    # Keep the usage row off the real shards (same seam the turn-duration
+    # tests intercept).
+    monkeypatch.setattr(usage, "_write_token_record", lambda _record, _now: None)
+
+    client = _FakeClient(event)
+    if gate_result is None and gate_action is not None:
+        gate_result = ToolHookResult(action=gate_action)
+    gate = _FakeGate(gate_result) if gate_result is not None else None
+    builder = _FakeContextBuilder(gate) if gate is not None else None
+    result_text = asyncio.run(
+        asyncio.wait_for(
+            _run_hook_inner(_FakeState(client, builder), "hook:test:9790", "go", None),
+            timeout=_PROMPT_BOUND_S,
+        )
+    )
+    return client, sel, gate, result_text
+
+
+def _denial_rows(sel: _RecordingSel) -> list[dict]:
+    return [r for r in sel.tool_rows if r.get("outcome") == "denied"]
+
+
+def test_no_gate_rejects_audits_and_still_returns_text(monkeypatch):
+    """Deny by default: no hook gate -> audit the denial, reject, keep going."""
+    client, sel, _gate, result_text = _drive(monkeypatch, gate_action=None)
+
+    assert client.rejected == [_REQUEST_ID], "reject_tool must be awaited exactly once"
+    assert client.approved == []
+
+    rows = _denial_rows(sel)
+    assert len(rows) == 1, "exactly one SEL denial row"
+    row = rows[0]
+    assert row["source"] == "webhook"
+    assert row["request_id"] == _REQUEST_ID
+    assert row["tool_name"] == "Run a tool"
+
+    # The turn completed promptly (wait_for above) and kept its text.
+    assert result_text == "hello world"
+
+
+def test_gate_deny_is_audited_then_rejected(monkeypatch):
+    """A TOOL_DENY verdict rejects, with the denial attributed to the gate."""
+    client, sel, gate, result_text = _drive(monkeypatch, gate_action=TOOL_DENY)
+
+    assert client.rejected == [_REQUEST_ID]
+    assert client.approved == []
+    assert len(gate.calls) == 1
+    # The gate got the security-relevant fields, not just the display title.
+    assert gate.calls[0]["session_key"] == "hook:test:9790"
+    assert gate.calls[0]["tool_kind"] == "execute"
+
+    rows = _denial_rows(sel)
+    assert len(rows) == 1
+    assert rows[0]["error"] == "hook_deny"
+    assert rows[0]["source"] == "webhook"
+    assert result_text == "hello world"
+
+
+def test_gate_would_ask_fails_closed(monkeypatch):
+    """TOOL_ALLOW means "ask the user" interactively; headless it must deny."""
+    client, sel, _gate, _text = _drive(monkeypatch, gate_action=TOOL_ALLOW)
+
+    assert client.rejected == [_REQUEST_ID]
+    assert client.approved == []
+    rows = _denial_rows(sel)
+    assert len(rows) == 1
+    assert rows[0]["error"] == "no_interactive_approver"
+
+
+def test_gate_auto_approve_approves_once_and_audits(monkeypatch):
+    """The gate's affirmative auto-approve is honoured and SEL-audited."""
+    client, sel, _gate, result_text = _drive(monkeypatch, gate_action=TOOL_AUTO_APPROVE)
+
+    assert client.approved == [_REQUEST_ID], "approve_tool must be awaited exactly once"
+    assert client.rejected == []
+    assert _denial_rows(sel) == []
+
+    approvals = [r for r in sel.tool_rows if r.get("outcome") == "auto_approved"]
+    assert len(approvals) == 1
+    assert approvals[0]["source"] == "webhook"
+    assert approvals[0]["request_id"] == _REQUEST_ID
+    assert result_text == "hello world"
+
+
+def test_gate_exception_denies_and_still_answers(monkeypatch):
+    """A raising gate must not leave the request unanswered (the stall)."""
+    client, sel, _gate, result_text = _drive(
+        monkeypatch, None, gate_result=RuntimeError("gate blew up")
+    )
+
+    assert client.rejected == [_REQUEST_ID]
+    assert client.approved == []
+    rows = _denial_rows(sel)
+    assert len(rows) == 1
+    assert rows[0]["error"] == "gate_error"
+    assert result_text == "hello world"
+
+
+def test_auto_approve_is_name_grant_verified_headless(monkeypatch):
+    """A withheld name grant denies: no approver exists to downgrade to."""
+    refusal = name_grant.Refusal(code="shadowed", detail="PATH leads elsewhere")
+
+    async def _refuse(_event):
+        return refusal
+
+    monkeypatch.setattr(name_grant, "refusal_for_event", _refuse)
+    client, sel, _gate, _text = _drive(monkeypatch, TOOL_AUTO_APPROVE)
+
+    assert client.rejected == [_REQUEST_ID], "the withheld grant must deny"
+    assert client.approved == []
+    rows = _denial_rows(sel)
+    assert len(rows) == 1
+    assert rows[0]["error"] == "name_grant_headless_reject"
+    # The decline itself is audited too (name_grant.log_decline through _sel).
+    declines = [r for r in sel.tool_rows if (r.get("metadata") or {}).get("reason") == "name_grant"]
+    assert len(declines) == 1
+    assert declines[0]["source"] == "webhook"
+
+
+def test_low_fidelity_child_auto_approve_is_denied(monkeypatch):
+    """A child event with unverified security context cannot ride a
+    title-derived auto-approve; headless the downgrade is deny."""
+    event = _permission_event(sub_session_id="child-1")
+    assert event.child_low_fidelity, "premise: this event is low-fidelity"
+    client, sel, _gate, _text = _drive(monkeypatch, TOOL_AUTO_APPROVE, event=event)
+
+    assert client.rejected == [_REQUEST_ID]
+    assert client.approved == []
+    rows = _denial_rows(sel)
+    assert len(rows) == 1
+    assert rows[0]["error"] == "child_low_fidelity"
+
+
+def test_identity_grant_covers_verified_child(monkeypatch):
+    """The identity-keyed grant still stands for a child whose MCP identity is
+    verified: both sides of the match are non-agent-authored."""
+    event = _permission_event(
+        sub_session_id="child-1",
+        mcp_server_name="approved-server",
+        tool_name="list_things",
+        mcp_identity_trusted=True,
+    )
+    assert event.child_mcp_identity_trusted, "premise: identity verified"
+    client, sel, _gate, _text = _drive(
+        monkeypatch,
+        None,
+        gate_result=ToolHookResult(action=TOOL_AUTO_APPROVE, identity_grant=True),
+        event=event,
+    )
+
+    assert client.approved == [_REQUEST_ID]
+    assert client.rejected == []
+    assert _denial_rows(sel) == []
+
+
+def test_unauditable_auto_approve_is_denied(monkeypatch):
+    """Audit-or-deny: an auto-approve whose SEL write raises must not run."""
+    sel_calls: list[dict] = []
+
+    class _RaisingSel(_RecordingSel):
+        def log_tool_invocation(self, **kwargs) -> None:
+            sel_calls.append(kwargs)
+            if kwargs.get("outcome") == "auto_approved":
+                raise OSError("audit disk full")
+
+    import kiro_crew.dashboard.handlers as handlers_pkg
+
+    raising = _RaisingSel()
+    monkeypatch.setattr(handlers_pkg, "sel", lambda: raising)
+    monkeypatch.setattr(usage, "_write_token_record", lambda _record, _now: None)
+
+    client = _FakeClient()
+    builder = _FakeContextBuilder(_FakeGate(ToolHookResult(action=TOOL_AUTO_APPROVE)))
+    result_text = asyncio.run(
+        asyncio.wait_for(
+            _run_hook_inner(_FakeState(client, builder), "hook:test:9790", "go", None),
+            timeout=_PROMPT_BOUND_S,
+        )
+    )
+
+    assert client.rejected == [_REQUEST_ID], "unaudited approval must become a reject"
+    assert client.approved == []
+    assert result_text == "hello world"
+    # The auto-approve audit was ATTEMPTED with critical=True before the wire.
+    attempted = [c for c in sel_calls if c.get("outcome") == "auto_approved"]
+    assert attempted and attempted[0].get("critical") is True
+    # The decision itself is still recorded: a best-effort denial row names
+    # the audit failure so the permission decision cannot vanish from SEL.
+    denials = [c for c in sel_calls if c.get("outcome") == "denied"]
+    assert len(denials) == 1
+    assert denials[0].get("error") == "audit_write_failed"
+
+
+def test_permission_kind_constant_matches_the_wire_vocabulary():
+    """The handler spells the event kind locally (the agent-sdk boundary gate
+    forbids adding an ACP import edge); this pin breaks if the vocabulary moves."""
+    assert _EVENT_PERMISSION_REQUEST_KIND == EVENT_PERMISSION_REQUEST


### PR DESCRIPTION
## Summary

A webhook-triggered agent turn (`POST /api/hooks/agent`) streams events in `_run_hook_inner`, which consumed only `EVENT_TEXT_CHUNK` and `EVENT_COMPLETE`. When the provider emitted `EVENT_PERMISSION_REQUEST`, nothing ever answered it: the provider waited for a decision that never came, the turn idled into the `_run_hook_agent` `asyncio.wait_for` timeout (default 300s), and the watchdog cancelled it, reporting "cancelled by the user". The webhook runner was the only headless runner that neither decided nor audited.

Closes #9790

## Change

Add an `EVENT_PERMISSION_REQUEST` branch to the stream loop, mirroring the headless contract shared by `task_planner`, `llm_helpers`, and `subagent_manager`:

- **Deny by default.** Webhook payloads are untrusted external input and this surface has no interactive approver. `TOOL_ALLOW` ("ask the user" on interactive surfaces) fails closed; a missing hook gate rejects; a raising gate rejects (`gate_error`) rather than leaving the request unanswered — an unanswered request is the exact stall this fixes.
- **Approve only on the gate's affirmative `TOOL_AUTO_APPROVE`,** and even then:
  - `name_grant.refusal_for_event` is awaited at the point of honour (auto-approve tiers are statements about a PROGRAM name, and the shell re-resolves that name through a PATH that can lead with agent-writable directories). A withheld grant denies (`name_grant_headless_reject`) and the decline is audited via `name_grant.log_decline`, same as the `llm_helpers` headless path.
  - A low-fidelity backend-child request (`AcpEvent.child_low_fidelity`) cannot ride a title-derived auto-approve; only the identity-keyed grant (`identity_grant_covers_child`) stands, same rule the dashboard runner and subagent manager enforce. Headless there is no card to downgrade to, so the downgrade is deny (`child_low_fidelity`).
- **Every decision is SEL-audited with `source="webhook"` BEFORE the wire call** so a transport failure cannot skip the audit (the stated invariant in `llm_helpers`). The auto-approve row is written with `critical=True` (audit-or-deny): an approval that cannot be audited is rejected instead.
- `EVENT_TEXT_CHUNK` / `EVENT_COMPLETE` handling is unchanged; the turn still returns its text.

## Tests

`test/test_webhook_permission_requests.py` (new) drives the real `_run_hook_inner` with a fake client whose stream yields a permission request followed by a complete event:

- no gate → `reject_tool` awaited exactly once with the request id, SEL denial row (`source="webhook"`, matching `request_id`), turn returns its text promptly instead of hitting the timeout path
- gate `TOOL_DENY` → audited `hook_deny` then rejected; gate receives the security-relevant fields (session key, tool kind)
- gate `TOOL_ALLOW` → fails closed (`no_interactive_approver`)
- gate `TOOL_AUTO_APPROVE` → `approve_tool` awaited exactly once, `auto_approved` row audited
- raising gate → rejected with `gate_error`, turn still completes
- withheld name grant → rejected with `name_grant_headless_reject`, decline audited
- low-fidelity child → rejected with `child_low_fidelity`
- identity-verified child + `identity_grant=True` → approved
- SEL write failure on the auto-approve row → the approval is rejected (audit-or-deny), and the attempt carried `critical=True`

## Verification

- Local gates green: `isort`, `flake8`, `mypy src/kiro_crew/` (1457 files), diff-scoped black gate (one graduated baseline entry pruned per the gate's instruction), brand gate. Test execution is left to CI per repo policy.
- Two pre-push model-pinned review lanes (GPT and Opus contracts) ran against the diff; both High findings (missing name-grant verification, missing low-fidelity-child downgrade) are fixed in this revision, plus the advisory items: gate-exception deny, `agent=` attribution on the SEL rows, and audit-or-deny on the unattended auto-approve. Two advisories consciously not taken: the gate call stays inline on the event loop (same shape as `chat_runner`/`task_planner`, precedent noted) and no in-band steer notice is sent on denial (webhook sessions are ephemeral; the turn now completes and returns text, which removes the user-facing symptom).


## Pattern harvest

Rule candidate: every headless `async for event in client.stream(...)` / `session.prompt(...)` loop must carry an `EVENT_PERMISSION_REQUEST` arm (deny-by-default, hook-gated, name-grant-verified, child-fidelity-downgraded, SEL-audited before the wire call). A scan flagging stream loops that consume `EVENT_COMPLETE` without an `EVENT_PERMISSION_REQUEST` arm would have caught this webhook runner — the only headless consumer missing one — at introduction time.
