### PR TITLE
fix: scope the kiro-cli readiness gate to backends that sign in via it

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -579,6 +579,52 @@ Subprocess lifecycle:
   carry that error. These sites authorize on a **freshly verified** probe
   (`verified_ready`, 30s ceiling), never the bare latch — a stale `ready=True`
   would green-light exactly the signed-out spawn the gate exists to prevent.
+  - **The latch governs only a harness that signs in through kiro-cli.** The
+    gate first reads `agent.acp_backend` (off the loop, through
+    `KiroCrewConfig.load`) and applies only when that backend is a member of
+    `backends_retired_by_host_logout()` — positive membership (H5/H6), answered
+    by `kiro_readiness.backend_signs_in_via_kiro_cli()` over `selected_backend()`.
+    For any other
+    selected harness (claude-agent-acp, codex-acp) the probe describes a binary
+    the sessions never spawn, and refusing on it locked every gated endpoint
+    behind a kiro-cli sign-in the operator had stopped needing; the gate now
+    returns `None` without consulting the service. An unreadable config answers
+    "kiro" so the latch keeps governing — fail closed toward the gate. The two
+    spawn sites do **not** rely on that `None`: each tests the membership itself
+    and never resolves kiro-cli for a foreign harness (`/api/models` answers
+    `model_list_backend_unsupported` 503; `/api/sessions/usage` publishes the
+    `{"available": false}` marker that hides the credit pill), because kiro-cli
+    may still be installed and signed out on that host and the browser storm is
+    what the spawn does whatever backend the sessions use.
+    `test_kiro_spawn_readiness_gate.py::test_gate_applies_exactly_to_the_kiro_identity_store_members`
+    pins the membership over every id in `ACP_BACKENDS_KNOWN`.
+  - **One backend snapshot per request.** The gate takes `backend=` from a
+    caller that already read the configured backend for its own branch
+    (`/api/models`, `/api/sessions/usage`), and reads config itself only when
+    handed none. Two reads are two snapshots: a `PATCH agent.acp_backend`
+    landing between them admits the kiro-cli branch on the first while the gate
+    stands aside on the second — one unauthenticated spawn.
+    `test_api_models_gates_on_its_own_snapshot_not_a_second_read` pins it.
+  - **A caller that continues a live session gates on THAT session's backend.**
+    A live session keeps the backend it was started on (a PATCH refreshes
+    defaults and retires nothing in flight), and plain regenerate continues the
+    slot's session rather than discarding it, so after a switch to Claude Code
+    the rerun still lands on the old kiro-cli.
+    `kiro_readiness.live_session_signs_in_via_kiro_cli` peeks
+    `state.sessions._sessions` (never creates) and reads the provider's own
+    `uses_kiro_identity_store` declaration (H14) — the same membership the gate
+    derives for a configured backend, so the id is never re-derived from a
+    live session; `None` falls back to the configured
+    backend, which is what a fresh session would get. `POST
+    /v1/chat/completions` with an `id` naming a slot that already holds a live
+    session continues it the same way, so that endpoint gates once the slot is
+    known rather than before the body is read; an `id` for a slot with no live
+    session, or no `id` at all, starts fresh on the configured backend.
+    Edit-resend and rewind discard the conversation first, so the configured
+    backend is theirs.
+    `test_chat_regenerate_cov80.py::test_regenerate_gates_on_the_live_sessions_backend_after_a_hot_switch`
+    and `test_openai_compat.py::TestApiCompletionsBlocking::test_gates_on_the_live_sessions_backend_after_a_hot_switch`
+    pin it.
 - **`AcpAuthRequired` is the authoritative logout signal.** Readiness is probed
   at gateway start and on explicit user action only, so a mid-session sign-out is
   discovered when the ACP attempt fails, not by a poll. `AcpRuntime`/`AcpClient`

--- a/docs/system-specs/modules/claude-code-provider.md
+++ b/docs/system-specs/modules/claude-code-provider.md
@@ -66,6 +66,16 @@ which of the two is absent (`COMPONENT_CLAUDE_ACP_ADAPTER`,
 half-install does not read as a total one. A probe that itself fails reads
 `UNKNOWN`, never `MISSING`.
 
+A Claude Code deployment does **not** need kiro-cli installed or signed in. The
+dashboard's kiro-cli readiness guard (`dashboard/kiro_readiness.py`) reads
+`agent.acp_backend` and applies only to members of
+`backends_retired_by_host_logout()`, so regenerate, rewind, edit-resend and
+`/v1/chat/completions` run on this harness with no kiro-cli present;
+`/api/models` answers from the registry (`_cc_models`) and
+`/api/sessions/usage` hides the kiro credit pill without spawning anything. Both
+are spelled out in `modules/acp-client.md` § "Poll-driven spawn sites are
+readiness-gated".
+
 Both operator-facing surfaces read that one verdict:
 
 - `kirocrew doctor` prints Claude Code as an optional backend — present, absent

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1970,6 +1970,17 @@ kiro-cli-authenticated harness; on any other selected backend the guard stands
 aside and the empty-200 case stays open there, which is the smaller defect next
 to a permanent 503 on a working install.
 
+**Decision: no harness-side readiness probe for the foreign harnesses.** On
+claude-agent-acp and codex-acp the destructive reruns run with no pre-flight
+check, and the turn's own ACP attempt is the authority — the same rule an
+ordinary send already follows. A Claude-side or Codex-side probe would have to
+spawn that harness's CLI on a timer to ask whether it is signed in, which is
+the browser-storm shape the kiro-cli gate exists to contain, and neither
+adapter offers a cheaper sign-in query. The cost accepted is that a
+signed-out foreign harness rewrites history on regenerate/rewind before its
+error card lands; revisit only if an adapter grows a side-effect-free
+sign-in check (a credentials-file read, not a spawn).
+
 **An unresolved check is never rendered as "setup required."** The cold probe
 spawns two sandboxed `kiro-cli` subprocesses (`--version`, then `whoami`), which
 takes long enough to read; rendering first-run setup chrome across that window

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1047,7 +1047,18 @@ specified compatibility change.
   edit-resend, rewind) have already rewritten durable history by the time a turn
   could fail; and `POST /v1/chat/completions` has no transcript, so an error card
   would surface as a successful empty completion. A missing or invalid service
