### PR TITLE
fix: stop routing /proc/meminfo through the agent-path gate (#9894)

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -66,7 +66,6 @@ from kiro_crew.hooks import (
     TOOL_DENY,
     fire_tool_hooks,
     identity_grant_covers_child,
-    safe_read_file,
 )
 from kiro_crew.llm_helpers import (
     FALLBACK_CANDIDATE_ATTEMPTS,
@@ -778,20 +777,30 @@ def _timeout_context(
     return " | ".join(parts)
 
 
-def check_memory_available(min_gb: float = 4.0, path: str = "/proc/meminfo") -> tuple[bool, float]:
+def check_memory_available(
+    min_gb: float = 4.0, *, path: str = "/proc/meminfo"
+) -> tuple[bool, float]:
     """Check if enough memory is available to spawn a subagent.
 
-    Reads /proc/meminfo MemAvailable via ``safe_read_file`` (hooks.py)
-    and compares against *min_gb*.
+    Reads /proc/meminfo MemAvailable with a plain ``open`` and compares
+    against *min_gb*. The read deliberately does NOT go through
+    ``hooks.safe_read_file``: that gate polices agent-supplied paths, and
+    this path is a fixed module constant that no caller overrides in
+    production, so the gate adds no protection here — while a gate refusal
+    under load would silently disable spawn back-pressure exactly when it
+    matters (the gate's refusal modes correlate with CPU contention).
+    ``platform_compat._linux_available_mib`` reads the same file the same
+    way. The ``path`` keyword is keyword-only and exists for tests only;
+    production callers always take the constant.
     Returns (ok, available_gb).  On read failure returns (True, -1.0)
     to avoid blocking spawns on non-Linux systems.
     """
     try:
-        text = safe_read_file(path)
-    except PermissionError:
-        logger.warning("Memory check blocked: sensitive path %s", path)
-        return (True, -1.0)
-    except OSError:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except (OSError, UnicodeDecodeError):
+        # UnicodeDecodeError is a ValueError, not an OSError: without it a
+        # mangled read would escape a function whose contract is fail-open.
         return (True, -1.0)
     try:
         for line in text.splitlines():

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         check_memory_available,
         create_agent_folder,
         logger,
+        platform_compat,
         redact_credentials,
         redact_exfiltration_urls,
         sel,
@@ -224,6 +225,39 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 batch_total=max(0, int(batch_total)),
             )
             return self._manager._announce_rejection(info)
+        if avail_gb < 0 and platform_compat.IS_LINUX:
+            # A negative reading means the guard did not run: /proc/meminfo is
+            # unreadable on the one platform where it must exist. Proceeding
+            # is the stated fail-open contract for an unmeasurable host, but
+            # on Linux it must be observable rather than indistinguishable
+            # from a healthy check. macOS/Windows structurally lack
+            # /proc/meminfo, so emitting there would fire on every spawn and
+            # drown the signal.
+            logger.warning(
+                "Subagent memory guard could not run (min %.1f GB); proceeding unchecked",
+                min_mem,
+            )
+            # Context-aware pass so a host with a companion loaded is not
+            # audited with the weaker OSS baseline (the census gate in
+            # test_security_posture.py pins the baseline site count). Imported
+            # here because this function runs rebound on the subagent module's
+            # namespace, where a module-level import in this file is inert
+            # (see _component.bind_component_globals). The slice comes AFTER
+            # redaction: slicing first could split a companion-only credential
+            # at the boundary and persist an unmatched fragment.
+            from kiro_crew.platform.context import redact_log_via_context
+
+            task_note = redact_log_via_context(_redacted_task)[:120]
+            sel().log_tool_invocation(
+                session_key=parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="memory_check_unavailable",
+                metadata={
+                    "min_gb": min_mem,
+                    "task": task_note,
+                },
+            )
 
         # --- Admission gate: refuse NEW spawns while host memory posture is
         # critical. Complements the absolute spawn_min_memory_gb floor above

--- a/test/test_admission_gate.py
+++ b/test/test_admission_gate.py
@@ -299,6 +299,46 @@ class TestSpawnAdmissionGate:
         call_kwargs = mock_sel.return_value.log_tool_invocation.call_args[1]
         assert call_kwargs["outcome"] == "rejected_invalid_cwd"
 
+    def test_unmeasurable_memory_proceeds_but_is_logged(self) -> None:
+        """(True, -1.0) means the guard did not run: spawn proceeds, SEL logs it."""
+        mgr = self._mgr()
+        with patch(
+            "kiro_crew.subagent.check_memory_available", return_value=(True, -1.0)
+        ), patch("kiro_crew.platform_compat.IS_LINUX", True), patch(
+            "kiro_crew.subagent.KiroCrewConfig"
+        ) as mock_cfg, patch(
+            "kiro_crew.subagent.cached_admission_check", return_value=_admitted()
+        ), patch(
+            "kiro_crew.subagent.validate_cwd", return_value=("", "not allowed")
+        ), patch(
+            "kiro_crew.subagent.sel"
+        ) as mock_sel:
+            mock_cfg.load.return_value.agent.spawn_min_memory_gb = 4.0
+            mock_cfg.load.return_value.agent.subagent_cwd_allowed_roots = []
+            mock_sel.return_value.log_tool_invocation = MagicMock()
+
+            info = mgr.spawn(task="test task", parent_session_key="sess-1", cwd="/x")
+
+        # The spawn proceeded past the memory guard (it reached the cwd gate),
+        # so the fail-open contract held...
+        assert info is not None
+        assert info.done is True
+        outcomes = [
+            c[1]["outcome"]
+            for c in mock_sel.return_value.log_tool_invocation.call_args_list
+        ]
+        assert outcomes[-1] == "rejected_invalid_cwd"
+        # ...and the guard-did-not-run case was made observable.
+        assert "memory_check_unavailable" in outcomes
+        unavailable = next(
+            c[1]
+            for c in mock_sel.return_value.log_tool_invocation.call_args_list
+            if c[1]["outcome"] == "memory_check_unavailable"
+        )
+        assert unavailable["tool_name"] == "spawn_run"
+        assert unavailable["metadata"]["min_gb"] == 4.0
+        assert unavailable["metadata"]["task"] == "test task"
+
 
 # ── config key ───────────────────────────────────────────────────────────────
 

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -1511,16 +1511,38 @@ class TestCheckMemoryAvailable:
         ok, _ = check_memory_available(min_gb=4.0, path=str(f))
         assert ok is True
 
-    def test_sensitive_path_rejected(self, tmp_path):
-        """Returns (True, -1.0) for sensitive paths — fails open."""
+    def test_does_not_route_through_path_gate(self, tmp_path):
+        """The constant kernel path bypasses the agent-path gate.
+
+        A gate refusal under load must not silently disable spawn
+        back-pressure, so the read is a plain ``open``. A function-local
+        re-route through either gate helper makes this test fail loudly.
+        """
         from unittest.mock import patch
 
         from kiro_crew.subagent import check_memory_available
 
         f = tmp_path / "meminfo"
         f.write_text("MemAvailable:    8388608 kB\n")
-        with patch("kiro_crew.subagent.safe_read_file", side_effect=PermissionError("blocked")):
-            ok, avail = check_memory_available(path=str(f))
+        with patch(
+            "kiro_crew.hooks.safe_read_file",
+            side_effect=AssertionError("gate must not be consulted"),
+        ), patch(
+            "kiro_crew.hooks.is_sensitive_path",
+            side_effect=AssertionError("gate must not be consulted"),
+        ):
+            ok, avail = check_memory_available(min_gb=4.0, path=str(f))
+        assert ok is True
+        assert avail == 8.0
+
+    def test_permission_error_fails_open(self, tmp_path):
+        """A real EACCES from open() is an OSError and fails open (True, -1.0)."""
+        from unittest.mock import patch
+
+        from kiro_crew.subagent import check_memory_available
+
+        with patch("builtins.open", side_effect=PermissionError("denied")):
+            ok, avail = check_memory_available(path="/proc/meminfo")
         assert ok is True
         assert avail == -1.0
 

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -322,34 +322,46 @@ class TestDigestHoldSecs:
 
 
 class TestCheckMemoryAvailable:
-    def test_parses_mem_available(self) -> None:
-        text = "MemTotal:       1000 kB\nMemAvailable:    8388608 kB\n"
-        with patch.object(sa, "safe_read_file", return_value=text):
-            ok, gb = sa.check_memory_available(min_gb=4.0)
+    def test_parses_mem_available(self, tmp_path: Path) -> None:
+        f = tmp_path / "meminfo"
+        f.write_text("MemTotal:       1000 kB\nMemAvailable:    8388608 kB\n")
+        ok, gb = sa.check_memory_available(min_gb=4.0, path=str(f))
         assert ok is True
         assert gb == 8.0
 
-    def test_below_threshold_reports_not_ok(self) -> None:
-        text = "MemAvailable:    1048576 kB\n"
-        with patch.object(sa, "safe_read_file", return_value=text):
-            ok, gb = sa.check_memory_available(min_gb=4.0)
+    def test_below_threshold_reports_not_ok(self, tmp_path: Path) -> None:
+        f = tmp_path / "meminfo"
+        f.write_text("MemAvailable:    1048576 kB\n")
+        ok, gb = sa.check_memory_available(min_gb=4.0, path=str(f))
         assert (ok, gb) == (False, 1.0)
 
-    def test_sensitive_path_fails_open(self) -> None:
-        with patch.object(sa, "safe_read_file", side_effect=PermissionError):
+    def test_path_gate_not_consulted(self, tmp_path: Path) -> None:
+        """The fixed kernel path is read with plain open, never the gate."""
+        f = tmp_path / "meminfo"
+        f.write_text("MemAvailable:    8388608 kB\n")
+        with (
+            patch("kiro_crew.hooks.safe_read_file", side_effect=AssertionError),
+            patch("kiro_crew.hooks.is_sensitive_path", side_effect=AssertionError),
+        ):
+            assert sa.check_memory_available(min_gb=4.0, path=str(f)) == (True, 8.0)
+
+    def test_permission_error_fails_open(self) -> None:
+        with patch("builtins.open", side_effect=PermissionError):
             assert sa.check_memory_available() == (True, -1.0)
 
     def test_read_error_fails_open(self) -> None:
-        with patch.object(sa, "safe_read_file", side_effect=OSError):
+        with patch("builtins.open", side_effect=OSError):
             assert sa.check_memory_available() == (True, -1.0)
 
-    def test_malformed_line_fails_open(self) -> None:
-        with patch.object(sa, "safe_read_file", return_value="MemAvailable:  notanumber kB\n"):
-            assert sa.check_memory_available() == (True, -1.0)
+    def test_malformed_line_fails_open(self, tmp_path: Path) -> None:
+        f = tmp_path / "meminfo"
+        f.write_text("MemAvailable:  notanumber kB\n")
+        assert sa.check_memory_available(path=str(f)) == (True, -1.0)
 
-    def test_missing_key_fails_open(self) -> None:
-        with patch.object(sa, "safe_read_file", return_value="MemTotal: 12 kB\n"):
-            assert sa.check_memory_available() == (True, -1.0)
+    def test_missing_key_fails_open(self, tmp_path: Path) -> None:
+        f = tmp_path / "meminfo"
+        f.write_text("MemTotal: 12 kB\n")
+        assert sa.check_memory_available(path=str(f)) == (True, -1.0)
 
 
 class TestReadIntFile:


### PR DESCRIPTION
## Summary

Fixes the subagent admission memory guard failing open when the sensitive-path gate refuses `/proc/meminfo` (#9894).

`check_memory_available` read the fixed kernel path through `safe_read_file` (hooks.py), the gate meant for agent-supplied paths. When that gate failed closed under load (path-resolution stall / per-prefix cooldown — the #9482 class), the function swallowed the `PermissionError` and returned `(True, -1.0)`, the same `ok=True` a healthy check returns — so spawn back-pressure was silently disabled exactly when CPU contention made it matter.

## Changes

- **`src/kiro_crew/subagent.py`** — `check_memory_available` reads the path with a plain `open(path, encoding="utf-8")`, matching `platform_compat._linux_available_mib` which reads the same file the same way. The path is a module constant no production caller overrides (`admission.py` and `_available_memory_gb` both call with `min_gb` only), so the gate added no protection here; the `path` kwarg is keyword-only and documented as tests-only. A genuine EACCES is an `OSError` and keeps the `(True, -1.0)` fail-open contract; `UnicodeDecodeError` is caught too so a mangled read cannot escape a fail-open function. The docstring states why the gate is deliberately bypassed so a future reviewer does not re-route it.
- **`src/kiro_crew/subagent_manager/admission.py`** — the guard-did-not-run case is observable: when `avail_gb < 0` on Linux (the one platform where `/proc/meminfo` must exist), the admission path emits one `logger.warning` and an SEL `log_tool_invocation` with outcome `memory_check_unavailable` (mirroring the adjacent `refused_low_memory` shape), and the spawn still proceeds — fail-open for an unmeasurable host stays a stated, logged choice. macOS/Windows structurally lack the file, so emitting there would fire on every spawn and drown the signal.
- **Tests** — gate-seam patches move to `builtins.open` patches / tmp files via the `path` kwarg. New tests: the gate helpers (`hooks.safe_read_file` / `hooks.is_sensitive_path`) are never consulted; a `PermissionError` from `open` still yields `(True, -1.0)`; the admission path proceeds past the guard AND logs `memory_check_unavailable` (in `test_admission_gate.py`, following the `refused_low_memory` pattern, with `IS_LINUX` pinned so Windows shards pass).

## Verification

- Local static gates green: `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (1458 files), diff-scoped black gate (touched non-baselined files clean).
- Pre-push review: Opus lane PASS with 0 blocking findings; its three advisory findings (per-spawn SEL noise on macOS/Windows, `path` kwarg not structurally tests-only, `UnicodeDecodeError` escaping the fail-open contract) are all addressed. GPT lane spawned without file-read tools twice (known model-pin issue) and gave a summary-only PASS; the server-side GPT review lane on this PR is the authoritative gate.
- Test suites run in CI (repo policy: no local test runs).

No frontend changes.

## Pattern harvest

Rule candidate: a health/telemetry probe of a fixed kernel or platform path must not route through the agent-path security gate — the gate's failure modes (resolution stall, per-prefix cooldown) correlate with exactly the load conditions the probe exists to detect, and a gate refusal then reads as a healthy fail-open. Read fixed module-constant paths directly and reserve the gate for agent- or user-influenced paths; when a guard must fail open, emit a distinct observable outcome so "guard did not run" is never indistinguishable from "guard passed".

Closes #9894
