### PR TITLE
fix: repair missing auxiliary agent specs from Check again (#9883)

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -53,7 +53,7 @@ from typing import Any
 
 from kiro_crew import hooks, identity_stores, platform_compat
 from kiro_crew._sqlite_compat import sqlite3
-from kiro_crew.agent_files import AGENT_FILENAME
+from kiro_crew.agent_files import AGENT_FILENAME, LITE_AGENT_FILENAME
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import CRED_KIRO_API_KEY, read_env_file_credential
 from kiro_crew.config.paths import config_dir
@@ -70,6 +70,15 @@ from kiro_crew.sandbox import (
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
+
+# Dashboard-facing text for a spec-repair arm that reported success while the
+# overlay still lists missing specs (the no-op-is-failure rule documented on
+# ``repair_agent_specs``). Shared by the main-rebuild and auxiliary arms so the
+# remediation command cannot drift between them.
+_SPECS_STILL_MISSING_ERROR = (
+    "The repair reported success but the specs are still missing. "
+    "Run `kirocrew setup --agent-only --clean` on the gateway host."
+)
 
 OFFICIAL_INSTALL_DOCS_URL = "https://kiro.dev/cli/"
 # The exact command the user runs to sign in. A CODE CONSTANT, never a catalog
@@ -2205,6 +2214,40 @@ class KiroPrerequisiteService:
         logger.info("Agent specs repaired from the readiness gate")
         return ""
 
+    async def _repair_auxiliary_specs(self, missing: list[str]) -> str:
+        """Write the missing AUXILIARY required specs. Returns failure text, or ``""``.
+
+        The counterpart to :meth:`_repair_agent_specs` for the required specs
+        other than the main one — today only the lite agent spec. Unlike the
+        main-spec rebuild, this write is NOT in the lost-update class that
+        method's docstring gates on: ``_install_lite_agent_fallback`` is an
+        atomic whole-file JSON write, and no ``tools``/``allowedTools`` half is
+        toggle-merged into the lite spec, so there is no concurrent edit to
+        lose — and the spec is only written here when it is absent anyway.
+
+        An auxiliary name this method does not know how to write is deliberately
+        left alone: it stays missing, and the caller's post-repair overlay
+        reports it through the still-missing error text instead of a false
+        success.
+        """
+
+        def _write() -> None:
+            from kiro_crew.agent import _install_lite_agent_fallback  # circular import
+
+            if LITE_AGENT_FILENAME in missing:
+                _install_lite_agent_fallback()
+
+        try:
+            await asyncio.to_thread(_write)
+        except Exception as exc:
+            logger.error(
+                "Auxiliary agent spec repair from the readiness gate failed",
+                exc_info=True,
+            )
+            return _sanitize_detail(f"{type(exc).__name__}: {exc}")
+        logger.info("Auxiliary agent specs repaired from the readiness gate")
+        return ""
+
     async def repair_agent_specs(self, caller: str = "") -> dict[str, Any]:
         """Repair the managed agent specs, then return the post-repair snapshot.
 
@@ -2242,6 +2285,28 @@ class KiroPrerequisiteService:
             # what the card's button offers.
             repairable = AGENT_FILENAME in missing_before
             if not repairable:
+                auxiliary_missing = [
+                    name for name in missing_before if name != AGENT_FILENAME
+                ]
+                error = ""
+                if auxiliary_missing:
+                    # Only auxiliary required specs are missing. The main-spec
+                    # gate above keeps rebuild_agent_config away from a present
+                    # main spec, but the auxiliary specs have their own writers
+                    # with no such lost-update class (see
+                    # _repair_auxiliary_specs), so refusing to write them would
+                    # leave the gate blocking on a file the button never
+                    # writes. Runs even when a spec is REJECTED: acceptance is
+                    # only evaluated for PRESENT specs, so a rejected main spec
+                    # and a missing lite spec can coexist, and writing a MISSING
+                    # file rewrites nothing — the lost-update reasoning behind
+                    # the rejection guard does not apply to it.
+                    error = await self._repair_auxiliary_specs(auxiliary_missing)
+                elif not rejected_before:
+                    # Nothing to repair: a concurrent repair already wrote the
+                    # specs. Report, do not write.
+                    before["agent_spec_repair_error"] = ""
+                    return before
                 if rejected_before:
                     # Not a no-op: acceptance is only re-answerable by the binary,
                     # and the stat-only overlay cannot ask it. force=True because
@@ -2251,14 +2316,15 @@ class KiroPrerequisiteService:
                         await self._probe(force=True)
                     except Exception:  # noqa: BLE001 — stale state beats a 500
                         logger.warning("Re-probe of rejected agent specs failed", exc_info=True)
-                    result = await self._agent_spec_overlay(self._snapshot_dict())
-                    result["agent_spec_repair_error"] = ""
-                    return result
-                # Nothing to repair, only an auxiliary spec is missing (which the
-                # main-spec gate deliberately excludes), or a concurrent repair
-                # already wrote it. Report, do not write.
-                before["agent_spec_repair_error"] = ""
-                return before
+                result = await self._agent_spec_overlay(self._snapshot_dict())
+                if (
+                    not error
+                    and auxiliary_missing
+                    and (result.get("missing_agent_specs") or [])
+                ):
+                    error = _SPECS_STILL_MISSING_ERROR
+                result["agent_spec_repair_error"] = error
+                return result
             error = await self._repair_agent_specs()
             if not error and AGENT_FILENAME in rejected_before:
                 # Acceptance is only re-answerable by the binary, and the overlay
@@ -2272,10 +2338,7 @@ class KiroPrerequisiteService:
                     logger.warning("Re-probe after agent-spec repair failed", exc_info=True)
             result = await self._agent_spec_overlay(self._snapshot_dict())
             if not error and (result.get("missing_agent_specs") or []):
-                error = (
-                    "The rebuild reported success but the specs are still missing. "
-                    "Run `kirocrew setup --agent-only --clean` on the gateway host."
-                )
+                error = _SPECS_STILL_MISSING_ERROR
             result["agent_spec_repair_error"] = error
             return result
 

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -5469,13 +5469,22 @@ class TestRejectedAgentSpecsNarrowReadiness:
         """
         agents = self._spec_dir(tmp_path)
         (agents / "kirocrew.json").write_text("{}", encoding="utf-8")
+        # The lite spec is PRESENT so this stays a pure rejection state; the
+        # mixed rejected-main/missing-lite state has its own repair test in
+        # TestAgentSpecRepair.
+        (agents / "kirocrew-lite.json").write_text("{}", encoding="utf-8")
         rebuilt: list[str] = []
         calls: list[list[str]] = []
 
         async def run(_command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
             calls.append(args)
             if args[:2] == ["agent", "validate"]:
-                return ProcessResult(ok=True, output="x is invalid: bad", returncode=0)
+                # Reject ONLY the main spec: the lite spec is staged present and
+                # accepted, keeping this a pure single-spec rejection state.
+                if Path(args[-1]).name == "kirocrew.json":
+                    return ProcessResult(
+                        ok=True, output="x is invalid: bad", returncode=0
+                    )
             return ProcessResult(ok=True)
 
         service = self._service(tmp_path, run)
@@ -5743,6 +5752,11 @@ class TestAgentSpecRepair:
         step — so rebuilding over an existing spec can drop a concurrent toggle's
         edit and resurrect a server the user just disabled. Gating on the MAIN
         spec's ABSENCE removes that window: with no file there is no edit to lose.
+
+        The missing LITE spec is still repaired — via its own writer, never via
+        the whole-file rebuild. Remove the auxiliary arm from
+        ``repair_agent_specs`` and this test fails: the repair would report
+        success while the overlay keeps listing the lite spec.
         """
         from kiro_crew import agent as agent_module
         from kiro_crew.agent_files import LITE_AGENT_FILENAME
@@ -5754,11 +5768,117 @@ class TestAgentSpecRepair:
             agent_module, "rebuild_agent_config", lambda: calls.append(1)
         )
 
+        def _write_lite() -> None:
+            (agents / LITE_AGENT_FILENAME).write_text(
+                '{"name": "kirocrew-lite"}', encoding="utf-8"
+            )
+
+        monkeypatch.setattr(agent_module, "_install_lite_agent_fallback", _write_lite)
+
         status = await self._service(tmp_path).repair_agent_specs("owner")
 
         assert calls == []
-        assert status["missing_agent_specs"] == [LITE_AGENT_FILENAME]
+        assert (agents / LITE_AGENT_FILENAME).is_file()
+        assert status["missing_agent_specs"] == []
         assert status["agent_spec_repair_error"] == ""
+        assert status["ready"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_main_spec_does_not_block_the_lite_repair(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Rejection and a missing lite spec can coexist; both get their remedy.
+
+        Acceptance is only evaluated for PRESENT specs, so kirocrew.json can be
+        latched REJECTED while kirocrew-lite.json is missing. A rejection branch
+        that returns before the auxiliary arm leaves that mixed state with no
+        error, no write, and a permanently blocked gate. Writing a MISSING file
+        rewrites nothing, so the lost-update reasoning behind the rejection
+        guard does not apply to it.
+        """
+        from kiro_crew import agent as agent_module
+        from kiro_crew.agent_files import LITE_AGENT_FILENAME
+
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        (agents / AGENT_FILENAME).write_text('{"name": "kirocrew"}', encoding="utf-8")
+        service = self._service(tmp_path)
+        service._status.rejected_agent_specs = [AGENT_FILENAME]
+        calls: list[int] = []
+        monkeypatch.setattr(
+            agent_module, "rebuild_agent_config", lambda: calls.append(1)
+        )
+
+        def _write_lite() -> None:
+            (agents / LITE_AGENT_FILENAME).write_text(
+                '{"name": "kirocrew-lite"}', encoding="utf-8"
+            )
+
+        monkeypatch.setattr(agent_module, "_install_lite_agent_fallback", _write_lite)
+
+        status = await service.repair_agent_specs("owner")
+
+        assert calls == []  # the rejected main spec is never regenerated
+        assert (agents / LITE_AGENT_FILENAME).is_file()
+        assert status["missing_agent_specs"] == []
+        assert status["agent_spec_repair_error"] == ""
+
+    @pytest.mark.asyncio
+    async def test_failed_lite_spec_write_reports_a_sanitized_exception(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The auxiliary arm reports its failure the way the main rebuild does.
+
+        Sanitized for the same reason as the main path: the error string is
+        dashboard-facing.
+        """
+        from kiro_crew import agent as agent_module
+
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        (agents / AGENT_FILENAME).write_text('{"name": "kirocrew"}', encoding="utf-8")
+        monkeypatch.setattr(agent_module, "rebuild_agent_config", lambda: None)
+
+        def _boom() -> None:
+            raise PermissionError("agents dir is read-only")
+
+        monkeypatch.setattr(agent_module, "_install_lite_agent_fallback", _boom)
+
+        status = await self._service(tmp_path).repair_agent_specs("owner")
+
+        assert "PermissionError: agents dir is read-only" in (
+            status["agent_spec_repair_error"]
+        )
+        assert status["ready"] is False
+
+    @pytest.mark.asyncio
+    async def test_silent_no_op_lite_write_is_reported_as_a_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A lite write that declines without raising must not read as success.
+
+        Mirrors ``test_silent_no_op_rebuild_is_reported_as_a_failure`` for the
+        auxiliary arm: the post-repair overlay is what turns a silent no-op into
+        a visible error instead of a success report, honoring the docstring's
+        no-op-is-failure rule.
+        """
+        from kiro_crew import agent as agent_module
+
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        (agents / AGENT_FILENAME).write_text('{"name": "kirocrew"}', encoding="utf-8")
+        monkeypatch.setattr(agent_module, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr(
+            agent_module, "_install_lite_agent_fallback", lambda: None
+        )
+
+        status = await self._service(tmp_path).repair_agent_specs("owner")
+
+        assert "still missing" in status["agent_spec_repair_error"]
+        assert status["ready"] is False
 
     @pytest.mark.asyncio
     async def test_concurrent_repairs_rebuild_exactly_once(


### PR DESCRIPTION
## Summary

"Check again" on the Agent specs missing gate never recreated a missing auxiliary spec (`kirocrew-lite.json`) and reported success while the gate stayed blocked forever (#9883).

`KiroPrerequisiteService.repair_agent_specs` gated its only write on the MAIN spec (`kirocrew.json`) being absent. When only an auxiliary required spec was missing it took the "report, do not write" branch and returned `agent_spec_repair_error=""`, while `_agent_spec_overlay` kept listing the lite spec and forcing `ready=False, repair_required=True` — violating the method's own documented no-op-is-failure rule.

## Change

- New `_repair_auxiliary_specs(missing)` helper next to `_repair_agent_specs`: writes the missing lite spec via the existing writer `kiro_crew.agent._install_lite_agent_fallback` under `asyncio.to_thread`, returning sanitized error text on exception, exactly like the main arm. The lite write is outside the lost-update class that gates the main-spec rebuild: it is an atomic whole-file JSON write and no `tools`/`allowedTools` half is toggle-merged into the lite spec.
- Auxiliary arm in `repair_agent_specs`: when the main spec is present but an auxiliary required spec is missing, write it, then re-run the overlay. Still-missing specs (unknown auxiliary name, declined write) now surface through the shared `_SPECS_STILL_MISSING_ERROR` text instead of a silent no-op.
- The arm runs even when a present spec is latched REJECTED: acceptance is only evaluated for present specs, so a rejected main spec and a missing lite spec can coexist, and writing a missing file rewrites nothing (found by pre-push review, both lanes).
- The still-missing error text is lifted to one module constant shared by both arms and reworded from "The rebuild reported success…" to "The repair reported success…" (the auxiliary arm never runs `rebuild_agent_config`).
- The rejected-spec re-probe and the main-spec rebuild behavior are unchanged. No frontend change: `KiroPrerequisiteGate` already renders `agent_spec_repair_error`.

## Tests

- Only the lite spec missing → repair writes it, `missing_agent_specs == []`, `agent_spec_repair_error == ""` (fails with the auxiliary arm removed).
- Rejected main spec + missing lite spec → lite is still written, main spec never regenerated.
- Lite writer raises → non-empty sanitized error text.
- Lite writer declines silently → visible still-missing error.
- Existing pure-rejection test now stages the lite spec so it stays a pure rejection state.

## Verification

- Local static gates green: `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (0 issues, 1458 files), diff-scoped black gate, subprocess-encoding gate, brand gate.
- Tests are run by CI per the owner rule (no local pytest).
- Two pre-push model-pinned review lanes run; all findings addressed (1 Medium: mixed rejected/missing state; 2 Low: error-string dedupe + reword).

Closes #9883


## Pattern harvest

Rule candidate: semgrep / AST lint
Pattern: a repair/rebuild entry point whose success path can decline silently gates its write on ONE spec of a multi-spec required set; the excluded members become unrepairable while the API reports success. Detectable as a guard of the form `X in missing` where `missing` is derived from a REQUIRED_* tuple with more than one member and no arm handles the complement.