-  fails closed in all three.
+  fails closed in all three. **All three apply only while the selected harness
+  signs in through kiro-cli**: the guard reads `agent.acp_backend` first and
+  stands aside — returning `None` without consulting the service — unless the
+  backend is a member of `backends_retired_by_host_logout()`, because the latch
+  describes a kiro-cli sign-in and says nothing about a claude-agent-acp or
+  codex-acp session (see `modules/acp-client.md` § "The latch governs only a
+  harness that signs in through kiro-cli"). "Selected" means the backend the
+  turn will run on: plain regenerate continues the slot's live session, which
+  keeps its backend across a hot switch, so it gates on
+  `live_session_signs_in_via_kiro_cli()` (the provider's own
+  `uses_kiro_identity_store` declaration) and falls back to the configured
+  default only with no session live.
   **These callers authorize on a FRESH probe, not the latch**
   (`kiro_verified_ready` → `KiroPrerequisiteService.verified_ready`, re-probing
   when the latch is older than `_VERIFY_MAX_AGE_SECS` = 30s). The latch is
@@ -1954,7 +1965,10 @@ roles, so the `error` card an `AcpAuthRequired` turn appends is invisible and th
 request would return **HTTP 200 with empty content** — an OpenAI SDK client
 cannot distinguish that from a model that legitimately said nothing. It returns
 the `kiro_prerequisite_required` 503 in OpenAI error shape until the endpoint
-learns to translate `AcpAuthRequired` itself.
+learns to translate `AcpAuthRequired` itself. That 503 exists only for a
+kiro-cli-authenticated harness; on any other selected backend the guard stands
+aside and the empty-200 case stays open there, which is the smaller defect next
+to a permanent 503 on a working install.
 
 **An unresolved check is never rendered as "setup required."** The cold probe
 spawns two sandboxed `kiro-cli` subprocesses (`--version`, then `whoami`), which

--- a/src/kiro_crew/dashboard/chat_regenerate.py
+++ b/src/kiro_crew/dashboard/chat_regenerate.py
@@ -11,7 +11,10 @@ from aiohttp import web
 from kiro_crew.dashboard.chat_persistence import _save_slot_to_history, save_slot_off_loop
 from kiro_crew.dashboard.chat_runner import _run_chat, _start_next_queued_turn
 from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
-from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
+from kiro_crew.dashboard.kiro_readiness import (
+    live_session_signs_in_via_kiro_cli,
+    reject_if_kiro_unverified,
+)
 from kiro_crew.dashboard.remote_relay import remote_bound_refusal
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -41,17 +44,29 @@ _SAVE_DRAIN_ATTEMPTS = 8
 
 async def api_chat_slot_regenerate(request: web.Request) -> web.Response:
     """POST /api/chat/slots/{slot}/regenerate — regenerate the last assistant reply."""
-    # Destructive: this truncates and PERSISTS history before the background
-    # turn runs, so a failed turn cannot undo it. Unlike an ordinary send, the
-    # readiness latch must be honored BEFORE the mutation.
-    blocked = await reject_if_kiro_unverified(request)
-    if blocked is not None:
-        return blocked
     state: DashboardState = request.app["state"]
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+
+    # Destructive: this truncates and PERSISTS history before the background
+    # turn runs, so a failed turn cannot undo it. Unlike an ordinary send, the
+    # readiness latch must be honored BEFORE the mutation. Gated on the backend
+    # the turn will ACTUALLY run on: regenerate continues the slot's live
+    # session (no discard, unlike edit-resend and rewind), and a live session
+    # keeps the backend it was started on across a hot switch of
+    # `agent.acp_backend` -- so after a switch to Claude Code the configured
+    # default says "not kiro" while the rerun still lands on a kiro-cli that may
+    # be signed out. Only with no live session does the default decide.
+    blocked = await reject_if_kiro_unverified(
+        request,
+        signs_in_via_kiro_cli=live_session_signs_in_via_kiro_cli(
+            state, effective_session_key(slot)
+        ),
+    )
+    if blocked is not None:
+        return blocked
 
     # A crew-bound slot has no local regenerate: it would truncate LOCAL history
     # and re-run the turn on this machine, diverging from the peer.

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -25,6 +25,7 @@ from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
 from kiro_crew.acp_backends import (
     ACP_BACKEND_CLAUDE,
     ACP_BACKEND_CODEX,
+    backends_retired_by_host_logout,
     model_registry_namespace,
     selectable_backend_values,
 )
@@ -2156,6 +2157,22 @@ async def api_models(request: web.Request) -> web.Response:
         return web.json_response(_cc_models(request, configured_default=cfg.agent.model))
     if backend == ACP_BACKEND_CODEX:
         return web.json_response(_codex_models(request, configured_default=cfg.agent.model))
+    # The list below comes from `kiro-cli chat --list-models`, so it is only an
+    # answer for a harness that signs in through kiro-cli (positive membership,
+    # harness-parity H5). Any other selected backend is refused BEFORE the binary
+    # is resolved, and deliberately not routed through the readiness gate: that
+    # gate stands aside for a foreign harness, while kiro-cli may still be
+    # installed and signed out on this host, and an unauthenticated spawn opens a
+    # browser window on every 8s poll whatever backend the sessions use.
+    if backend not in backends_retired_by_host_logout():
+        return web.json_response(
+            {
+                "error": "model list is served by kiro-cli; not available on the "
+                "selected agent backend",
+                "code": "model_list_backend_unsupported",
+            },
+            status=503,
+        )
     # Signed-out gateways must never reach the spawn below. kiro-cli auto-opens
     # an interactive browser login for ANY subcommand run unauthenticated
     # (--no-interactive does not suppress it, and there is no opt-out env var),
@@ -2163,8 +2180,11 @@ async def api_models(request: web.Request) -> web.Response:
     # degraded — which is exactly the signed-out state. Ungated, that pairing
     # opened a browser window every 8s indefinitely. The 503 is the same
     # degraded response the timeout/unresolved branches already return, so the
-    # client contract is unchanged; only the subprocess is skipped.
-    blocked = await reject_if_kiro_unverified(request)
+    # client contract is unchanged; only the subprocess is skipped. The gate is
+    # handed the backend read above rather than reading its own: two reads are
+    # two snapshots, and a PATCH landing between them would admit this branch on
+    # the first while the gate stood aside on the second.
+    blocked = await reject_if_kiro_unverified(request, backend=backend)
     if blocked is not None:
         return blocked
     kiro_bin: str | None = None

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -43,7 +43,11 @@ from kiro_crew.dashboard.handlers._shared import (
     guard_owner_surface_routes,
     internal_memory_scope,
 )
-from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
+from kiro_crew.dashboard.kiro_readiness import (
+    backend_signs_in_via_kiro_cli,
+    reject_if_kiro_unverified,
+    selected_backend,
+)
 from kiro_crew.dashboard.session_memory import SessionMemorySampler
 from kiro_crew.dashboard.state import DashboardState, _normalize_slot_key
 from kiro_crew.executors import subprocess_executor
@@ -544,6 +548,25 @@ def _publish_usage(payload: dict[str, object]) -> None:
     _usage_cache_ts = time.time()
 
 
+def _publish_usage_unavailable_without_refresh_stamp() -> None:
+    """Hide the pill for a backend that has no kiro credit plan, WITHOUT a stamp.
+
+    ``_publish_usage`` stamps ``_usage_cache_ts`` with now, which is right for a
+    scrape result: it starts the refresh interval. It is wrong here. A switch back
+    to a kiro identity-store backend inside ``_USAGE_REFRESH_SECS`` would then
+    find a fresh-looking cache and skip the fetch, leaving the pill hidden for up
+    to ten minutes on a harness that does have a plan to show. Leaving the stamp
+    at zero means the first kiro poll after a switch refreshes immediately, and
+    the marker itself is idempotent so a 30s foreign-backend poll rewrites
+    nothing once it is set.
+    """
+    global _usage_cache, _usage_cache_ts
+    if _usage_cache.get("available") is False:
+        return
+    _usage_cache = {"available": False}
+    _usage_cache_ts = 0.0
+
+
 def _cache_transient_failure() -> None:
     """Record a transient usage-fetch failure without blanking the pill.
 
@@ -963,11 +986,24 @@ async def _fetch_usage_bg() -> None:
 
 async def api_sessions_usage(request: web.Request) -> web.Response:
     """GET /api/sessions/usage — cached kiro credit usage (background refresh)."""
+    # The credit plan this scrapes is kiro-cli's, so it exists only for a
+    # harness that signs in through kiro-cli (positive membership, harness-parity
+    # H5). On any other selected backend publish the same unavailable marker
+    # `_fetch_usage_bg` uses for an absent binary -- the pill hides -- WITHOUT
+    # scheduling the fetch: the readiness gate stands aside for a foreign
+    # harness, while kiro-cli may still be installed and signed out here, and the
+    # scrape below opens a browser login on every 30s poll in that state.
+    backend = await selected_backend()
+    if not backend_signs_in_via_kiro_cli(backend):
+        _publish_usage_unavailable_without_refresh_stamp()
+        return web.json_response({"usage": _usage_cache})
     # Same browser-storm guard as api_models: the /usage scrape shells out to
     # `kiro-cli chat --no-interactive ... /usage`, which auto-opens a browser
     # login while signed out. This endpoint is polled every 30s by the top-bar
     # credit pill, so an unauthenticated gateway spawned a browser every 30s.
-    blocked = await reject_if_kiro_unverified(request)
+    # One snapshot: the gate is handed the backend read above, never a second
+    # read a PATCH could land between.
+    blocked = await reject_if_kiro_unverified(request, backend=backend)
     if blocked is not None:
         return blocked
     now = time.time()

--- a/src/kiro_crew/dashboard/kiro_readiness.py
+++ b/src/kiro_crew/dashboard/kiro_readiness.py
@@ -17,15 +17,25 @@ latched value can be arbitrarily stale. That splits the callers in two:
   history by the time the turn fails. See
   ``docs/system-specs/modules/acp-client.md`` § "Poll-driven spawn sites are
   readiness-gated".
+
+Both halves describe a KIRO-CLI sign-in, so both apply only while the selected
+harness authenticates through kiro-cli's identity store
+(:func:`backend_signs_in_via_kiro_cli` over :func:`selected_backend`). On a
+deployment whose
+``agent.acp_backend`` is claude-agent-acp or codex-acp the latch describes a
+binary the sessions never spawn: refusing on it locked every gated endpoint
+behind a kiro-cli sign-in the operator had deliberately stopped needing.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
 from aiohttp import web
 
+from kiro_crew.acp_backends import backends_retired_by_host_logout
 from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
 
 logger = logging.getLogger(__name__)
@@ -61,6 +71,92 @@ _clock = time.monotonic
 # Small enough that an external logout cannot linger behind this gate, large
 # enough that a burst of callers collapses onto one probe.
 _VERIFY_MAX_AGE_SECS = 30.0
+
+
+async def selected_backend() -> str | None:
+    """The configured ``agent.acp_backend``, or ``None`` when config is unreadable.
+
+    Reads the SAME field the provider factory builds a session from (already
+    normalized by ``resolve_selected_backend``), off the loop because
+    ``KiroCrewConfig.load`` stats -- and on a cache miss re-reads --
+    ``config.json``. The import is deferred: this module is imported by every
+    gated handler, and ``kiro_crew.config`` is heavier than anything else it
+    needs.
+
+    Read ONCE per request and passed along. A handler that reads the backend for
+    its own branch and then lets the gate read it again has two snapshots, and a
+    ``PATCH agent.acp_backend`` landing between them lets the kiro-cli branch
+    proceed on the first while the gate stands aside on the second -- one
+    unauthenticated spawn, which is exactly the browser-opening event the gate
+    exists to prevent.
+    """
+
+    from kiro_crew.config import KiroCrewConfig
+
+    try:
+        cfg = await asyncio.to_thread(KiroCrewConfig.load)
+    except Exception:
+        logger.warning(
+            "Could not read agent.acp_backend; keeping the kiro-cli readiness gate",
+            exc_info=True,
+        )
+        return None
+    backend = getattr(getattr(cfg, "agent", None), "acp_backend", "")
+    return backend if isinstance(backend, str) else None
+
+
+def backend_signs_in_via_kiro_cli(backend: str | None) -> bool:
+    """Whether *backend* authenticates through kiro-cli's identity store.
+
+    Answered as POSITIVE membership in ``backends_retired_by_host_logout()``
+    (harness-parity H5/H6): kiro-cli and KAS resolve every access token from that
+    store, so a kiro-cli sign-in verdict is a verdict about their sessions. A
+    harness outside the set (claude-agent-acp, codex-acp) signs in some other way,
+    and the readiness probe -- ``kiro-cli --version`` then ``whoami`` -- says
+    nothing about whether its sessions can run.
+
+    ``None`` (unknown: config unreadable, or a provider that is not an ACP
+    harness) answers ``True``, failing CLOSED toward the gate: the kiro-cli latch
+    keeps governing exactly as it did before this question existed. Guessing
+    "foreign harness" on a broken config would un-gate the browser-opening spawn
+    on the one host where nothing else can be trusted either.
+    """
+
+    if backend is None:
+        return True
+    return backend in backends_retired_by_host_logout()
+
+
+def live_session_signs_in_via_kiro_cli(state: object, session_key: str) -> bool | None:
+    """Whether a LIVE session on *session_key* signs in through kiro-cli, or ``None``.
+
+    A live session keeps the backend it was started on: ``PATCH
+    agent.acp_backend`` refreshes the defaults new sessions are built with and
+    deliberately retires nothing in flight (``handlers/core.py``). So for a
+    caller that CONTINUES an existing session -- regenerate does, it neither
+    discards nor rebuilds -- the configured default is the wrong thing to gate
+    on after a switch: the turn will run on the old harness, and if that is a
+    signed-out kiro-cli the history is rewritten before the auth failure lands.
+
+    The answer is the provider's OWN declaration, ``uses_kiro_identity_store``
+    (harness-parity H14) -- the same membership the gate derives for a
+    configured backend through :func:`backend_signs_in_via_kiro_cli`, read from
+    the one place the session layer already reads it, so the id is never
+    re-derived here. Peeks only, never creates: ``state.sessions._sessions`` is
+    read the way ``chat_runner`` reads it for ``/compact``. Anything that is not
+    a live session carrying a ``bool`` declaration answers ``None`` -- a mocked
+    manager, a key with no session, a provider that declares nothing -- and the
+    caller then falls back to the configured backend, which is what a fresh
+    session would get.
+    """
+
+    sessions = getattr(getattr(state, "sessions", None), "_sessions", None)
+    if not isinstance(sessions, dict):
+        return None
+    declared = getattr(
+        getattr(sessions.get(session_key), "provider", None), "uses_kiro_identity_store", None
+    )
+    return declared if isinstance(declared, bool) else None
 
 
 async def kiro_session_ready(service: object) -> bool:
@@ -215,7 +311,12 @@ def _service(request: web.Request) -> object:
     return service
 
 
-async def reject_if_kiro_unverified(request: web.Request) -> web.Response | None:
+async def reject_if_kiro_unverified(
+    request: web.Request,
+    *,
+    backend: str | None = None,
+    signs_in_via_kiro_cli: bool | None = None,
+) -> web.Response | None:
     """Return 503 for the endpoints that must fail closed on a stale latch.
 
     Two classes qualify, both because the ACP attempt cannot be their authority:
@@ -245,10 +346,41 @@ async def reject_if_kiro_unverified(request: web.Request) -> web.Response | None
     :func:`kiro_verified_ready` — a stale ``ready=True`` is as dangerous as a
     stale ``ready=False`` here (it authorizes the history rewrite or the
     browser-opening spawn), and only these paths pay for the re-probe.
+
+    The latch governs ONLY a harness that signs in through kiro-cli
+    (:func:`backend_signs_in_via_kiro_cli`). *backend* is the harness the caller
+    is about to act on: a caller that already read the configured backend for
+    its own branch passes that same snapshot so one request cannot authorize a
+    spawn on two different configurations, and a caller that continues a live
+    session passes that session's own verdict as *signs_in_via_kiro_cli*
+    (:func:`live_session_signs_in_via_kiro_cli`), which survives a hot switch of
+    the default and outranks *backend*. Left ``None``, the configured backend
+    is read here. For a backend outside the identity-store set this returns
+    ``None`` without consulting the service: the destructive
+    reruns and ``/v1/chat/completions`` then start their turn on that harness,
+    whose own ACP attempt is the authority for its sign-in, exactly as it is for
+    an ordinary send. That leaves the ``/v1/chat/completions`` empty-200 case
+    (an ``AcpAuthRequired`` card its collectors cannot see) open on those
+    harnesses, which is the pre-existing gap the 503 papered over for kiro-cli
+    alone — a permanent 503 on a working Claude Code install was the larger
+    defect. The poll-driven spawn sites do NOT rely on this ``None``: they test
+    the membership themselves and never resolve kiro-cli for a foreign harness,
+    because the binary may still be installed and signed out on that host and the
+    browser storm is what the spawn does, whatever the selected backend.
     """
 
-    if await kiro_verified_ready(_service(request)):
-        _clear_refusal_warning()
-        return None
-    _warn_refused_once(_log_safe_path(request))
-    return web.json_response(_KIRO_NOT_READY_RESPONSE, status=503)
+    if signs_in_via_kiro_cli is None:
+        if backend is None:
+            backend = await selected_backend()
+        signs_in_via_kiro_cli = backend_signs_in_via_kiro_cli(backend)
+    if signs_in_via_kiro_cli:
+        if await kiro_verified_ready(_service(request)):
+            _clear_refusal_warning()
+            return None
+        _warn_refused_once(_log_safe_path(request))
+        return web.json_response(_KIRO_NOT_READY_RESPONSE, status=503)
+    logger.debug(
+        "%s: kiro-cli readiness gate not applicable to the selected backend",
+        _log_safe_path(request),
+    )
+    return None

--- a/src/kiro_crew/dashboard/openai_compat.py
+++ b/src/kiro_crew/dashboard/openai_compat.py
@@ -26,7 +26,11 @@ from kiro_crew import members as members_mod
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.context import _neutralize_structural_markers
 from kiro_crew.dashboard.chat_runner import _run_chat
-from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
+from kiro_crew.dashboard.chat_utils import effective_session_key
+from kiro_crew.dashboard.kiro_readiness import (
+    live_session_signs_in_via_kiro_cli,
+    reject_if_kiro_unverified,
+)
 from kiro_crew.dashboard.state import DashboardState, _normalize_slot_key
 from kiro_crew.dashboard.turn_dispatch import chat_turn_timeout_secs
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -130,24 +134,6 @@ def _redact(text: str) -> str:
 
 async def api_completions(request: web.Request) -> web.StreamResponse:
     """POST /v1/chat/completions — OpenAI-compatible chat endpoint."""
-    # Unlike the dashboard, this endpoint has no transcript the caller reads: the
-    # collectors below pick up only `chunk`/`assistant` roles, so the `error` card
-    # an AcpAuthRequired turn appends is invisible and the request would return
-    # HTTP 200 with empty content — an SDK client cannot tell that apart from a
-    # model that legitimately said nothing. Fail closed until this endpoint
-    # translates AcpAuthRequired into an OpenAI-shaped error.
-    blocked = await reject_if_kiro_unverified(request)
-    if blocked is not None:
-        return web.json_response(
-            {
-                "error": {
-                    "message": "Kiro CLI setup or sign-in is required before starting a session.",
-                    "type": "service_unavailable_error",
-                    "code": "kiro_prerequisite_required",
-                }
-            },
-            status=503,
-        )
     state: DashboardState = request.app["state"]
 
     try:
@@ -265,31 +251,66 @@ async def api_completions(request: web.Request) -> web.StreamResponse:
             {"error": {"message": "invalid id (slot name)", "type": "invalid_request_error"}},
             status=400,
         )
+    # App tokens get ONE uniform answer for the whole member-* space,
+    # BEFORE any existence check -- including the readiness gate's live-session
+    # peek below, which would otherwise answer 503 for a member slot holding a
+    # live kiro session and 404 for one that does not: an app can never own a member slot, so
+    # the reservation 409 for a missing key next to the ownership 404
+    # for an existing one would let an app enumerate member threads.
+    if (
+        slot_id
+        and request.get("app", "")
+        and _normalize_slot_key(slot_id).startswith(members_mod.DM_SLOT_KEY_PREFIX)
+    ):
+        sel().log_api_access(
+            caller=request.get("app", ""),
+            operation="openai_compat.chat",
+            outcome="denied",
+            source="app_isolation",
+            resources=f"slot={slot_id}",
+            error="app cannot access member slots",
+        )
+        return web.json_response(
+            {
+                "error": {"message": "not found", "type": "invalid_request_error"},
+                "code": "not_found",
+            },
+            status=404,
+        )
+    # Unlike the dashboard, this endpoint has no transcript the caller reads: the
+    # collectors below pick up only `chunk`/`assistant` roles, so the `error` card
+    # an AcpAuthRequired turn appends is invisible and the request would return
+    # HTTP 200 with empty content — an SDK client cannot tell that apart from a
+    # model that legitimately said nothing. Fail closed until this endpoint
+    # translates AcpAuthRequired into an OpenAI-shaped error.
+    #
+    # Gated here, once the slot is known, rather than before the body is read:
+    # an `id` naming a slot with a LIVE session continues that session, which
+    # keeps the harness it started on across a PATCH of agent.acp_backend
+    # (the same rule regenerate applies), so the configured default is the wrong
+    # backend to gate on for it. A missing or not-yet-live slot gets a fresh
+    # session on the configured default, which is what a `None` verdict reads.
+    live_slot = state._slots.get(_normalize_slot_key(slot_id)) if slot_id else None
+    live_verdict = (
+        live_session_signs_in_via_kiro_cli(state, effective_session_key(live_slot))
+        if live_slot is not None
+        else None
+    )
+    blocked = await reject_if_kiro_unverified(request, signs_in_via_kiro_cli=live_verdict)
+    if blocked is not None:
+        return web.json_response(
+            {
+                "error": {
+                    "message": "Kiro CLI setup or sign-in is required before starting a session.",
+                    "type": "service_unavailable_error",
+                    "code": "kiro_prerequisite_required",
+                }
+            },
+            status=503,
+        )
     completion_id = _make_id()
 
     if slot_id:
-        # App tokens get ONE uniform answer for the whole member-* space,
-        # BEFORE any existence check: an app can never own a member slot, so
-        # the reservation 409 for a missing key next to the ownership 404
-        # for an existing one would let an app enumerate member threads.
-        if request.get("app", "") and _normalize_slot_key(slot_id).startswith(
-            members_mod.DM_SLOT_KEY_PREFIX
-        ):
-            sel().log_api_access(
-                caller=request.get("app", ""),
-                operation="openai_compat.chat",
-                outcome="denied",
-                source="app_isolation",
-                resources=f"slot={slot_id}",
-                error="app cannot access member slots",
-            )
-            return web.json_response(
-                {
-                    "error": {"message": "not found", "type": "invalid_request_error"},
-                    "code": "not_found",
-                },
-                status=404,
-            )
         # Membership must be checked on the canonical (filename-charset) key —
         # get_or_create_slot folds unsafe chars, so a raw slot_id may map to an
         # existing slot even when the raw string is absent from _slots.

--- a/test/test_chat_regenerate_cov80.py
+++ b/test/test_chat_regenerate_cov80.py
@@ -1791,3 +1791,46 @@ async def test_no_variants_refusal_carries_its_own_code(state) -> None:
         payload = await resp.json()
         assert payload["code"] == "no_variants"
         assert payload["error"] == "no variants"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_gates_on_the_live_sessions_backend_after_a_hot_switch(state) -> None:
+    """A live session keeps its backend across a PATCH of agent.acp_backend.
+
+    Regenerate continues that session rather than discarding it, so with the
+    default switched to Claude Code and the slot still on a signed-out kiro-cli,
+    the configured default would let the truncation through and the auth failure
+    would land only after the history was rewritten.
+    """
+    from types import SimpleNamespace
+
+    from kiro_crew.acp_backends import ACP_BACKEND_CLAUDE
+    from kiro_crew.config import KiroCrewConfig
+    from kiro_crew.dashboard.chat_utils import effective_session_key
+    from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
+
+    class _SignedOut(KiroPrerequisiteService):
+        async def session_ready(self) -> bool:
+            return False
+
+        async def verified_ready(self, *, max_age_secs: float) -> bool:
+            del max_age_secs
+            return False
+
+    slot = state.get_or_create_slot("s1")
+    slot.append("user", "hi")
+    slot.append("assistant", "hello v1")
+    state.kiro_prerequisite_service = object.__new__(_SignedOut)
+    state.sessions._sessions = {
+        effective_session_key(slot): SimpleNamespace(
+            provider=SimpleNamespace(uses_kiro_identity_store=True)
+        )
+    }
+    configured = SimpleNamespace(agent=SimpleNamespace(acp_backend=ACP_BACKEND_CLAUDE))
+    with patch.object(KiroCrewConfig, "load", classmethod(lambda cls: configured)):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/slots/s1/regenerate")
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "kiro_prerequisite_required"
+
+    assert [m["role"] for m in slot.messages] == ["user", "assistant"]

--- a/test/test_kiro_spawn_readiness_gate.py
+++ b/test/test_kiro_spawn_readiness_gate.py
@@ -30,6 +30,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from chat_test_helpers import _make_ready_kiro_prerequisite
 
+from kiro_crew.acp_backends import (
+    ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_KIRO,
+    ACP_BACKEND_OPENCODE,
+    ACP_BACKENDS_KNOWN,
+    backends_retired_by_host_logout,
+)
 from kiro_crew.dashboard import kiro_readiness
 from kiro_crew.dashboard.handlers import agents, sessions
 from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
@@ -451,3 +458,190 @@ async def test_a_ready_gateway_logs_no_refusal() -> None:
             await agents.api_models(request)
 
     warn.assert_not_called()
+
+
+# ── The latch governs only a harness that signs in through kiro-cli ──────────
+#
+# ``reject_if_kiro_unverified`` describes a kiro-cli sign-in. On a deployment
+# whose ``agent.acp_backend`` is claude-agent-acp or codex-acp that latch says
+# nothing about the sessions, and refusing on it locked regenerate, rewind,
+# ``/v1/chat/completions``, ``/api/models`` and ``/api/sessions/usage`` behind
+# a kiro-cli sign-in the operator had deliberately stopped needing. The gate
+# now reads the selected backend as POSITIVE membership in
+# ``backends_retired_by_host_logout()`` (harness-parity H5/H6); the two kiro-cli
+# spawn sites test that membership themselves so a foreign harness never has the
+# browser-opening binary resolved on its behalf either.
+
+
+def _config_selecting(backend: str):
+    """Patch the config read the gate performs so it reports *backend*."""
+
+    from kiro_crew.config import KiroCrewConfig
+
+    cfg = SimpleNamespace(agent=SimpleNamespace(acp_backend=backend, model=""))
+    return patch.object(KiroCrewConfig, "load", classmethod(lambda cls: cfg))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", sorted(ACP_BACKENDS_KNOWN))
+async def test_gate_applies_exactly_to_the_kiro_identity_store_members(backend: str) -> None:
+    """Membership, not identity: every known backend is answered from the set."""
+    request = _request(_make_signed_out_kiro_prerequisite())
+    with _config_selecting(backend):
+        resp = await kiro_readiness.reject_if_kiro_unverified(request)
+
+    if backend in backends_retired_by_host_logout():
+        assert resp is not None and resp.status == 503
+        assert json.loads(resp.body)["code"] == "kiro_prerequisite_required"
+    else:
+        assert resp is None
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_backend_never_consults_the_prerequisite_service() -> None:
+    """Even an ABSENT service (which fails closed for kiro) is not asked."""
+    request = MagicMock()
+    request.app = {}
+    with _config_selecting(ACP_BACKEND_CLAUDE):
+        assert await kiro_readiness.reject_if_kiro_unverified(request) is None
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_config_keeps_the_gate(caplog: pytest.LogCaptureFixture) -> None:
+    """Fail closed toward the latch: a broken config must not un-gate the spawn."""
+    from kiro_crew.config import KiroCrewConfig
+
+    def _boom(cls):
+        raise OSError("config.json unreadable")
+
+    request = _request(_make_signed_out_kiro_prerequisite())
+    with patch.object(KiroCrewConfig, "load", classmethod(_boom)):
+        with caplog.at_level("WARNING", logger=kiro_readiness.logger.name):
+            resp = await kiro_readiness.reject_if_kiro_unverified(request)
+
+    assert resp is not None and resp.status == 503
+    assert any("agent.acp_backend" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_api_models_refuses_a_foreign_backend_before_resolving_kiro_cli() -> None:
+    """A selectable harness with no model list of its own (opencode, at the time of
+    writing) is refused before kiro-cli is resolved: the kiro-cli list is not its
+    answer, and claude and codex each read their adapter's advertised list
+    instead."""
+    request = _request(_make_signed_out_kiro_prerequisite())
+    with _config_selecting(ACP_BACKEND_OPENCODE):
+        with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)) as resolve:
+            with patch("asyncio.create_subprocess_exec", AsyncMock()) as spawn:
+                resp = await agents.api_models(request)
+
+    resolve.assert_not_called()
+    spawn.assert_not_called()
+    assert resp.status == 503
+    assert json.loads(resp.body)["code"] == "model_list_backend_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_api_sessions_usage_hides_the_pill_on_a_foreign_backend_without_a_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A signed-out kiro-cli left on a Claude Code host must not be scraped."""
+    monkeypatch.setattr(sessions, "_usage_cache", {"credits_plan": 10.0})
+    monkeypatch.setattr(sessions, "_usage_cache_ts", 0.0)
+    request = _request(_make_signed_out_kiro_prerequisite())
+    with _config_selecting(ACP_BACKEND_CLAUDE):
+        with patch.object(sessions, "_fetch_usage_bg", AsyncMock()) as fetch:
+            resp = await sessions.api_sessions_usage(request)
+
+    fetch.assert_not_called()
+    assert resp.status == 200
+    assert json.loads(resp.body) == {"usage": {"available": False}}
+
+
+@pytest.mark.asyncio
+async def test_switching_back_to_kiro_refreshes_usage_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The foreign-backend marker must not start a refresh interval.
+
+    ``_publish_usage`` stamps the cache with now; a switch back to a kiro
+    identity-store backend inside ``_USAGE_REFRESH_SECS`` would then find a
+    fresh-looking cache and skip the fetch, hiding the pill for up to ten minutes
+    on a harness that does have a plan to show.
+    """
+    monkeypatch.setattr(sessions, "_usage_cache", {"credits_plan": 10.0})
+    monkeypatch.setattr(sessions, "_usage_cache_ts", 0.0)
+    with patch.object(sessions, "_fetch_usage_bg", AsyncMock()) as fetch:
+        with _config_selecting(ACP_BACKEND_CLAUDE):
+            await sessions.api_sessions_usage(_request(_make_signed_out_kiro_prerequisite()))
+        fetch.assert_not_called()
+        assert sessions._usage_cache == {"available": False}
+
+        with _config_selecting(ACP_BACKEND_KIRO):
+            resp = await sessions.api_sessions_usage(_request(_make_ready_kiro_prerequisite()))
+
+    fetch.assert_called_once()
+    assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_backend_snapshot_is_used_instead_of_a_config_read() -> None:
+    """A caller's snapshot is authoritative: the gate must not read config again."""
+    from kiro_crew.config import KiroCrewConfig
+
+    def _boom(cls):
+        raise AssertionError("the gate re-read config despite being handed a backend")
+
+    request = _request(_make_signed_out_kiro_prerequisite())
+    with patch.object(KiroCrewConfig, "load", classmethod(_boom)):
+        assert (
+            await kiro_readiness.reject_if_kiro_unverified(request, backend=ACP_BACKEND_CLAUDE)
+            is None
+        )
+        resp = await kiro_readiness.reject_if_kiro_unverified(request, backend=ACP_BACKEND_KIRO)
+    assert resp is not None and resp.status == 503
+
+
+@pytest.mark.asyncio
+async def test_api_models_gates_on_its_own_snapshot_not_a_second_read() -> None:
+    """A PATCH landing between the handler's read and the gate's must not admit a spawn.
+
+    The handler read kiro; by the time the gate would read again the default has
+    flipped to a foreign backend. With two reads the gate stands aside and the
+    kiro-cli branch spawns unauthenticated once. With one snapshot it refuses.
+    """
+    request = _request(_make_signed_out_kiro_prerequisite())
+    with _config_selecting(ACP_BACKEND_KIRO):
+        with patch.object(
+            kiro_readiness, "selected_backend", AsyncMock(return_value=ACP_BACKEND_CLAUDE)
+        ):
+            with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)) as resolve:
+                resp = await agents.api_models(request)
+
+    resolve.assert_not_called()
+    assert resp.status == 503
+    assert json.loads(resp.body)["code"] == "kiro_prerequisite_required"
+
+
+def test_live_session_verdict_is_the_providers_own_declaration_and_nothing_else() -> None:
+    live = SimpleNamespace(
+        sessions=SimpleNamespace(
+            _sessions={
+                "k": SimpleNamespace(provider=SimpleNamespace(uses_kiro_identity_store=True)),
+                "f": SimpleNamespace(provider=SimpleNamespace(uses_kiro_identity_store=False)),
+            }
+        )
+    )
+    assert kiro_readiness.live_session_signs_in_via_kiro_cli(live, "k") is True
+    assert kiro_readiness.live_session_signs_in_via_kiro_cli(live, "f") is False
+    assert kiro_readiness.live_session_signs_in_via_kiro_cli(live, "other") is None
+    assert (
+        kiro_readiness.live_session_signs_in_via_kiro_cli(
+            SimpleNamespace(sessions=MagicMock()), "k"
+        )
+        is None
+    )
+    undeclared = SimpleNamespace(
+        sessions=SimpleNamespace(_sessions={"k": SimpleNamespace(provider=SimpleNamespace())})
+    )
+    assert kiro_readiness.live_session_signs_in_via_kiro_cli(undeclared, "k") is None

