### PR TITLE
fix(apps): let a sandboxed app backend mint its local token

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -71,10 +71,15 @@ private members exist. A private process, corrupt binding or unverifiable peer
 receives `403 member_owner_token_refused`; an actual unowned host app/CLI can
 still bootstrap the owner. Possession of `.local_secret` alone cannot promote
 a private agent into dashboard owner authority. A published V1 runtime only
-authorizes its Global V1 operations; owner bootstrap still requires host OS
-provenance. A sandboxed macOS app without a trusted runtime record cannot use
-this local-secret endpoint; use the host login-link CLI. An unavailable Seatbelt
-query likewise fails closed.
+authorizes its Global V1 operations. Owner bootstrap requires host OS provenance
+OR a caller the gateway's own app-backend registry vouches for: a backend this
+gateway spawned, or one of its descendants, matched only while the gateway still
+holds an unreaped process handle for that root. An adopted backend holds no such
+handle and is refused. That second leg reaches no private member, because the
+protected-binding check runs ahead of it and refuses a bound caller outright.
+A sandboxed macOS app this gateway did not spawn, carrying no trusted runtime
+record, cannot use this local-secret endpoint; use the host login-link CLI. An
+unavailable Seatbelt query likewise fails closed.
 Run the login-link CLI on the same host as the gateway so its process can be
 attributed. For a WSL gateway, mint the link from WSL; a Windows-side client
 cannot supply Linux kernel process identity. The resulting owner login link
@@ -182,7 +187,8 @@ helper checks the peer's process incarnation before and after querying the
 kernel. A denied or unknown result grants no Global authority. This preserves
 ordinary sandboxed V1 callers while refusing private descendants that encounter
 a Global ancestor's binding. Private bindings keep their existing protected
-identity checks; owner bootstrap still requires an unsandboxed process.
+identity checks; owner bootstrap requires an unsandboxed process or a backend the
+gateway's app-backend registry vouches for.
 
 Private members also hide the crew home's `snapshots` and `sessions` directories:
 snapshots can contain Global memory, and transcripts can contain other members'

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -2648,6 +2648,34 @@ def spawned_backend_names() -> list[str]:
         return sorted(name for name, ap in _processes.items() if ap.proc is not None)
 
 
+def spawned_backend_owns_pid(pid: int) -> bool:
+    """Whether a backend THIS gateway spawned owns *pid*.
+
+    Owning means *pid* is the spawned root or descends from it, because
+    ``wrap_argv`` places a sandbox launcher between us and the real server —
+    the same ownership shape :func:`_spawn_owns_listener` reads off a listener.
+
+    Only a record holding a LIVE ``Popen`` answers, and that is the whole
+    security value: an unreaped child's pid cannot be recycled by the kernel, so
+    a root that answers here is a process this gateway started and still owns.
+    ``poll() is None`` is what carries that, not ``proc is not None`` on its own —
+    once a child exits and is reaped its pid is free for anyone. An ADOPTED
+    backend belongs to another supervisor and carries no handle at all (see
+    :func:`spawned_backend_names`), so it is refused rather than trusted on a pid
+    this gateway cannot vouch for.
+
+    The ancestry walk runs OUTSIDE ``_lock``: it reads ``/proc`` per candidate,
+    and the snapshot taken under the lock is all the registry state it needs.
+    """
+    with _lock:
+        roots = [
+            ap.pid
+            for ap in _processes.values()
+            if ap.proc is not None and ap.pid > 0 and ap.proc.poll() is None
+        ]
+    return any(_pid_is_self_or_descendant_of(pid, root) for root in roots)
+
+
 def get_app_backend_port(app_name: str) -> int | None:
     """Get the port for a running app backend (used by reverse proxy)."""
     with _lock:

--- a/src/kiro_crew/member_memory_auth.py
+++ b/src/kiro_crew/member_memory_auth.py
@@ -806,6 +806,30 @@ def private_memory_boundaries_active() -> bool:
         return True
 
 
