### PR TITLE
fix(apps): featured spotlight falls back to local hero art

### DIFF
--- a/website/src/components/appstore/FeaturedSpotlight.tsx
+++ b/website/src/components/appstore/FeaturedSpotlight.tsx
@@ -27,7 +27,7 @@ import Clickable from '../Clickable'
 import AppIcon from '../AppIcon'
 import { gradientFor } from './gradient'
 import { categoryFor } from './categories'
-import { useHeroArt } from './useHeroArt'
+import { useHeroArt, type InstalledArtSource } from './useHeroArt'
 import { useEditorialArt, type EditorialArtwork } from './useEditorialArt'
 import { sourceLabel, isVerified, type RegistryApp } from './types'
 import { appDisplayName, appDescription } from './appManifest'
@@ -168,6 +168,7 @@ export default function FeaturedSpotlight({
   curated = false,
   layout = 'stacked',
   compact = false,
+  leadInstalled,
   onOpenApp,
   onGet,
   onEnable,
@@ -221,6 +222,15 @@ export default function FeaturedSpotlight({
    * fallback row reads as secondary beside the lead.
    */
   compact?: boolean
+  /**
+   * The LEAD app's installed record, when it is installed — the local
+   * second-chance art source for `useHeroArt` (#6887): a registry hero that
+   * fails to LOAD swaps once to the app's own on-disk art instead of
+   * degrading straight to the gradient. Only the lead's art fills the band,
+   * so only the lead's record is threaded. Omitted (a non-installed lead, or
+   * a caller that has no installed list), the hook stays behaviour-identical.
+   */
+  leadInstalled?: InstalledArtSource
   onOpenApp: (name: string, e?: React.MouseEvent | React.KeyboardEvent) => void
   onGet: (name: string) => void
   onEnable: (name: string) => void
@@ -236,7 +246,7 @@ export default function FeaturedSpotlight({
   // app rather than being skipped -- React forbids the skip, and `useHeroArt`
   // answers "no art" for no app, which is the same answer it gives for an app
   // shipping none.
-  const hero = useHeroArt(lead)
+  const hero = useHeroArt(lead, leadInstalled)
   const editorial = useEditorialArt(artwork)
   // Unconditional like the art hooks above: the early return below sits between
   // this and the compact branch that reads it, and React forbids the skip.

--- a/website/src/components/appstore/useHeroArt.ts
+++ b/website/src/components/appstore/useHeroArt.ts
@@ -16,17 +16,97 @@ type HeroFields = Pick<RegistryApp, 'heroImage' | 'heroImageDark' | 'screenshots
 const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i
 
 /**
+ * A path segment the URL parser treats as a DOT SEGMENT during normalization.
+ *
+ * WHATWG path normalization reads `%2e` as `.` (case-insensitively), so the
+ * double-dot set is `..`, `.%2e`, `%2e.` and `%2e%2e`, and the single-dot set
+ * is `.` and `%2e`. Matching the parser's own set — not just literal dots — is
+ * what keeps a percent spelling from walking through, the same
+ * parser-is-the-authority rule the origin probe below follows.
+ */
+const DOT_SEGMENT_RE = /^(?:\.|%2e){1,2}$/i
+
+/**
+ * True when the URL parser would MOVE this path while normalizing it.
+ *
+ * Judges the value the PARSER will see (:func:`asParserSees` runs first, so a
+ * tab or newline inside a dot segment cannot hide it), then splits on BOTH
+ * separators: WHATWG converts ``\`` to ``/`` in special-scheme URLs before
+ * normalizing, so ``\..\`` is the same escape as ``/../``. A value that
+ * carries a dot segment stays same-origin — an origin probe alone passes it —
+ * but the browser resolves the segments AFTER a resolver joins its route on,
+ * so ``/apps/<name>/art/../../../api/tips/next`` is requested as
+ * ``/api/tips/next``: a content-controlled ``<img>`` invoking an authenticated
+ * API. One sanctioned LEADING ``./`` is allowed (it means the same
+ * repo-relative path and every consumer strips it). Deliberately FAIL-CLOSED on
+ * query/fragment text: a raw ``/../`` after ``?`` cannot move path segments, but
+ * splitting the value at ``?`` would misjudge relative manifest values (where
+ * ``?`` is literal path data once per-segment encoding runs), so a pathological
+ * query costs a gradient fallback rather than a widened parser model.
+ */
+function hasTraversalSegments(path: string): boolean {
+  const seen = asParserSees(path)
+  const scan = (v: string): boolean => {
+    const rel = v.startsWith('./') ? v.slice(2) : v
+    return rel.split(/[\\/]/).some(seg => DOT_SEGMENT_RE.test(seg))
+  }
+  // Two views of the value, refused when EITHER carries a dot segment. The
+  // whole-value view covers a relative manifest value, which is re-joined
+  // under the art route after per-segment encoding — `?` and `#` are literal
+  // path data there, so "a?/../y" would traverse the joined URL. The
+  // pre-terminator view covers a verbatim browser-bound value, whose path
+  // STOPS at the first `?` or `#` — "/app-assets/..?x" ends in a real dot
+  // segment the whole-value split reads as one non-dot "..?x".
+  return scan(seen) || scan(seen.split(/[?#]/)[0])
+}
+
+/**
+ * The one absolute route the SERVER writes into a registry row: the blob-proxy
+ * URL its enrichment step builds (``/api/apps/blob?repo=…&path=…``). Not part
+ * of :data:`CLIENT_ART_ROUTE_RE` because a MANIFEST never legitimately
+ * declares it — only :func:`resolveArtPath`, which consumes enriched rows,
+ * accepts it. The literal ``?`` is required: a bare or sub-pathed spelling
+ * names nothing the proxy serves.
+ */
+const ENRICHED_BLOB_ROUTE_RE = /^\/api\/apps\/blob\?./
+
+/**
  * Resolve a manifest art path the way the installed-app surfaces resolve
  * ``iconPath``: a repo-relative path (registry apps declare art relative to
- * their repo root) is routed through the blob proxy, while absolute paths
- * (``/app-assets/...`` built-ins) and full URLs pass through untouched so
- * shipping apps keep working byte-for-byte. Server-enriched registry rows
- * already arrive as ``/api/apps/blob?...`` URLs and start with ``/``, so they
- * are naturally left alone rather than double-wrapped.
+ * their repo root) is routed through the blob proxy, while allowlisted
+ * absolute paths and full URLs pass through untouched so shipping apps keep
+ * working byte-for-byte.
+ *
+ * A registry row is third-party content and this function's output lands in
+ * ``<img src>`` verbatim, so each branch that passes a value through raw is
+ * positively gated rather than open-ended:
+ *
+ * - ABSOLUTE values pass only on the art allowlist — shipped client assets and
+ *   the installed-art route (:data:`CLIENT_ART_ROUTE_RE`), plus the
+ *   server-enriched blob route (:data:`ENRICHED_BLOB_ROUTE_RE`) — and only
+ *   with no traversal segments. "Same origin" alone is not a safety property:
+ *   ``heroImage: "/api/tips/next"`` would fire an authenticated GET the row's
+ *   author chose the moment the image renders.
+ * - RELATIVE values with a repo are immune by construction: the blob proxy
+ *   encodes them whole into a query parameter.
+ * - RELATIVE values with NO repo are refused: they would render relative to
+ *   the current page, which on a root-mounted SPA is the same reach as an
+ *   absolute path, and nothing legitimate used that branch.
+ * - FULL URLs pass through: a cross-origin image request carries no
+ *   same-origin credentials, and registry rows may name CDNs by design.
+ *
+ * Branch decisions read the parser's view of the value (:func:`asParserSees`);
+ * the clean value returns byte-identical.
  */
 export function resolveArtPath(path: string, repo?: string): string {
-  if (!path || !repo) return path
-  if (path.startsWith('/') || SCHEME_RE.test(path)) return path
+  if (!path) return path
+  const seen = asParserSees(path)
+  if (seen.startsWith('/')) {
+    if (hasTraversalSegments(seen)) return ''
+    return CLIENT_ART_ROUTE_RE.test(seen) || ENRICHED_BLOB_ROUTE_RE.test(seen) ? path : ''
+  }
+  if (SCHEME_RE.test(seen)) return path
+  if (!repo) return ''
   // The blob proxy rejects "." path segments; "./assets/x.png" means the same
   // repo-relative path as "assets/x.png", so normalize the common form.
   const rel = path.startsWith('./') ? path.slice(2) : path
@@ -61,16 +141,34 @@ const ORIGIN_PROBE_ORIGIN = 'https://origin-probe.invalid'
  * ``<img>`` is the value we classified.
  *
  * The parser removes every ASCII tab and newline anywhere in the input and trims
- * leading C0 controls and spaces, all BEFORE parsing. Measured: against a
- * same-origin base, ``/<TAB>/host/x``, ``/<LF>/host/x``, ``<TAB>//host/x`` and
- * ``<SPACE>//host/x`` all resolve to ``https://host`` — so no test on the raw
- * string's first characters can decide anything. (A space or form feed MID-value
- * is not stripped and stays on-origin, which is why this mirrors the spec's exact
- * set rather than "all whitespace".)
+ * leading AND trailing C0 controls and spaces, all BEFORE parsing. Measured:
+ * against a same-origin base, ``/<TAB>/host/x``, ``/<LF>/host/x``,
+ * ``<TAB>//host/x`` and ``<SPACE>//host/x`` all resolve to ``https://host`` — so
+ * no test on the raw string's first characters can decide anything. The trailing
+ * trim matters to the traversal guard for the same reason: ``/app-assets/.. ``
+ * ends in what the raw string calls a non-dot segment, and the parser exposes
+ * the ``..`` by trimming the space first. (A space or form feed MID-value is not
+ * stripped and stays on-origin, which is why this mirrors the spec's exact set
+ * rather than "all whitespace".)
  */
 function asParserSees(path: string): string {
-  return path.replace(/[\t\n\r]/g, '').replace(/^[\u0000-\u0020]+/, '')
+  return path
+    .replace(/[\t\n\r]/g, '')
+    .replace(/^[\u0000-\u0020]+/, '')
+    .replace(/[\u0000-\u0020]+$/, '')
 }
+
+/**
+ * The same-origin absolute paths a manifest may point ``<img>`` at: a shipped
+ * client asset, or the installed-art route the resolvers themselves emit (the
+ * hero/screenshot gates re-classify those outputs before rendering them). A
+ * positive route allowlist, because "same origin" alone is not a safety
+ * property here: an authenticated API route is same-origin too, and a manifest
+ * naming ``/api/...`` outright would have it fetched — with credentials — the
+ * moment a fallback ``<img>`` renders. The prefix must be followed by a real
+ * asset path, so a bare route names nothing.
+ */
+const CLIENT_ART_ROUTE_RE = /^\/(?:app-assets|apps\/[^\\/]+\/art)\/[^\\/]/
 
 /**
  * Classify one art path read off an installed app's ``app.json``.
@@ -92,6 +190,14 @@ function asParserSees(path: string): string {
  * and a tab or leading space splitting the two slashes), which is the evidence
  * that the parser has to be the authority and not a regex approximating it.
  *
+ * Dot segments are the fourth refusal family, in the parser's own spelling set
+ * (``..``, ``%2e%2e``, their mixes, and the backslash-separated forms — see
+ * :func:`hasTraversalSegments`): a traversal value stays same-origin, so the
+ * probe alone passes it, but the browser normalizes the segments AFTER a
+ * resolver joins its route on — ``heroImage: "../../../api/tips/next"`` would
+ * turn the installed-art route into a manifest-controlled request against an
+ * authenticated API endpoint.
+ *
  * This mirrors the backend, which honours only the repo-relative ``iconPath``
  * when it builds a store row and never a manifest-declared ``iconUrl``.
  */
@@ -99,6 +205,12 @@ export function classifyManifestArt(path: unknown): ArtPathKind {
   if (typeof path !== 'string' || !path) return 'refused'
   const value = asParserSees(path)
   if (!value) return 'refused'
+  // TWO leading separators make an AUTHORITY reference: the parser consumes
+  // "//host" as a host, not as path segments. A generic host fails the origin
+  // comparison below, but a value naming the PROBE's own host would match it
+  // exactly — while on the real dashboard origin it still targets that
+  // external host. Refused by shape, before any origin math.
+  if (/^[\\/]{2}/.test(value)) return 'refused'
   // Parses on its own => it carries a scheme, so it is not ours to honour.
   try {
     new URL(value)
@@ -111,7 +223,12 @@ export function classifyManifestArt(path: unknown): ArtPathKind {
   } catch {
     return 'refused'
   }
-  return value.startsWith('/') ? 'same-origin' : 'relative'
+  if (hasTraversalSegments(value)) return 'refused'
+  if (!value.startsWith('/')) return 'relative'
+  // Same-origin is necessary but not sufficient: only the client-art routes
+  // are a manifest's to name (see CLIENT_ART_ROUTE_RE) — any other absolute
+  // path is a request the manifest author chose, not art.
+  return CLIENT_ART_ROUTE_RE.test(value) ? 'same-origin' : 'refused'
 }
 
 /**
@@ -235,13 +352,46 @@ export function hasHeroArt(app: HeroFields): boolean {
 }
 
 /**
+ * The slice of an INSTALLED app a caller hands over so the hook can build a
+ * local second-chance candidate from the app's own manifest. The art fields
+ * are ``unknown`` because a manifest is JSON from disk — :func:`installedArt`
+ * owns the refusal of anything that is not a usable same-origin path, exactly
+ * as it does for the detail page's fallbacks.
+ */
+export type InstalledArtSource = {
+  name: string
+  manifest?: {
+    heroImage?: unknown
+    heroImageDark?: unknown
+    screenshots?: unknown
+  } | null
+}
+
+/**
  * *app* is optional so a caller can hold the hook call unconditional while still
  * declining to render: a surface whose app list came from a published document
  * may legitimately have nothing to show, and React forbids skipping the hook to
  * handle that. No app means no art, which is the same answer as an app shipping
  * none.
+ *
+ * *installed* is the optional local second chance (#6887): when the app is
+ * INSTALLED its art bytes are already on local disk, so a registry asset that
+ * fails to LOAD (offline, captive portal, blocked host) swaps once to the
+ * installed-app art route instead of degrading straight to the gradient — the
+ * same two-latch discipline AppIcon (#6804) and the detail page (#6864) run.
+ * Deliberately not a precedence change: the registry's asset stays the primary
+ * ``src`` and keeps its cache win; the local candidate is consulted only when
+ * that src errors, and never retried when it IS the failed primary. When the
+ * fallback also fails — or none is supplied, every pre-existing caller — the
+ * terminal state is ``''`` (the gradient), exactly as before. Both latches
+ * reset when the resolved primary changes (theme flip, a re-fetch filling in
+ * metadata); the fallback latch alone resets when the local candidate moves
+ * (an install completing under a mounted page). The candidate is same-origin
+ * by construction: it only ever comes out of :func:`installedArt`, which
+ * refuses anything a third-party manifest could use to point this ``<img>``
+ * at another host.
  */
-export function useHeroArt(app?: HeroFields): { src: string; onError: () => void } {
+export function useHeroArt(app?: HeroFields, installed?: InstalledArtSource): { src: string; onError: () => void } {
   const { theme } = useTheme()
   const dark = theme === 'dark'
   const chosen = (dark
@@ -250,12 +400,38 @@ export function useHeroArt(app?: HeroFields): { src: string; onError: () => void
   // Repo-relative manifest paths (all three fields: heroImage, heroImageDark,
   // screenshots) resolve through the blob proxy; absolute paths pass through.
   const resolved = resolveArtPath(chosen, app?.repo)
+  // The local candidate mirrors the primary's field choice over the RESOLVED
+  // values (a refused field falls through to the next, as the detail page's
+  // fallback resolution does), then the first usable local screenshot — any of
+  // the app's own art beats the gradient.
+  const m = installed?.manifest
+  const localLight = installedArt(m?.heroImage, installed?.name)
+  const localDark = installedArt(m?.heroImageDark, installed?.name)
+  const fallback = (dark ? (localDark || localLight) : (localLight || localDark))
+    || installedArtList(m?.screenshots, installed?.name)[0] || ''
   const [failed, setFailed] = useState('')
-  // Reset the failure latch when the resolved art changes (theme flip, or a
-  // re-fetch that filled in metadata) so a new URL gets a fresh attempt.
-  useEffect(() => { setFailed('') }, [resolved])
+  const [fallbackFailed, setFallbackFailed] = useState('')
+  // Reset the failure latches when the resolved art changes (theme flip, or a
+  // re-fetch that filled in metadata) so a new URL gets a fresh attempt. A
+  // changed primary clears BOTH: an app update rewrites the local file in
+  // place, so a stale fallback latch would be a sticky failure.
+  useEffect(() => { setFailed(''); setFallbackFailed('') }, [resolved])
+  // The same per-URL reset for the fallback latch alone: the candidate moves
+  // independently of the primary and must never inherit a stale failure.
+  useEffect(() => { setFallbackFailed('') }, [fallback])
+  // '' never counts as a failed primary: with no registry art at all the hook
+  // answers '' as it always has — the second chance is for a LOAD failure,
+  // not a precedence flip.
+  const primaryFailed = resolved !== '' && failed === resolved
+  // Skipped when the candidate matches the failed primary (retrying the URL
+  // that just errored is a second doomed request) and once it has itself
+  // failed, so '' stays the terminal state.
+  const secondChance = primaryFailed && fallback !== '' && fallback !== resolved && fallbackFailed !== fallback
   return {
-    src: failed === resolved ? '' : resolved,
-    onError: () => setFailed(resolved),
+    src: primaryFailed ? (secondChance ? fallback : '') : resolved,
+    onError: () => {
+      if (!primaryFailed) setFailed(resolved)
+      else setFallbackFailed(fallback)
+    },
   }
 }

--- a/website/src/pages/apps/DiscoverPage.tsx
+++ b/website/src/pages/apps/DiscoverPage.tsx
@@ -264,6 +264,16 @@ function DiscoverPageBody() {
     }
   }
 
+  /* Installed-app lookup for the featured cards' local-art second chance
+     (#6887): a card whose LEAD app is installed hands its installed record to
+     FeaturedSpotlight, so a registry hero that fails to load swaps to the
+     app's own on-disk art instead of the gradient. `apps` is the normalized
+     installed list this page already holds via useAppsData — no extra fetch. */
+  const installedByName = useMemo(
+    () => new Map(apps.map(a => [a.name, a] as const)),
+    [apps],
+  )
+
   const filteredBrowse = useMemo(() => {
     const q = query.trim().toLowerCase()
     const list = browseApps.filter(a => {
@@ -558,6 +568,11 @@ function DiscoverPageBody() {
                        inline install rows per card made the row taller than
                        the lead above it, inverting the hierarchy. */
                     compact={block.form === 'row'}
+                    /* The local second-chance art source: present only when
+                       the lead app is installed, absent otherwise — which is
+                       what keeps a non-installed lead's card on the plain
+                       hide-to-gradient path. */
+                    leadInstalled={installedByName.get(section.apps[0]?.name ?? '')}
                     busyName={
                       featuredBusyName(actionLoading, section.apps)
                     }

--- a/website/src/test/AppDetailPageCoverage.test.tsx
+++ b/website/src/test/AppDetailPageCoverage.test.tsx
@@ -203,8 +203,8 @@ describe('AppDetailPage — uncovered surfaces', () => {
     displayName: 'Ledger Lens',
     description: 'Reads your books and explains them.',
     author: 'zezhexu',
-    screenshots: ['/shots/light-one.png', '/shots/light-two.png', '/shots/light-three.png'],
-    screenshotsDark: ['/shots/dark-one.png', '/shots/dark-two.png'],
+    screenshots: ['/app-assets/shots/light-one.png', '/app-assets/shots/light-two.png', '/app-assets/shots/light-three.png'],
+    screenshotsDark: ['/app-assets/shots/dark-one.png', '/app-assets/shots/dark-two.png'],
   }
 
   it('steps through the lightbox with the next and previous controls', async () => {
@@ -293,7 +293,7 @@ describe('AppDetailPage — uncovered surfaces', () => {
     await loaded()
 
     expect((screen.getByAltText('Screenshot 1') as HTMLImageElement).getAttribute('src'))
-      .toBe('/shots/dark-one.png')
+      .toBe('/app-assets/shots/dark-one.png')
     // The dark set is shorter, so the third light shot must not leak through.
     expect(screen.queryByAltText('Screenshot 3')).not.toBeInTheDocument()
   })
@@ -313,24 +313,24 @@ describe('AppDetailPage — uncovered surfaces', () => {
         description: 'Reads your books and explains them.',
         // The detail-ratio banner wins over the Browse hero and sizes its own
         // container, so both resolution arms are exercised here.
-        heroImageDetail: '/hero/detail-light.png',
-        heroImage: '/hero/browse-light.png',
+        heroImageDetail: '/app-assets/hero/detail-light.png',
+        heroImage: '/app-assets/hero/browse-light.png',
       },
     }))
     renderDetail()
     await loaded()
 
-    const hero = document.querySelector('img[src="/hero/detail-light.png"]') as HTMLImageElement
+    const hero = document.querySelector('img[src="/app-assets/hero/detail-light.png"]') as HTMLImageElement
     expect(hero).not.toBeNull()
     expect(hero.parentElement?.className).toContain('aspect-[25/6]')
-    expect(document.querySelector('img[src="/hero/browse-light.png"]')).toBeNull()
+    expect(document.querySelector('img[src="/app-assets/hero/browse-light.png"]')).toBeNull()
 
     fireEvent.error(hero)
     // #6864: the terminal state is now an UNMOUNTED banner. The fallback
     // candidate here is the identical URL (no registry row, so the local art
     // already won the precedence), nothing is retried, and no empty bordered
     // box is left where the banner was.
-    expect(document.querySelector('img[src="/hero/detail-light.png"]')).toBeNull()
+    expect(document.querySelector('img[src="/app-assets/hero/detail-light.png"]')).toBeNull()
     expect(document.querySelector('.aspect-\\[25\\/6\\]')).toBeNull()
   })
 

--- a/website/src/test/FeaturedSpotlightLocalFallback.test.tsx
+++ b/website/src/test/FeaturedSpotlightLocalFallback.test.tsx
@@ -1,0 +1,332 @@
+/**
+ * FeaturedSpotlight local-art fallback (#6887) — the port of #6804/#6864's
+ * two-latch second chance to the Discover page's featured band.
+ *
+ * An INSTALLED lead app's registry hero stays the primary `src` (no precedence
+ * change — #6804 rejects a flip), but when that asset fails to LOAD the app's
+ * own bytes are on local disk, so the band must swap once to the installed-app
+ * art route instead of degrading straight to the designed gradient. When the
+ * fallback fails too — or the lead is not installed — the gradient stays the
+ * terminal state, exactly as before.
+ *
+ * Per the standard #6804 set, these tests FIRE the element's `error` event and
+ * assert the rendered `src` actually changed — asserting a handler is attached
+ * proves nothing. The suite also locks the default-inert contract for callers
+ * that pass no installed source (every pre-existing `useHeroArt` caller).
+ */
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockTheme = vi.hoisted(() => ({ value: 'light' as 'light' | 'dark' }))
+vi.mock('../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: mockTheme.value }),
+}))
+
+vi.mock('../components/AppIcon', () => ({
+  default: () => <div data-testid="app-icon" />,
+}))
+
+// The DiscoverPage threading tests below need the api surface useAppsData
+// reads; the hook- and component-level suites never touch it, so one
+// file-level mock serves all three.
+const { listApps, listRegistry, listRegistries } = vi.hoisted(() => ({
+  listApps: vi.fn(),
+  listRegistry: vi.fn(),
+  listRegistries: vi.fn(),
+}))
+vi.mock('../api/client', () => ({
+  api: {
+    listApps: (...a: unknown[]) => listApps(...a),
+    listRegistry: (...a: unknown[]) => listRegistry(...a),
+    listRegistries: (...a: unknown[]) => listRegistries(...a),
+    updateRegistries: vi.fn(),
+    refreshRegistries: vi.fn(),
+    enableApp: vi.fn(),
+    disableApp: vi.fn(),
+    updateApp: vi.fn(),
+    uninstallApp: vi.fn(),
+    uninstallPreview: vi.fn(),
+    installApp: vi.fn(),
+    openApp: vi.fn(),
+  },
+}))
+
+import FeaturedSpotlight from '../components/appstore/FeaturedSpotlight'
+import DiscoverPage from '../pages/apps/DiscoverPage'
+import { useHeroArt, type InstalledArtSource } from '../components/appstore/useHeroArt'
+import type { RegistryApp } from '../components/appstore/types'
+
+// Registry (blob-proxy) primaries.
+const R_HERO = '/api/apps/blob?repo=demo%2Fdemo-app&path=assets%2Fhero.png'
+const R_HERO_DARK = '/api/apps/blob?repo=demo%2Fdemo-app&path=assets%2Fhero-dark.png'
+// Local install routes the manifest paths resolve to.
+const LOCAL_HERO = '/apps/demo-app/art/assets/hero.png'
+const LOCAL_HERO_DARK = '/apps/demo-app/art/assets/hero-dark.png'
+const LOCAL_SHOT = '/apps/demo-app/art/shots/a.png'
+
+const HERO_APP = {
+  heroImage: R_HERO,
+  heroImageDark: R_HERO_DARK,
+  screenshots: [],
+} as unknown as RegistryApp
+
+const INSTALLED: InstalledArtSource = {
+  name: 'demo-app',
+  manifest: { heroImage: 'assets/hero.png', heroImageDark: 'assets/hero-dark.png' },
+}
+
+beforeEach(() => { mockTheme.value = 'light' })
+
+describe('useHeroArt — local second chance (#6887)', () => {
+  function mount(app?: RegistryApp, installed?: InstalledArtSource) {
+    return renderHook(
+      ({ a, i }: { a?: RegistryApp; i?: InstalledArtSource }) => useHeroArt(a, i),
+      { initialProps: { a: app, i: installed } },
+    )
+  }
+
+  it('primary error swaps src to the local route; a second error latches to the gradient', () => {
+    const { result } = mount(HERO_APP, INSTALLED)
+    expect(result.current.src).toBe(R_HERO)
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(LOCAL_HERO)
+    act(() => result.current.onError())
+    expect(result.current.src).toBe('')
+  })
+
+  it('stays behaviour-identical with no installed source: one error latches to the gradient', () => {
+    const { result } = mount(HERO_APP)
+    expect(result.current.src).toBe(R_HERO)
+    act(() => result.current.onError())
+    expect(result.current.src).toBe('')
+  })
+
+  it('a theme flip changes the resolved primary and resets BOTH latches', () => {
+    const { result } = mount(HERO_APP, INSTALLED)
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.src).toBe('')
+    // The resolved URL changes, so the art deserves a fresh attempt — and the
+    // fallback family follows the theme, so a failure there retries dark local.
+    act(() => { mockTheme.value = 'dark' })
+    const dark = mount(HERO_APP, INSTALLED)
+    expect(dark.result.current.src).toBe(R_HERO_DARK)
+    act(() => dark.result.current.onError())
+    expect(dark.result.current.src).toBe(LOCAL_HERO_DARK)
+  })
+
+  it('rerendering with a changed primary clears the terminal latch in place', () => {
+    const { result, rerender } = mount(HERO_APP, INSTALLED)
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.src).toBe('')
+    const next = { ...HERO_APP, heroImage: '/api/apps/blob?repo=demo%2Fdemo-app&path=assets%2Fhero-v2.png' } as RegistryApp
+    rerender({ a: next, i: INSTALLED })
+    expect(result.current.src).toBe('/api/apps/blob?repo=demo%2Fdemo-app&path=assets%2Fhero-v2.png')
+    // And the fallback gets retried on the new primary's failure.
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(LOCAL_HERO)
+  })
+
+  it('skips a fallback identical to the failed primary rather than retrying it', () => {
+    // The local candidate already won the primary pick (the row's own field
+    // carries the local route); retrying the URL that just errored is a
+    // second doomed request.
+    const app = { heroImage: LOCAL_HERO, screenshots: [] } as unknown as RegistryApp
+    const { result } = mount(app, INSTALLED)
+    expect(result.current.src).toBe(LOCAL_HERO)
+    act(() => result.current.onError())
+    expect(result.current.src).toBe('')
+  })
+
+  it('no registry art at all still answers the gradient — the second chance is not a precedence flip', () => {
+    const app = { screenshots: [] } as unknown as RegistryApp
+    const { result } = mount(app, INSTALLED)
+    expect(result.current.src).toBe('')
+  })
+
+  it('falls through a refused manifest field to the next usable local candidate', () => {
+    // An absolute URL out of a manifest is refused (a third-party manifest
+    // must not point this <img> at another host); the next field still serves.
+    const { result } = mount(HERO_APP, {
+      name: 'demo-app',
+      manifest: { heroImage: 'https://evil.example/x.png', screenshots: ['shots/a.png'] },
+    })
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(LOCAL_SHOT)
+  })
+
+  it('answers the gradient when every manifest candidate is refused', () => {
+    const { result } = mount(HERO_APP, {
+      name: 'demo-app',
+      manifest: { heroImage: 'https://evil.example/x.png', screenshots: {} },
+    })
+    act(() => result.current.onError())
+    expect(result.current.src).toBe('')
+  })
+})
+
+describe('FeaturedSpotlight — installed lead swaps to local art on a failed registry hero', () => {
+  const noop = () => {}
+
+  function lead(over: Partial<RegistryApp> = {}): RegistryApp {
+    return {
+      name: 'demo-app',
+      displayName: 'Demo App',
+      description: 'About demo-app.',
+      author: 'Kiro Crew',
+      version: '1.0.0',
+      tags: ['agents'],
+      installed: true,
+      ...over,
+    } as RegistryApp
+  }
+
+  function mountCard(props: Partial<Parameters<typeof FeaturedSpotlight>[0]> = {}) {
+    return render(
+      <FeaturedSpotlight
+        type="app"
+        apps={[lead({ heroImage: R_HERO } as Partial<RegistryApp>)]}
+        onOpenApp={noop}
+        onGet={noop}
+        onEnable={noop}
+        {...props}
+      />,
+    )
+  }
+
+  function imgBySrc(src: string): HTMLImageElement | null {
+    return document.querySelector(`img[src="${src}"]`)
+  }
+
+  it('with leadInstalled, a failed registry hero swaps to the local route, then the gradient', () => {
+    mountCard({ leadInstalled: INSTALLED })
+    const primary = imgBySrc(R_HERO)
+    expect(primary).not.toBeNull()
+    fireEvent.error(primary!)
+    expect(imgBySrc(R_HERO)).toBeNull()
+    const local = imgBySrc(LOCAL_HERO)
+    expect(local).not.toBeNull()
+    // Local bytes gone too: terminal is the designed gradient plate, no
+    // broken-image frame left in the band.
+    fireEvent.error(local!)
+    expect(document.querySelector('img')).toBeNull()
+    expect(screen.getByTestId('app-icon')).toBeInTheDocument()
+  })
+
+  it('without leadInstalled (a non-installed lead), a failed hero degrades straight to the gradient', () => {
+    mountCard()
+    fireEvent.error(imgBySrc(R_HERO)!)
+    expect(document.querySelector('img')).toBeNull()
+    expect(screen.getByTestId('app-icon')).toBeInTheDocument()
+  })
+
+  it('a curated card is untouched: editorial art keeps its own error path', () => {
+    mountCard({
+      curated: true,
+      artwork: { url: 'https://apps.crew.kiro.dev/assets/editorial/aaa.png' },
+      leadInstalled: INSTALLED,
+    })
+    const img = document.querySelector('img') as HTMLImageElement
+    expect(img.getAttribute('src')).toContain('assets/editorial/aaa.png')
+    fireEvent.error(img)
+    // The editorial latch drops the band (curated cards never borrow the
+    // lead's art, local or registry) — the installed source changes nothing.
+    expect(document.querySelector('img')).toBeNull()
+  })
+})
+
+describe('DiscoverPage — threads the installed record to the featured lead (#6887)', () => {
+  function installedRow(name: string) {
+    return {
+      name,
+      version: '1.0.0',
+      displayName: 'Demo App',
+      enabled: true,
+      installedAt: '2026-01-01T00:00:00Z',
+      origin: 'registry',
+      resources: 'app',
+      lifecycle: 'app',
+      manifest: {
+        name,
+        version: '1.0.0',
+        displayName: 'Demo App',
+        description: 'An installed registry app',
+        author: 'demo',
+        heroImage: 'assets/hero.png',
+      },
+    }
+  }
+
+  function registryRow(name: string, over: Record<string, unknown> = {}) {
+    return {
+      name,
+      displayName: 'Demo App',
+      description: 'About it.',
+      version: '1.0.0',
+      author: 'demo',
+      tags: ['agents'],
+      featured: 1,
+      installed: false,
+      heroImage: R_HERO,
+      ...over,
+    }
+  }
+
+  function renderDiscover() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/apps']}>
+          <Routes>
+            <Route path="/apps" element={<DiscoverPage />} />
+            <Route path="/apps/detail/:name" element={<div data-testid="detail-route" />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+  }
+
+  beforeEach(() => {
+    listApps.mockReset()
+    listRegistry.mockReset()
+    listRegistries.mockReset()
+    listRegistries.mockResolvedValue({ registries: [] })
+  })
+
+  it('an INSTALLED featured lead gets the local second chance end to end', async () => {
+    listApps.mockResolvedValue([installedRow('demo-app')])
+    listRegistry.mockResolvedValue({
+      apps: [registryRow('demo-app', { installed: true })],
+      serverPlatform: { os: 'linux', arch: 'x86_64' },
+    })
+    renderDiscover()
+    const primary = await waitFor(() => {
+      const el = document.querySelector(`img[src="${R_HERO}"]`)
+      expect(el).not.toBeNull()
+      return el as HTMLImageElement
+    })
+    fireEvent.error(primary)
+    await waitFor(() => expect(document.querySelector(`img[src="${LOCAL_HERO}"]`)).not.toBeNull())
+    expect(document.querySelector(`img[src="${R_HERO}"]`)).toBeNull()
+  })
+
+  it('a NON-installed featured lead stays on the plain gradient path', async () => {
+    listApps.mockResolvedValue([])
+    listRegistry.mockResolvedValue({
+      apps: [registryRow('demo-app')],
+      serverPlatform: { os: 'linux', arch: 'x86_64' },
+    })
+    renderDiscover()
+    const primary = await waitFor(() => {
+      const el = document.querySelector(`img[src="${R_HERO}"]`)
+      expect(el).not.toBeNull()
+      return el as HTMLImageElement
+    })
+    fireEvent.error(primary)
+    await waitFor(() => expect(document.querySelector('img')).toBeNull())
+    expect(document.querySelector(`img[src^="/apps/"]`)).toBeNull()
+  })
+})

--- a/website/src/test/heroArtPathResolution.test.tsx
+++ b/website/src/test/heroArtPathResolution.test.tsx
@@ -52,6 +52,86 @@ describe('resolveArtPath', () => {
       .toBe('/app-assets/dev-fleet/hero.svg')
   })
 
+  it('refuses an absolute path whose dot segments would escape it (#6887 review)', () => {
+    // A registry row is third-party content and its absolute paths pass
+    // through to <img src> verbatim — a dot segment there normalizes into an
+    // arbitrary same-origin request (`/app-assets/../api/tips/next` is fetched
+    // as `/api/tips/next`), bypassing classifyManifestArt entirely. Refusing
+    // answers '' so the surface degrades to the gradient, same as no art.
+    expect(resolveArtPath('/app-assets/../api/tips/next', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/app-assets\\..\\api/tips/next', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/app-assets/%2e%2e/api/tips/next', 'octocat/some-app')).toBe('')
+    // No repo to resolve against changes nothing: the value is still absolute.
+    expect(resolveArtPath('/app-assets/../api/tips/next')).toBe('')
+  })
+
+  it('passes registry values through only on the art-route allowlist (#6887 review round 2)', () => {
+    // Traversal refusal alone is not enough: a registry row can name an
+    // authenticated same-origin API OUTRIGHT (`heroImage: "/api/tips/next"`),
+    // no dot segments needed — an <img> GET with credentials the row's author
+    // chose. Absolute values pass only on the art allowlist: shipped client
+    // assets, the installed-art route, and the server-enriched blob proxy.
+    expect(resolveArtPath('/api/tips/next', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/api/tips/next')).toBe('')
+    expect(resolveArtPath('/settings', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/api/apps/registry', 'octocat/some-app')).toBe('')
+    // The allowlist keeps every legitimate shape byte-identical.
+    expect(resolveArtPath('/app-assets/dev-fleet/hero.svg', 'octocat/some-app'))
+      .toBe('/app-assets/dev-fleet/hero.svg')
+    expect(resolveArtPath('/apps/demo-app/art/assets/hero.png', 'octocat/some-app'))
+      .toBe('/apps/demo-app/art/assets/hero.png')
+    const enriched = '/api/apps/blob?repo=octocat%2Fsome-app&path=assets%2Fhero.png'
+    expect(resolveArtPath(enriched, 'octocat/some-app')).toBe(enriched)
+    // A RELATIVE value with no repo resolves against the current page — the
+    // same reach (`api/tips/next` under a root-mounted page is `/api/...`), so
+    // the repo-less pass-through is gone: nothing legitimate used it (built-ins
+    // declare absolute /app-assets/ paths), and it rendered a dead relative
+    // URL at best.
+    expect(resolveArtPath('api/tips/next')).toBe('')
+    expect(resolveArtPath('assets/hero.png')).toBe('')
+    // Full URLs keep their documented pass-through (a cross-origin image
+    // carries no same-origin credentials; registry rows may name CDNs).
+    expect(resolveArtPath('https://example.com/hero.png', 'octocat/some-app'))
+      .toBe('https://example.com/hero.png')
+  })
+
+  it('judges the value the PARSER will see, not the raw spelling (#6887 review)', () => {
+    // The parser strips every ASCII tab and newline BEFORE it recognizes
+    // separators and dot segments, so a tab inside `..` (or inside a percent
+    // spelling of it) is invisible to a raw-string scan but normalizes all the
+    // same. The guard runs on the parser's view of the value.
+    expect(resolveArtPath('/app-assets/.\t./api/tips/next', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/app-assets/%2\tE%2E/api/tips/next', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/app-assets\\.\n.\\api/tips/next', 'octocat/some-app')).toBe('')
+    expect(classifyManifestArt('a/.\t./b.png')).toBe('refused')
+    // A relative value with NO repo passes through raw and resolves against
+    // the current page, so it gets the same traversal guard...
+    expect(resolveArtPath('assets\\..\\api/tips/next')).toBe('')
+    // ...a full URL's own path is never this guard's business.
+    expect(resolveArtPath('https://example.com/a/../b.png')).toBe('https://example.com/a/../b.png')
+    // The parser also trims TRAILING C0 controls and spaces before it parses,
+    // so a terminal dot segment cannot hide behind one.
+    expect(resolveArtPath('/app-assets/..\u0000', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/app-assets/%2e%2e\u000c', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/app-assets/.. ', 'octocat/some-app')).toBe('')
+    expect(classifyManifestArt('/app-assets/.. ')).toBe('refused')
+    // Mid-value spaces are NOT stripped (the parser keeps them too).
+    expect(classifyManifestArt('/app-assets/a b.svg')).toBe('same-origin')
+    // `?` and `#` TERMINATE the path, so a dot segment right before one is
+    // real ("/app-assets/..?x" is fetched from "/") even though the raw split
+    // reads "..?x" as one non-dot segment.
+    expect(resolveArtPath('/app-assets/..?x', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/app-assets/..#x', 'octocat/some-app')).toBe('')
+    expect(resolveArtPath('/app-assets/%2e%2e?x', 'octocat/some-app')).toBe('')
+    expect(classifyManifestArt('/app-assets/..?x')).toBe('refused')
+    // ...while a RELATIVE value keeps the whole-value view: it is re-joined
+    // under the art route after per-segment encoding, where `?` is literal
+    // path data, so "a?/../y" would traverse the joined URL and stays refused.
+    expect(classifyManifestArt('a?/../y')).toBe('refused')
+    // An innocent query on a clean path stays accepted.
+    expect(classifyManifestArt('/app-assets/x.svg?v=2')).toBe('same-origin')
+  })
+
   it('does not double-wrap a server-enriched blob proxy URL', () => {
     const enriched = '/api/apps/blob?repo=octocat%2Fsome-app&path=assets%2Fhero.png'
     expect(resolveArtPath(enriched, 'octocat/some-app')).toBe(enriched)
@@ -64,8 +144,13 @@ describe('resolveArtPath', () => {
       .toBe('data:image/png;base64,AAAA')
   })
 
-  it('passes through when there is no repo to resolve against', () => {
-    expect(resolveArtPath('assets/hero.png')).toBe('assets/hero.png')
+  it('refuses a relative value with no repo to resolve against (#6887 review round 2)', () => {
+    // Without a repo the value cannot be blob-proxied, and passing it raw
+    // renders an <img> src relative to the CURRENT PAGE — on a root-mounted
+    // SPA, 'api/tips/next' is '/api/tips/next', the same authenticated-GET
+    // reach as the absolute spelling. Nothing legitimate used this branch:
+    // built-ins declare absolute /app-assets/ paths.
+    expect(resolveArtPath('assets/hero.png')).toBe('')
     expect(resolveArtPath('', 'octocat/some-app')).toBe('')
   })
 })
@@ -79,6 +164,74 @@ describe('classifyManifestArt', () => {
    * review. Deleting them alongside the wrapper would have retired the evidence
    * and kept the rule.
    */
+
+  it('refuses dot segments in every spelling the URL parser normalizes (#6887 review)', () => {
+    // The fourth refusal family: a dot segment survives the origin probe (it
+    // stays same-origin) but the browser NORMALIZES it after the art route is
+    // joined on, so `/apps/<name>/art/../../../api/tips/next` is requested as
+    // `/api/tips/next` — a manifest-controlled <img> invoking an authenticated
+    // API. WHATWG treats `%2e` as `.` during path normalization, so the
+    // percent forms are the same hole and are refused by the same rule.
+    expect(classifyManifestArt('../../../api/tips/next')).toBe('refused')
+    expect(classifyManifestArt('assets/../../../api/tips/next')).toBe('refused')
+    expect(classifyManifestArt('/app-assets/../api/tips/next')).toBe('refused')
+    expect(classifyManifestArt('/./api/tips/next')).toBe('refused')
+    expect(classifyManifestArt('a/%2e%2e/b.png')).toBe('refused')
+    expect(classifyManifestArt('a/%2E%2E/b.png')).toBe('refused')
+    expect(classifyManifestArt('a/.%2e/b.png')).toBe('refused')
+    expect(classifyManifestArt('a/%2e./b.png')).toBe('refused')
+    expect(classifyManifestArt('a/%2e/b.png')).toBe('refused')
+    expect(classifyManifestArt('./../api/tips/next')).toBe('refused')
+    // WHATWG converts `\` to `/` in special-scheme URLs before normalizing, so
+    // a backslash-separated dot segment is the same escape.
+    expect(classifyManifestArt('/app-assets\\..\\api/tips/next')).toBe('refused')
+    expect(classifyManifestArt('a\\..\\b.png')).toBe('refused')
+    expect(installedArt('../../../api/tips/next', 'demo-app')).toBe('')
+    expect(installedArt('/app-assets/../api/tips/next', 'demo-app')).toBe('')
+  })
+
+  it('refuses authority-form values, including ones naming the probe host itself (#6887 review)', () => {
+    // "//host/..." is an AUTHORITY reference: the parser consumes the host
+    // instead of path segments. A generic host already fails the origin
+    // comparison, but a value naming the probe's own host would match it
+    // exactly and slip through — while on the real dashboard origin it still
+    // targets that external host. Refused by shape, before any origin math.
+    expect(classifyManifestArt('//origin-probe.invalid/app-assets/x.svg')).toBe('refused')
+    expect(classifyManifestArt('///origin-probe.invalid/x.png')).toBe('refused')
+    expect(classifyManifestArt('/\\origin-probe.invalid/x.png')).toBe('refused')
+    expect(classifyManifestArt('\\\\origin-probe.invalid\\x.png')).toBe('refused')
+    // A SINGLE leading separator is not an authority form: the existing pins
+    // ("/app-assets/x.svg" same-origin, "\\example.com/x.png" relative) hold.
+    expect(classifyManifestArt('/app-assets/x.svg')).toBe('same-origin')
+  })
+
+  it('accepts a same-origin absolute path ONLY on the client-art allowlist (#6887 review)', () => {
+    // The positive origin rule alone accepts ANY same-origin absolute path —
+    // including "/api/tips/next", an authenticated API a malicious installed
+    // manifest could name outright (no traversal needed) and have fetched by
+    // <img> the moment the registry primary errors. A manifest may only point
+    // at shipped client assets or the installed-art route.
+    expect(classifyManifestArt('/api/tips/next')).toBe('refused')
+    expect(classifyManifestArt('/api/apps/registry')).toBe('refused')
+    expect(classifyManifestArt('/settings')).toBe('refused')
+    expect(classifyManifestArt('/hero/browse-light.png')).toBe('refused')
+    expect(installedArt('/api/tips/next', 'demo-app')).toBe('')
+    expect(clientLocalArt('/api/tips/next')).toBe('')
+    // The allowlist: shipped client assets, and the installed-art route the
+    // resolvers themselves emit (the #6864 gates re-classify those outputs).
+    expect(classifyManifestArt('/app-assets/worlds/hero-light.svg')).toBe('same-origin')
+    expect(classifyManifestArt('/apps/demo-app/art/assets/hero.png')).toBe('same-origin')
+    // A bare prefix with no child asset names nothing servable.
+    expect(classifyManifestArt('/app-assets/')).toBe('refused')
+    expect(classifyManifestArt('/apps/demo-app/art/')).toBe('refused')
+  })
+
+  it('keeps the sanctioned leading "./" spelling working', () => {
+    // `./assets/x.png` means the same repo-relative path as `assets/x.png` and
+    // is stripped downstream — only the LEADING dot segment is sanctioned.
+    expect(classifyManifestArt('./assets/x.png')).toBe('relative')
+    expect(installedArt('./assets/x.png', 'demo-app')).toBe('/apps/demo-app/art/assets/x.png')
+  })
   it('REFUSES every spelling the URL parser resolves off-origin', () => {
     // Measured against a real parser, resolving each against a same-origin base.
     // Four families, three of which defeated a successive prefix test here:


### PR DESCRIPTION
## Problem / Motivation

On the Discover page, a featured card's hero art turns into the designed gradient when the registry asset fails to load — even when the app is INSTALLED and the same art is sitting on local disk. The app icon (#6804) and the detail page (#6864) already fall back to the installed app's own art in this situation; the featured spotlight was the last surface that did not, which is the inconsistency #6887 (from the #6864 audit) asks to close.

## Why it matters

An offline or captive-portal dashboard shows a gradient where the user's installed app could show its real artwork. The degrade is mild (a gradient, not a blank box), but it is inconsistent: the same app under the same conditions shows real art on its detail page and icon, and a placeholder on the storefront's most prominent card.

## What changed (motivation → approach → change)

`useHeroArt` now takes an optional installed-app source and runs the two-latch second chance the sibling surfaces use: when the registry hero errors, the hook swaps once to the installed app's local art route; when that errors too, it latches to `''` and the gradient shows. Both latches reset when the resolved primary changes (theme flip), the fallback latch alone resets when the local candidate moves, and a fallback identical to the failed primary is never retried. The registry asset stays the primary `src` — no precedence change. `DiscoverPage` threads each featured lead's installed record into `FeaturedSpotlight` as a `leadInstalled` prop; callers that pass nothing are behaviour-identical, pinned by test.

The art-path guards in the same file are hardened, because the fallback leans on them: `classifyManifestArt` now refuses dot segments in every spelling the URL parser normalizes (`..`, `%2e%2e` and mixes, backslash separators, tab/newline-hidden and trailing-control forms, terminal segments before `?`/`#`) and refuses authority-form values (`//host/...`), which could previously name the origin probe's own host and slip the same-origin comparison. Both guards now gate absolute paths **positively**: an absolute value must match the client art allowlist (`/app-assets/...`, `/apps/<name>/art/...`) or the enriched blob route (`/api/apps/blob?...`) — not merely be traversal-free — and `resolveArtPath` applies the same gates per branch, refusing the repo-less relative pass-through outright. Without this, an installed manifest or registry row declaring `heroImage: "../../../api/tips/next"` (or any same-origin absolute like `/api/tips/next`) would make the art route request an authenticated API endpoint. Clean values — blob-proxy rows, `/app-assets/...` built-ins, full URLs, repo-relative paths — return byte-identical.

**Scope notes (changes that ride along in this diff, each verified):**
- *Allowlist gate is stricter than a pure traversal refusal.* Verified harmless against real data: every absolute art path in every builtin `app.json` matches `/app-assets/...`; off-allowlist absolutes 404'd on the art route before this change, so no working art is lost. Enriched rows resolve through the blob route, which is allowlisted.
- *The no-repo relative branch of `resolveArtPath` now refuses instead of passing through.* Its single caller (`useHeroArt`) only reaches that branch with third-party manifest values; no builtin or registry row ships repo-less relative art. The old pass-through pin was rewritten to a refusal pin, red-proven against the unfixed code.
- *Refusals cover WHATWG parser normalization* (`%2e` dot-segment spellings, backslash separators, `?`/`#`-terminal segments, authority forms, trailing C0/space trim) because the browser normalizes the URL before the request — a byte-level check alone is bypassable. All spellings pinned red-before-green.
- `resolveArtPath` is shared with `AppDetailPage`; the tightened contract was checked against the registry's actual absolute-path shapes (see above) so no legitimate row shape degrades there.

```mermaid
flowchart LR
  subgraph Before
    A1[registry hero errors]:::ctx --> B1[gradient]:::ctx
  end
  subgraph After
    A2[registry hero errors]:::ctx --> B2[installed app's local art]:::added --> C2[gradient only if that fails too]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 1,2 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟦 unchanged

*A failed registry hero on an installed app's featured card now shows the app's own art; the gradient becomes the last resort instead of the first.*

## Tests

`FeaturedSpotlightLocalFallback.test.tsx` (new): hook-level renderHook coverage — primary-fails → fallback src, fallback-fails → `''`, theme flip and primary change reset the latches, self-match never retried, no installed source stays behaviour-identical, no-registry-art stays `''` (the second chance is not a precedence flip), refused manifest values fall through to the next usable candidate. Component-level: an installed lead swaps to the local route then the gradient; a non-installed lead degrades straight to the gradient; curated cards are untouched. Page-level: `DiscoverPage` threads the installed record for an installed featured lead and not for a non-installed one, proven by firing real `error` events end to end.

`heroArtPathResolution.test.tsx` (extended): every traversal and authority spelling above is pinned as refused through both `classifyManifestArt` and `resolveArtPath`, alongside pins that the sanctioned leading `./`, mid-value spaces, innocent queries, single-separator values, and all clean pass-throughs keep their exact prior behavior. All fallback and refusal tests were proven red against the unfixed code before the fix.

## Manual verification

Verified in a real browser (scripted Playwright against a vite dev server with the registry blob route blocked at the network layer): the featured card for an installed app renders the local art after the registry asset fails, and renders the gradient on main. Screenshots below are from that run.

## Screenshots / video

Before (main): the registry asset is unreachable and the installed app's featured card degrades to the gradient.

![Featured card degrades to gradient when the registry asset is blocked](./evidence/before-registry-unreachable-gradient.png)

After (this PR): the same failure now shows the installed app's own local hero art.

![Featured card shows the installed app's local art when the registry asset is blocked](./evidence/after-local-art-fallback.png)

## Related Issues

Fixes #6887

## Pattern harvest

Rule candidate: review-prompt
Pattern: a content-controlled string handed to `<img src>` must be judged as the URL parser sees it (preprocessing, `?`/`#` terminators, both separators, the WHATWG dot-segment set) — a raw-string scan misses every one of those spellings.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