--- a/test/test_openai_compat.py
+++ b/test/test_openai_compat.py
@@ -174,6 +174,103 @@ class TestApiCompletionsBlocking:
         assert body["error"]["type"] == "service_unavailable_error"
         assert isinstance(body["error"]["message"], str)
 
+    async def test_gates_on_the_live_sessions_backend_after_a_hot_switch(self, tmp_path):
+        """An `id` naming a slot with a live session gates on THAT session's backend.
+
+        The live session keeps the harness it started on across a PATCH of
+        agent.acp_backend, so with the default switched to Claude Code and the
+        slot still on a signed-out kiro-cli, gating on the configured default
+        would answer the empty 200 this endpoint fails closed to prevent.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from kiro_crew.acp_backends import ACP_BACKEND_CLAUDE
+        from kiro_crew.config import KiroCrewConfig
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        slot = _make_slot()
+        state = _make_state(slot)
+        state.sessions = SimpleNamespace(
+            _sessions={
+                effective_session_key(slot): SimpleNamespace(
+                    provider=SimpleNamespace(uses_kiro_identity_store=True)
+                )
+            }
+        )
+        request = _make_request(
+            {
+                "model": "kiro",
+                "messages": [{"role": "user", "content": "hello"}],
+                "id": slot.key,
+            },
+            state,
+        )
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": ""},
+            home=tmp_path,
+            audit_writer=AsyncMock(),
+        )
+        service._has_probed = True
+        request.app["kiro_prerequisite_service"] = service
+        configured = SimpleNamespace(agent=SimpleNamespace(acp_backend=ACP_BACKEND_CLAUDE))
+
+        with patch.object(KiroCrewConfig, "load", classmethod(lambda cls: configured)):
+            response = await api_completions(request)
+
+        assert response.status == 503
+        assert json.loads(response.text)["error"]["code"] == "kiro_prerequisite_required"
+
+    async def test_app_token_member_slot_is_404_before_the_live_session_peek(self, tmp_path):
+        """The readiness gate's live-session peek must not become an existence oracle.
+
+        An app can never own a member slot, so it gets the uniform 404 whether or
+        not that slot holds a live kiro session -- a 503 for a live signed-out one
+        would let an app enumerate member threads through the gate.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from kiro_crew.acp_backends import ACP_BACKEND_CLAUDE
+        from kiro_crew.config import KiroCrewConfig
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        slot = _make_slot()
+        slot.key = "member-alpha"
+        state = _make_state(slot)
+        state.sessions = SimpleNamespace(
+            _sessions={
+                effective_session_key(slot): SimpleNamespace(
+                    provider=SimpleNamespace(uses_kiro_identity_store=True)
+                )
+            }
+        )
+        request = _make_request(
+            {
+                "model": "kiro",
+                "messages": [{"role": "user", "content": "hello"}],
+                "id": slot.key,
+            },
+            state,
+            app="some-app",
+        )
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": ""},
+            home=tmp_path,
+            audit_writer=AsyncMock(),
+        )
+        service._has_probed = True
+        request.app["kiro_prerequisite_service"] = service
+        configured = SimpleNamespace(agent=SimpleNamespace(acp_backend=ACP_BACKEND_CLAUDE))
+
+        with patch.object(KiroCrewConfig, "load", classmethod(lambda cls: configured)):
+            response = await api_completions(request)
+
+        assert response.status == 404
+        assert json.loads(response.text)["code"] == "not_found"
+
     async def test_basic_response(self):
         slot = _make_slot()
         state = _make_state(slot)