+def _gateway_spawned_app_backend(pid: int) -> bool:
+    """Positive host provenance for an app backend this gateway spawned.
+
+    ``_verified_host_process`` reads provenance off namespace identity, which an
+    app backend cannot satisfy: ``apps.backend`` launches every one of them
+    through ``wrap_argv``, so a healthy backend sits in its own mount/user
+    namespace and compares unequal to the gateway. Namespace identity is the
+    wrong question to ask about a process the gateway itself started, and asking
+    it alone refuses every app backend on any host holding one V2 store.
+
+    The registry read here is not weaker evidence than the comparison it stands
+    in for. It is in-process gateway state no app can write, and only a record
+    whose ``Popen`` is still unreaped answers, which is what keeps the root pid
+    immune to reuse. It widens neither of the other two legs: a caller carrying a
+    private-member binding stays refused by ``protected_member_session_for_pid``,
+    so this cannot promote a private member into the owner.
+    """
+    try:
+        from kiro_crew.apps.backend import spawned_backend_owns_pid
+    except Exception:
+        return False
+    return spawned_backend_owns_pid(pid)
+
+
 def local_owner_bootstrap_allowed(request: Any) -> bool:
     """The shared local secret cannot promote a private member into the owner."""
     try:
@@ -816,7 +840,7 @@ def local_owner_bootstrap_allowed(request: Any) -> bool:
             isinstance(pid, int)
             and platform_compat.get_process_start_id(pid)
             and protected_member_session_for_pid(pid) is None
-            and _verified_host_process(pid)
+            and (_verified_host_process(pid) or _gateway_spawned_app_backend(pid))
         )
     except Exception:
         return False

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -410,6 +410,76 @@ class TestPidAncestry:
         assert bmod._spawn_owns_listener(9100, 43) is False
 
 
