### PR TITLE
refactor(acp): route 'auto'-served checks through model_is_unusable (#9859)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -2309,11 +2309,12 @@ def _model_is_unentitled(data: str, available_models: Sequence[str] | None) -> s
     if not available_models:
         return None
     rejected = match.group(1)
-    # Compare case-insensitively on the bare id: the rejection echoes back the
-    # id that was sent, but casing has no meaning in these ids and an
-    # entitled-but-differently-cased match must not be reported as unentitled.
-    advertised = {m.strip().lower() for m in available_models if m and m.strip()}
-    if rejected.strip().lower() in advertised:
+    # Route the served-list membership through the canonical helper: casing has
+    # no meaning in these ids, and an entitled-but-differently-cased match must
+    # not be reported as unentitled. The empty-list guard above preserves the
+    # None-on-empty contract, so the helper's empty-means-usable answer is
+    # never consulted here.
+    if not model_is_unusable(rejected, available_models):
         return None
     return rejected
 
@@ -2613,8 +2614,7 @@ def _auto_remedy(available_models: Sequence[str] | None) -> str:
     numbering of the remaining step shifts so the list still reads (1)(2)(3)
     or (1)(2).
     """
-    usable = [m.strip().lower() for m in (available_models or []) if m and m.strip()]
-    if usable and DEFAULT_MODEL not in usable:
+    if model_is_unusable(DEFAULT_MODEL, available_models):
         return "or (2) "
     return f"(2) set agent.model to '{DEFAULT_MODEL}' in ~/.kiro/crew/config.json, or (3) "
 
@@ -2711,7 +2711,7 @@ def _format_acp_error(
                     f"not help."
                     f"{req_id_suffix}"
                 )
-            elif DEFAULT_MODEL in {m.lower() for m in usable}:
+            elif not model_is_unusable(DEFAULT_MODEL, available_models):
                 # Same two-step shape as the branches around it (the error card
                 # says "do both" under every entitlement row): the picker fixes
                 # this session, the default stops the next one -- and here

--- a/test/test_acp_error_surface.py
+++ b/test/test_acp_error_surface.py
@@ -448,6 +448,30 @@ class TestTransientMarkerCoupling:
         assert "set agent.model to 'auto'" not in _format_acp_error(unnamed, no_auto)
         assert "set agent.model to 'auto'" in _format_acp_error(unnamed, with_auto)
 
+    def test_auto_served_checks_agree_with_model_is_unusable(self):
+        """Both 'is ``auto`` served?' call sites route through the canonical
+        helper: feed mixed-case, whitespace-padded advertised lists and assert
+        each site's verdict is exactly the helper's, so a change to
+        advertised-list semantics lands once.
+        """
+        from kiro_crew.acp.client import (
+            DEFAULT_MODEL,
+            _auto_remedy,
+            _format_acp_error,
+            model_is_unusable,
+        )
+
+        for advertised in ([" Auto ", "claude-x"], ["CLAUDE-X"]):
+            served = not model_is_unusable(DEFAULT_MODEL, advertised)
+            # (a) _auto_remedy emits the "(2) set agent.model" step iff served.
+            remedy = _auto_remedy(advertised)
+            assert ("(2) set agent.model" in remedy) is served
+            # (b) an unentitled non-auto id picks the "set it to 'auto'"
+            # wording iff served ('claude-opus-4.8' is absent from both lists).
+            formatted = _format_acp_error(_MODEL_UNAVAILABLE, advertised)
+            assert "does not have access to model 'claude-opus-4.8'" in formatted
+            assert ("agent.model to 'auto' in ~/.kiro/crew/config.json to let" in formatted) is served
+
 
 class TestConnectionErrorClassification:
     """Connection failures are transient, while credential failures win precedence."""


### PR DESCRIPTION
## Problem / Motivation

The merged fix for #9099 (commit 4fdf1ab33) implemented the "is `auto` served?" decision with hand-rolled membership checks in `src/kiro_crew/acp/client.py` instead of routing through the canonical helper `model_is_unusable`, which already owns the served-list rules (case folding, blank stripping, "empty/unknown advertised list means assume usable"). Two spellings of the same predicate can drift.

## Why it matters

`docs/system-specs/common/model-selection.md` ("resolve, don't guess" / "Never hand-roll a membership test") names `model_is_unusable` as the single place every usability decision goes through, so a future change to advertised-list semantics (aliases, namespace-qualified ids such as the codex bucket from #9789) lands once. Today the behaviour is correct; left as-is, the next semantics change has to find and update several spellings or the user-facing advice and the send-path verdict disagree.

## What changed (motivation → approach → change)

Consolidation, not a behaviour change. Three fold sites:

- `_auto_remedy`: the `usable` list comprehension plus `if usable and DEFAULT_MODEL not in usable:` becomes `if model_is_unusable(DEFAULT_MODEL, available_models):`. Identical semantics — the helper returns False on an empty/None advertised list (matching the old `usable and ...` guard) and case-folds/strips exactly like the comprehension. The two returned strings are byte-identical.
- `_format_acp_error` unentitled branch: `elif DEFAULT_MODEL in {m.lower() for m in usable}:` becomes `elif not model_is_unusable(DEFAULT_MODEL, available_models):`. Safe because the branch is only reached when `_model_is_unentitled(data, available_models)` returned a truthy id, and that function returns `None` whenever `available_models` is empty — so the helper's empty-list-means-usable contract can never flip this branch. The local `usable` list stays: it is the unstripped-case display spelling for the `shown`/`more` strings.
- `_model_is_unentitled`: the inline advertised-set fold becomes `if not model_is_unusable(rejected, available_models):`. The function's own early `return None` on an empty list preserves its None-on-empty contract, so the helper's empty-means-usable answer is never consulted there. (Added in response to the First Principles review: the stated "lands once" goal was one fold short without it.)

Deliberately NOT folded: `if unentitled.strip().lower() == DEFAULT_MODEL:` is a sentinel-IDENTITY test (is the rejected id itself the `auto` sentinel), not a served-list membership test, so `model_is_unusable` is not the right helper for it. The repo has no shared case-fold helper for single model ids, so the expression stays as is.

No helper-contract change, so `docs/system-specs/common/model-selection.md` is untouched.

## Tests

- New: `test_auto_served_checks_agree_with_model_is_unusable` in `test/test_acp_error_surface.py` — feeds mixed-case, whitespace-padded advertised lists (`[" Auto ", "claude-x"]` and `["CLAUDE-X"]`) and asserts (a) `_auto_remedy` emits the `(2) set agent.model` step iff `not model_is_unusable(DEFAULT_MODEL, advertised)`, and (b) `_format_acp_error` on an unentitled non-auto id picks the "set it to 'auto'" wording iff the same predicate. This is a drift guard: both call sites must agree with the helper wherever its semantics go next.
- Unchanged: the existing text-pinning tests in `test/test_acp_error_surface.py` and `test/test_model_unentitled_meta.py` cover byte-identity of the user-facing strings and the `_model_is_unentitled` verdicts (including the case-insensitivity and empty-list contracts) and keep passing without modification.

## Manual verification

N/A — unit coverage sufficient: the change is a pure predicate fold in three pure functions, all fully exercised by the existing text-pinning and unentitled-meta tests plus the new agreement test.

## Related Issues

Closes #9859

## Pattern harvest

Rule candidate: review-prompt
Pattern: inline re-spelling of a canonical predicate (membership/usability check duplicated at call sites instead of routed through the named helper)

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