--- a/test/test_remote_crew_execution.py
+++ b/test/test_remote_crew_execution.py
@@ -3514,7 +3514,8 @@ class TestBoundSlotRefusesTurnRestartingActions:
 
         # Readiness is orthogonal to this guard; stub it so a 503 latch cannot
         # mask the 409 under test (continue is not readiness-gated).
-        async def _ok(_request):
+        async def _ok(_request, *, backend=None, signs_in_via_kiro_cli=None):
+            del backend, signs_in_via_kiro_cli
             return None
 
         monkeypatch.setattr("kiro_crew.dashboard.chat_regenerate.reject_if_kiro_unverified", _ok)


### PR DESCRIPTION
## Problem / Motivation

`reject_if_kiro_unverified()` refused regenerate, rewind, edit-resend, `/v1/chat/completions`, `/api/models` and `/api/sessions/usage` with the `kiro_prerequisite_required` 503 whenever kiro-cli was absent or signed out, without reading which harness `agent.acp_backend` selects. On a Claude Code or Codex deployment the latch describes a binary the sessions never spawn, so every one of those endpoints was locked behind a kiro-cli sign-in the operator had deliberately stopped needing.

## Why it matters

Anyone running the dashboard on a non-kiro backend without kiro-cli installed cannot regenerate a reply, rewind, edit-and-resend, list models, see usage, or use the OpenAI-compatible chat endpoint. The gate reports a prerequisite that does not apply, and there is no operator action other than installing and signing into a CLI the deployment does not use.