+class TestSpawnedBackendOwnsPid:
+    """Only a LIVE child of this gateway may be attributed to an app."""
+
+    @staticmethod
+    def _live(pid: int, name: str = "app") -> AppProcess:
+        return AppProcess(
+            app_name=name,
+            pid=pid,
+            proc=SimpleNamespace(poll=lambda: None),  # type: ignore[arg-type]
+        )
+
+    def test_the_spawn_root_itself_is_owned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod, "_processes", {"app": self._live(11)})
+        assert bmod.spawned_backend_owns_pid(11) is True
+
+    def test_a_launcher_descendant_is_owned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``wrap_argv`` puts a sandbox launcher between us and the real server."""
+        monkeypatch.setattr(bmod, "_processes", {"app": self._live(11)})
+        monkeypatch.setattr(bmod.platform_compat, "get_ppid", lambda _p: 11)
+        assert bmod.spawned_backend_owns_pid(22) is True
+
+    def test_an_unrelated_pid_is_not_owned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod, "_processes", {"app": self._live(11)})
+        monkeypatch.setattr(bmod.platform_compat, "get_ppid", lambda _p: 1)
+        assert bmod.spawned_backend_owns_pid(22) is False
+
+    def test_an_adopted_backend_is_never_owned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An adopted instance's pid belongs to a supervisor that is not us."""
+        adopted = AppProcess(app_name="app", pid=11, proc=None, adopted_pids=[11])
+        monkeypatch.setattr(bmod, "_processes", {"app": adopted})
+        assert bmod.spawned_backend_owns_pid(11) is False
+
+    def test_an_exited_child_is_never_owned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Once a child is reaped its pid is free for any process to take."""
+        dead = AppProcess(
+            app_name="app",
+            pid=11,
+            proc=SimpleNamespace(poll=lambda: 0),  # type: ignore[arg-type]
+        )
+        monkeypatch.setattr(bmod, "_processes", {"app": dead})
+        assert bmod.spawned_backend_owns_pid(11) is False
+
+    def test_a_record_with_no_pid_matches_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without the guard, pid 0 would be its own ancestor and match."""
+        blank = AppProcess(
+            app_name="app",
+            pid=0,
+            proc=SimpleNamespace(poll=lambda: None),  # type: ignore[arg-type]
+        )
+        monkeypatch.setattr(bmod, "_processes", {"app": blank})
+        assert bmod.spawned_backend_owns_pid(0) is False
+
+    def test_the_ancestry_walk_runs_outside_the_lock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A ``/proc`` read per candidate must not be serialised behind spawns."""
+        free: list[bool] = []
+
+        def _probe(pid: int, ancestor: int) -> bool:
+            # Non-reentrant lock, so a successful acquire proves it was released.
+            acquired = bmod._lock.acquire(blocking=False)
+            free.append(acquired)
+            if acquired:
+                bmod._lock.release()
+            return pid == ancestor
+
+        monkeypatch.setattr(bmod, "_processes", {"app": self._live(11)})
+        monkeypatch.setattr(bmod, "_pid_is_self_or_descendant_of", _probe)
+        assert bmod.spawned_backend_owns_pid(11) is True
+        assert free == [True]
+
+
 # ---------------------------------------------------------------------------
 # Node / npm binary resolution
 # ---------------------------------------------------------------------------

--- a/test/test_member_memory_provenance.py
+++ b/test/test_member_memory_provenance.py
@@ -60,6 +60,48 @@ def test_unowned_host_keeps_v1_and_owner_bootstrap(provenance):
     assert auth.local_owner_bootstrap_allowed(provenance.request)
 
 
+def _register_spawned_backend(monkeypatch, pid, *, name="crew-tunnel", live=True, adopted=False):
+    """Make *pid* the gateway's own app-backend record for *name*."""
+    from kiro_crew.apps import backend as apps_backend
+
+    record = apps_backend.AppProcess(
+        app_name=name,
+        pid=pid,
+        proc=None if adopted else SimpleNamespace(poll=lambda: None if live else 0),
+        adopted_pids=[pid] if adopted else [],
+    )
+    monkeypatch.setattr(apps_backend, "_processes", {name: record})
+
+
+def test_a_sandboxed_app_backend_still_bootstraps_the_owner(provenance, monkeypatch):
+    """Every app backend gets its own namespace, so the match can never hold."""
+    assert auth._verified_host_process(45) is False
+    assert not auth.local_owner_bootstrap_allowed(provenance.request)
+
+    _register_spawned_backend(monkeypatch, 45)
+    assert auth.local_owner_bootstrap_allowed(provenance.request)
+
+
+def test_a_backend_record_cannot_promote_a_private_member(provenance, monkeypatch):
+    """The private-member leg outranks app-backend provenance."""
+    auth.publish_member_session_pid(42, "member:alice", memory_store="member-alice")
+    _register_spawned_backend(monkeypatch, 45)
+    assert auth.protected_member_session_for_pid(45) == "member:alice"
+    assert not auth.local_owner_bootstrap_allowed(provenance.request)
+
+
+def test_an_adopted_backend_is_not_owner_provenance(provenance, monkeypatch):
+    """We hold no handle, so that pid is another supervisor's to vouch for."""
+    _register_spawned_backend(monkeypatch, 45, adopted=True)
+    assert not auth.local_owner_bootstrap_allowed(provenance.request)
+
+
+def test_an_exited_backend_is_not_owner_provenance(provenance, monkeypatch):
+    """A reaped pid can already belong to something else."""
+    _register_spawned_backend(monkeypatch, 45, live=False)
+    assert not auth.local_owner_bootstrap_allowed(provenance.request)
+
+
 def test_published_v1_runtime_keeps_v1_without_owner_authority(provenance):
     auth.publish_member_session_pid(42, "dashboard:one", memory_store="")
     assert auth.protected_member_session_for_pid(45) is None


### PR DESCRIPTION
## Problem / Motivation

An app that needs a gateway token cannot start. The Crew Tunnel app renders
`token mint failed: 403 Forbidden` and serves nothing. `GET /api/token/local`
answers `{"code": "member_owner_token_refused"}`, and the gateway's own audit
records `operation=token.local outcome=denied resources=unverified-owner-process`.

The trigger is the host's first private memory store. With only `memory_version: 1`
stores the same app starts fine.

## Why it matters

Creating one private crew member kills every app backend that needs a token, on
that whole host. Nothing in the dashboard says so: the app is enabled, its
process is alive, and the refusal is visible only inside the app's own error
text. The memory feature and the apps feature are unrelated from a user's seat,
so the cause is not guessable from the symptom.

