### PR TITLE
ci: spike -- Backend Tests shard 1 on the CodeBuild runner as an unprivileged user

### DIFF
--- a/.github/actions/run-as-runner/action.yml
+++ b/.github/actions/run-as-runner/action.yml
@@ -1,0 +1,91 @@
+name: Run steps as an unprivileged user
+description: >-
+  Gives a job the same user model on every Linux runner. GitHub-hosted runners
+  execute a job as the unprivileged `runner` user (uid 1001); the
+  CodeBuild-hosted runner executes it as root, and this repository's backend
+  suite asserts permission semantics root does not have (read-only refusals,
+  root-owned-ancestor checks, PermissionError) and refuses to run providers as
+  root at all. On a root runner this action creates `runner`, hands it the
+  workspace and the job temp dir, aligns the toolchain with the hosted image
+  (jq 1.7, gh, a resolvable libpython for the setup-python toolcache), and
+  installs `/usr/local/bin/ci-shell`: a `shell:` program that runs a step's
+  script as `runner` with the environment preserved. On a GitHub-hosted runner
+  ci-shell is a plain bash passthrough, so a step declaring
+  `shell: /usr/local/bin/ci-shell {0}` behaves identically on both.
+
+  Use it AFTER checkout and the setup-* actions (they install as root, which is
+  fine) and BEFORE any step whose behaviour depends on not being root. Steps
+  that write $GITHUB_OUTPUT / $GITHUB_ENV should keep the default shell: those
+  files are owned by the runner process.
+runs:
+  using: composite
+  steps:
+    - name: Provision the unprivileged user and ci-shell
+      shell: bash
+      env:
+        JQ_VERSION: "1.7.1"
+        JQ_SHA256: "5942c9b0934e510ee61eb3e30273f1b3fe2590df93933a93d7c58b81d19c8ff5"
+        GH_VERSION: "2.100.0"
+        GH_SHA256: "e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be"
+      run: |
+        set -euo pipefail
+        if [ "$(id -u)" != "0" ]; then
+          # GitHub-hosted (or any non-root) runner: passthrough shell, nothing else.
+          sudo install -m 755 /dev/stdin /usr/local/bin/ci-shell <<'EOF'
+        #!/bin/bash
+        # ci-shell (passthrough): this runner already executes jobs unprivileged.
+        exec bash --noprofile --norc -eo pipefail "$1"
+        EOF
+          echo "ci-shell: non-root runner ($(id -un), uid $(id -u)) -- passthrough installed."
+          exit 0
+        fi
+
+        echo "ci-shell: root runner -- provisioning 'runner' (uid 1001 if free)."
+        if ! id runner >/dev/null 2>&1; then
+          if getent passwd 1001 >/dev/null; then
+            useradd -m -s /bin/bash runner
+          else
+            useradd -m -u 1001 -s /bin/bash runner
+          fi
+        fi
+        # The checkout and the setup-* actions ran as root; the tests need to own
+        # what they write into (workspace, job temp). The tool cache stays
+        # root-owned 0755 -- readable is enough, pip --system already populated it.
+        chown -R runner: "$GITHUB_WORKSPACE" "$RUNNER_TEMP"
+
+        # setup-python's downloaded toolcache builds link libpython dynamically and
+        # rely on LD_LIBRARY_PATH, which this job's tests deliberately strip when
+        # they spawn a sanitized subprocess (observed: `python: error while loading
+        # shared libraries: libpython3.12.so.1.0`, rc 127). Register the lib dirs
+        # with the dynamic linker so the binary resolves without the variable, as
+        # the hosted image's system python does.
+        if compgen -G "$RUNNER_TOOL_CACHE/Python/*/x64/lib" >/dev/null; then
+          ls -d "$RUNNER_TOOL_CACHE"/Python/*/x64/lib > /etc/ld.so.conf.d/zz-actions-python-toolcache.conf
+          ldconfig
+        fi
+
+        # Toolchain parity with ubuntu-latest: jq 1.7 (standard:7.0 ships 1.6,
+        # which rejects syntax the repo's jq programs use) and gh.
+        if ! jq --version 2>/dev/null | grep -q "jq-1\.7"; then
+          curl -fsSL -o /tmp/jq "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
+          echo "${JQ_SHA256}  /tmp/jq" | sha256sum -c -
+          install -m 755 /tmp/jq /usr/local/bin/jq && rm -f /tmp/jq
+        fi
+        if ! command -v gh >/dev/null 2>&1; then
+          curl -fsSL -o /tmp/gh.tgz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz"
+          echo "${GH_SHA256}  /tmp/gh.tgz" | sha256sum -c -
+          tar -xzf /tmp/gh.tgz -C /tmp && install -m 755 "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+          rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_amd64"
+        fi
+
+        # The shell program. `runuser -m` keeps the step's environment (PATH with
+        # the setup-* tool dirs, GITHUB_*, RUNNER_*); HOME/USER/LOGNAME are set
+        # explicitly because -m suppresses runuser's own defaults for them.
+        install -m 755 /dev/stdin /usr/local/bin/ci-shell <<'EOF'
+        #!/bin/bash
+        # ci-shell: run the step script as the unprivileged `runner` user.
+        exec runuser -m -u runner -- env HOME=/home/runner USER=runner LOGNAME=runner \
+          bash --noprofile --norc -eo pipefail "$1"
+        EOF
+        echo "ci-shell: installed. jq $(jq --version), gh $(gh --version | head -1)."
+        runuser -m -u runner -- env HOME=/home/runner id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,14 +520,18 @@ jobs:
   backend-test:
     name: Backend Tests
     needs: [changes, await-fast-gate]
-    # NOT on the CodeBuild-hosted runner (yet). The pilot's first run routed
-    # these shards there and every shard failed 37-42 tests: the CodeBuild runner
-    # executes the job as root, and this suite asserts permission semantics
-    # (read-only refusals, root-owned checks, PermissionError) that root does not
-    # have; the standard:7.0 image also lacks the hosted toolchain (jq 1.7). They
-    # move once a non-root custom image exists -- see docs/ci/ci-and-reviews.md,
-    # "CodeBuild-hosted runner (pilot)".
-    runs-on: ubuntu-latest
+    # CodeBuild-hosted runner pilot, wave 3 SPIKE: shard 1 only. The pilot's
+    # first attempt routed all four shards and every one failed 37-42 tests,
+    # because the CodeBuild runner executes the job as root and this suite
+    # asserts permission semantics root does not have (read-only refusals,
+    # root-owned checks, PermissionError; the code refuses to run providers as
+    # root at all), and because standard:7.0 ships jq 1.6 and a toolcache
+    # python whose libpython needs LD_LIBRARY_PATH. The `run-as-runner` action
+    # below closes all of that inside the job (an unprivileged `runner` user,
+    # jq/gh/ldconfig), and the test steps run through its ci-shell. Shards 2-4
+    # stay hosted until shard 1 is green here; then all four move. See
+    # docs/ci/ci-and-reviews.md, "CodeBuild-hosted runner (pilot)".
+    runs-on: ${{ matrix.group == 1 && needs.changes.outputs.linux_runner_large || 'ubuntu-latest' }}
     # The slowest 3.12 shard runs 34 to 36 minutes on a hosted runner, and the
     # per-shard time swings by several minutes run to run (a 28-minute shard
     # reached 99% at 40 on the next run of the same tree). A cap that a green
@@ -571,6 +575,27 @@ jobs:
 
       - name: Install dependencies
         run: uv pip install --system -e ".[voice,desktop]" --group dev
+
+      # Same user model on every runner: on a root runner (CodeBuild) create the
+      # unprivileged `runner` user and hand it the workspace; everywhere install
+      # /usr/local/bin/ci-shell, which the test steps below declare as their
+      # shell. On ubuntu-latest it is a bash passthrough. Must come after the
+      # setup-* actions (they install as root, harmlessly) and before anything
+      # whose result depends on not being root.
+      - uses: ./.github/actions/run-as-runner
+
+      - name: Runner identity (spike diagnostics, CodeBuild only)
+        if: runner.environment == 'self-hosted'
+        shell: /usr/local/bin/ci-shell {0}
+        run: |
+          echo "runner.environment=self-hosted  name=$RUNNER_NAME"
+          echo "step user: $(id)"
+          echo "HOME=$HOME  USER=$USER"
+          echo "python: $(command -v python) -> $(python -c 'import sys; print(sys.version.split()[0])')"
+          python -c 'import os,sys; print("libpython resolves without LD_LIBRARY_PATH:", os.system("env -u LD_LIBRARY_PATH " + sys.executable + " -c pass") == 0)'
+          echo "jq $(jq --version)  gh $(gh --version | head -1)  git $(git --version)"
+          echo "workspace owner: $(stat -c %U "$GITHUB_WORKSPACE")  temp owner: $(stat -c %U "$RUNNER_TEMP")"
+          echo "unshare NEWNS (sandbox availability): $(unshare --mount --map-root-user true 2>&1 && echo ok || echo unavailable)"
 
       - name: Select test scope
         id: scope
@@ -632,6 +657,9 @@ jobs:
           LEAF_REPEAT: "3"
           LEAF_GATES: ${{ needs.changes.outputs.leaf_gates }}
           TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
+        # ci-shell: as the unprivileged `runner` user on a root runner, plain bash
+        # on ubuntu-latest (see the run-as-runner step).
+        shell: /usr/local/bin/ci-shell {0}
         run: |
           # Take the `python` problem matcher registered by actions/setup-python
           # out of scope before pytest writes a line. Its pattern is a traceback
@@ -713,6 +741,7 @@ jobs:
         # Fold any xdist parallel data files into a single .coverage (no-op if
         # pytest-cov already combined this shard), then name it per-shard so the
         # combine job can merge all shards with `coverage combine`.
+        shell: /usr/local/bin/ci-shell {0}
         run: |
           coverage combine 2>/dev/null || true
           test -f .coverage || { echo "::error::shard ${{ matrix.group }} produced no coverage data"; exit 1; }


### PR DESCRIPTION
## Summary

**Spike, not the migration.** Routes exactly one backend shard — `Backend Tests (3.12, 1)` — to the CodeBuild-hosted runner (`matrix.group == 1`), running the test steps as an unprivileged user through a new composite action. Shards 2–4 stay on `ubuntu-latest` and exercise the passthrough path of the same action, so the diff is a single set of steps for both runners. If shard 1 is green here, a follow-up PR moves all four; if it is not, the remaining failures tell us what a custom runner image would have to carry.

## Why

The pilot's first attempt to route the backend shards (#10328, revision 1) failed 37–42 tests per shard. Causes, all environment, none code:

1. **The CodeBuild runner executes the job as root.** GitHub-hosted runners use `runner` (uid 1001). The suite asserts permission semantics root does not have — `test_app_scaffold.py::TestWriteContainment::test_a_read_only_file_site_is_refused` (write through 0o444 → `DID NOT RAISE`), `test_governance_distribution.py::…agent_writable…` (root owns every chain), `test_computer_use_enable_state.py::…test_unreadable_file_is_disabled` (root reads chmod 000) — and `github_runner.validate_provider_executable` refuses root outright ("provider execution is disabled for a root gateway"), which takes `test_github_runner.py::TestResolveGh::*`, `test_issue_radar_gh_bin.py::*` and `test_source_providers.py::…strict_mode…` with it.
2. **jq 1.6** on `standard:7.0` vs 1.7 on the hosted image — `test_issue_triage_workflow.py` (7 tests) uses 1.7 syntax.
3. **libpython not resolvable without `LD_LIBRARY_PATH`.** setup-python's downloaded toolcache build links libpython dynamically; the tests that spawn a sanitized subprocess (`test_dev_fleet_backend_only_sync_skip.py`, 5 tests) got `python: error while loading shared libraries: libpython3.12.so.1.0` (rc 127).

AWS documents no non-root mode for the CodeBuild GitHub Actions runner, so this closes the gap inside the job instead of with a custom image.

## What changed

- `.github/actions/run-as-runner/action.yml` (new composite action). On a root runner: `useradd -m -u 1001 runner`, `chown -R runner: $GITHUB_WORKSPACE $RUNNER_TEMP`, register `$RUNNER_TOOL_CACHE/Python/*/x64/lib` with `ldconfig`, install jq 1.7.1 and gh 2.100.0 (sha256-pinned release binaries), and install `/usr/local/bin/ci-shell` = `runuser -m -u runner -- env HOME=/home/runner USER=runner LOGNAME=runner bash -eo pipefail "$1"`. On a non-root runner: install ci-shell as a bash passthrough and stop. Everything before it (checkout, setup-python, setup-uv, `uv pip install --system`) still runs as whatever user the runner is — that is fine, the tool cache only needs to be readable.
- `ci.yml` / `backend-test`: `runs-on` is `matrix.group == 1 && needs.changes.outputs.linux_runner_large || 'ubuntu-latest'`; the `Run tests` and `Stage shard coverage data` steps declare `shell: /usr/local/bin/ci-shell {0}`; a diagnostics step (CodeBuild only, `runner.environment == 'self-hosted'`) prints the effective user, libpython resolution, jq/gh/git versions, workspace ownership, and whether `unshare NEWNS` works in the container (answers the e2e/sandbox question for the inventory too). `Select test scope` keeps the default shell because it writes `$GITHUB_OUTPUT`.

Not in this PR: docs (the pilot entry still says backend stays hosted — true until the follow-up), the other three shards.

## How it was verified

Static only, per repo convention: YAML parses, `bash -n` on the action's script, brand gate clean against `origin/main`. The CI run on this PR is the experiment; result goes in a comment.

## Rollback

Delete the `runs-on` expression back to `ubuntu-latest`; ci-shell is a passthrough there, so the action and the `shell:` lines are inert.

## UX CONCERNS

none (CI-only)