## What changed (motivation → approach → change)

The gate exists to contain the browser-storm shape of repeatedly spawning a signed-out kiro-cli, so it should apply exactly to the backends whose sessions sign in through kiro-cli. It now applies only while the selected backend is a member of `backends_retired_by_host_logout()` (positive membership, harness-parity H5/H6), answered by `backend_signs_in_via_kiro_cli()` over `selected_backend()` in `dashboard/kiro_readiness.py`. An unreadable config keeps the gate, failing closed toward the latch.

The two poll-driven kiro-cli spawn sites test the membership themselves rather than relying on the gate standing aside, because kiro-cli may still be installed and signed out on such a host: `/api/models` answers `model_list_backend_unsupported` and `/api/sessions/usage` publishes the existing unavailable marker that hides the credit pill, neither resolving the binary. A caller that continues a live session gates on that session's own verdict, because a live session keeps the harness it started on across a PATCH of `agent.acp_backend`: `live_session_signs_in_via_kiro_cli()` reads the provider's existing `uses_kiro_identity_store` declaration (H14), the same membership the gate derives for a configured backend, so no backend id is re-derived from a live session and no new ABC surface is added. Plain regenerate does this, and so does `POST /v1/chat/completions` when its `id` names a slot that already holds a live session, which is why that endpoint now gates once the slot is known rather than before the body is read. The app-isolation 404 for member slots stays ahead of that peek, so the gate cannot become an existence oracle over member threads.