## What changed (motivation → approach → change)

An app backend can never look like the gateway. `apps/backend.py` launches every
one through `wrap_argv`, so it lands in its own mount and user namespace.
`local_owner_bootstrap_allowed` took host provenance from
`_verified_host_process`, which on Linux is
`process_namespaces_match(pid, os.getpid()) is True`. That question has no true
answer for a process the gateway itself started, so once
`private_memory_boundaries_active()` switches the gate on, every app backend is
refused.

`spawned_backend_owns_pid` asks the gateway's own app-backend registry instead.
It answers true when some record's `Popen` is still unreaped and the pid either is
that root or descends from it. The unreaped handle is what makes the root
trustworthy: the kernel cannot recycle a live child's pid, so a match names a
process this gateway started and still owns. Descent is required because the
sandbox launcher is the registered root and the real server is its child — pid
2342769 was the launcher and pid 2342770 the `node` server in the reported case.

The other two legs of the gate are untouched, so a caller carrying a
private-member binding is still refused by `protected_member_session_for_pid` and
the shared secret still cannot promote a member. An adopted backend holds no
handle and is refused on a pid this gateway cannot vouch for.
`docs/system-specs/modules/security.md` describes both provenance legs, on Linux
and on macOS.

One consequence is deliberate and is the reason this needs a maintainer's eye.
The token minted here carries no `app` claim, so an app backend that reads
`.local_secret` reaches owner-gated routes, `/api/memory/stores` among them. That
is the standing shape of `api_token_local` and is what every V1 host already
does; this change restores it on V2 hosts rather than introducing it. Scoping the
grant per app is a change to the app permission model and is not attempted here.

| caller at `/api/token/local` | Before | After |
|---|---|---|
| the owner's own dashboard process | 🟦 mints | 🟦 mints |
| a gateway-spawned app backend | 🟥 refused | 🟩 mints |
| a private member's session process | 🟦 refused | 🟦 refused |
| a backend adopted from another supervisor | 🟦 refused | 🟦 refused |
| a registered pid whose child already exited | 🟦 refused | 🟦 refused |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*An app the gateway started can take a token again; nobody else's answer moves.*

`_verified_host_process` has two other readers, and both are deliberately left
alone. `_verified_global_process` has no caller at all — `grep
_verified_global_process src/` returns only its own definition — so no app
backend reaches it. `memory_request_identity` is reachable and fails closed: an
app backend reads as unverified for Global V1 identity, so it is refused rather
than over-served. Extending the registry leg there would grant app backends
Global memory identity, which is a second privilege expansion of exactly the
class under review here and is not part of this change.

## Tests

`test/test_apps_backend_coverage.py::TestSpawnedBackendOwnsPid` locks the
predicate: the root matches, a launcher child matches through the ancestry walk,
an unrelated pid does not, an adopted record never matches, a reaped child never
matches, a record with no pid matches nothing, and the ancestry walk runs outside
`_lock`.

`test/test_member_memory_provenance.py` locks the gate: a sandboxed backend
bootstraps the owner while `_verified_host_process` is false for the same pid, a
registry match cannot promote a bound private member, and neither an adopted nor
an exited record counts as provenance.

`prove.py` reports PROVEN — reverting the production hunks and keeping the test
hunks fails an assertion.

## Manual verification

Reproduced against the live gateway before the change: `GET /api/token/local`
with the real local secret returned 403 `member_owner_token_refused`, and the
audit log carried one `unverified-owner-process` denial 8 seconds after the Crew
Tunnel backend started, 10 seconds before the user's error screenshot. Confirmed
the real process shape (`2342769` launcher → `2342770` node server) and that
`process_namespaces_match` returns no match for either pid, then confirmed the
predicate attributes both pids to the app and stops attributing them once the
child is reaped.

Not verified: a full Crew Tunnel start under the patched gateway. That needs a
gateway restart on the reporting host, which the maintainer can do; unit coverage
stands in for the predicate itself.

## Related Issues

no linked issue: reported in a chat session, not filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a positive-provenance check whose one test is unsatisfiable by
construction for a legitimate caller class, so enabling the check silently
withdraws a capability instead of narrowing it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