The second commit records in the specs why foreign harnesses get no readiness probe of their own: on `claude-agent-acp` and `codex-acp` the destructive reruns rely on the turn's own ACP attempt, as an ordinary send does, because a harness-side probe would have to spawn that CLI on a timer, and neither adapter offers a side-effect-free sign-in query.

## Tests

- `test/test_kiro_spawn_readiness_gate.py` (extended): `test_gate_applies_exactly_to_the_kiro_identity_store_members`, `test_a_foreign_backend_never_consults_the_prerequisite_service`, `test_an_unreadable_config_keeps_the_gate`, `test_api_models_refuses_a_foreign_backend_before_resolving_kiro_cli`, `test_api_sessions_usage_hides_the_pill_on_a_foreign_backend_without_a_spawn`, `test_switching_back_to_kiro_refreshes_usage_immediately`, `test_an_explicit_backend_snapshot_is_used_instead_of_a_config_read`, `test_api_models_gates_on_its_own_snapshot_not_a_second_read`, `test_live_session_verdict_is_the_providers_own_declaration_and_nothing_else`.
- `test/test_chat_regenerate_cov80.py`: `test_regenerate_gates_on_the_live_sessions_backend_after_a_hot_switch` locks in that a live session keeps its backend across a PATCH of `agent.acp_backend`.
- `test/test_openai_compat.py`: `TestApiCompletionsBlocking::test_gates_on_the_live_sessions_backend_after_a_hot_switch` locks in the same rule for the completions endpoint, and `test_app_token_member_slot_is_404_before_the_live_session_peek` pins that an app token gets the uniform 404 before the peek.
- `test/test_remote_crew_execution.py`: updated for the gate's keyword signature.
- 415 tests pass across the five modules.

## Manual verification

N/A beyond the unit coverage: the touched paths are handler-level and the tests drive them with the same config shapes the gateway loads. The branch was not exercised against a live gateway.

## Related Issues

None filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a readiness or prerequisite gate that names one harness's binary must test positive backend membership, never assume the configured backend.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FY8xmPpyfqCbxHPwM2gb9E
