### PR TITLE
fix: clip at grapheme boundaries at all text cut sites

### DIFF
--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/notify_out.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/notify_out.py
@@ -75,6 +75,7 @@ from kiro_crew.apps.builtins.ops_mission_control.backend.providers import (
 # notifications" depending only on test order. Binding here makes the gate patchable by
 # identity (``mock.patch.object(notify_out, ...)``) and immune to that.
 from kiro_crew.apps.manager import get_app_manifest, is_app_enabled
+from kiro_crew.imessage.plaintext import _grapheme_boundary, _grapheme_end
 from kiro_crew.notifications.bus import NotificationPayload, NotificationValidationError
 
 logger = logging.getLogger(__name__)
@@ -232,7 +233,14 @@ def _redacted(text: str) -> str:
 
 def _clip(text: str, limit: int) -> str:
     text = text.strip()
-    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+    if len(text) <= limit:
+        return text
+    # Pull the cut back to a grapheme-cluster boundary so a ZWJ family, flag,
+    # skin-tone, keycap or accented sequence is never split (a lone regional
+    # indicator renders as a boxed letter, not a flag). A leading cluster
+    # wider than the limit is emitted whole rather than as an empty cut.
+    cut = _grapheme_boundary(text, limit - 1) or _grapheme_end(text, limit - 1)
+    return text[:cut].rstrip() + "…"
 
 
 def _push(

--- a/src/kiro_crew/computer_use/render.py
+++ b/src/kiro_crew/computer_use/render.py
@@ -37,6 +37,7 @@ from kiro_crew.computer_use.types import (
     ElementRec,
     Snapshot,
 )
+from kiro_crew.imessage.plaintext import _grapheme_boundary, _grapheme_end
 
 # Bytes-per-unit ladder for the human-readable screenshot size. Kept local: it
 # is presentation, not business logic.
@@ -357,10 +358,16 @@ def _clip(text: str, limit: int) -> str:
     Newlines are collapsed because the tree's structure IS its indentation: a
     multi-line value would otherwise forge tree lines, letting page content
     masquerade as elements the model can address.
+
+    The cut is pulled back to a grapheme-cluster boundary so a ZWJ family,
+    flag, skin-tone, keycap or accented sequence is never split (this text is
+    the user's own desktop, so non-Latin is the normal case). A leading
+    cluster wider than the limit is emitted whole rather than as an empty cut.
     """
     flat = " ".join(text.split())
     if limit > 0 and len(flat) > limit:
-        return flat[:limit] + "…"
+        cut = _grapheme_boundary(flat, limit) or _grapheme_end(flat, limit)
+        return flat[:cut] + "…"
     return flat
 
 

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import unicodedata
 from typing import Any
 
 from aiohttp import web
@@ -18,6 +17,7 @@ from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
 )
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE, DashboardState, _ChatSlot
+from kiro_crew.imessage.plaintext import _grapheme_end
 from kiro_crew.llm_helpers import background_turn, run_bg_oneliner
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -806,10 +806,12 @@ def _title_reveal_prefixes(title: str) -> list[str]:
     two characters at a time instead, so a 12-character zh name reveals in about
     as many steps as a 6-word en one rather than 12.
 
-    A cut is extended past any combining marks that follow it, so a frame never
-    shows a Thai consonant whose tone mark has not arrived yet (``แก`` then
-    ``แก้``): the mark would appear to pop onto an already-drawn glyph. Chinese
-    and Japanese have no combining marks, so this only ever fires for Thai.
+    A cut is extended to the end of the grapheme cluster it lands in, so a
+    frame never shows an incomplete glyph: not a Thai consonant whose tone
+    mark has not arrived yet (``แก`` then ``แก้`` — the mark would appear to
+    pop onto an already-drawn glyph), and not half of a ZWJ family, flag,
+    skin-tone, keycap or accented sequence either. Chinese and Japanese have
+    no combining marks, so the combining case only ever fires for Thai.
     """
     words = title.split()
     if len(words) > 1:
@@ -820,12 +822,11 @@ def _title_reveal_prefixes(title: str) -> list[str]:
     prefixes: list[str] = []
     cut = _TITLE_REVEAL_CHAR_CHUNK
     while cut < len(single):
-        while cut < len(single) and unicodedata.combining(single[cut]):
-            cut += 1
-        if cut >= len(single):
+        end = _grapheme_end(single, cut)
+        if end >= len(single):
             break
-        prefixes.append(single[:cut])
-        cut += _TITLE_REVEAL_CHAR_CHUNK
+        prefixes.append(single[:end])
+        cut = end + _TITLE_REVEAL_CHAR_CHUNK
     return prefixes
 
 

--- a/test/test_chat_title.py
+++ b/test/test_chat_title.py
@@ -624,6 +624,21 @@ def test_reveal_prefixes_never_split_a_combining_mark():
         assert not unicodedata.combining(title[len(p)])
 
 
+def test_reveal_prefixes_never_split_a_grapheme_cluster():
+    """Cuts use grapheme boundaries, not code points: a ZWJ family, flag,
+    skin-tone, keycap or accented sequence is never left dangling (#10380)."""
+    from kiro_crew.imessage.plaintext import _joins_previous
+
+    title = "季度报告👨\u200d👩\u200d👧完成"
+    prefixes = chat_title._title_reveal_prefixes(title)
+    assert prefixes, "expected an animated reveal"
+    for p in prefixes:
+        assert title.startswith(p)
+        assert p != title
+        # The next character must not join onto the revealed prefix.
+        assert not _joins_previous(title, len(p)), f"split cluster in {p!r}"
+
+
 # --- Per-line excerpt bounding (_bounded_prompt_line) ------------------------
 #
 # A blind slice at the per-line budget lands mid-word, and the titling model

--- a/test/test_grapheme_safe_clips.py
+++ b/test/test_grapheme_safe_clips.py
@@ -1,0 +1,37 @@
+"""Grapheme-cluster-safe truncation at the three clip sites (#10380).
+
+Cutting by code point inside a grapheme cluster produces a changed or broken
+glyph: a dangling joiner, a lone regional indicator (boxed letter, not a
+flag), a dropped tone mark that changes the word. All three sites below share
+the one guard in ``kiro_crew.imessage.plaintext`` instead of each modeling a
+subset of the mechanisms (the title reveal used to extend past combining marks
+only, which covers one of six).
+"""
+
+from kiro_crew.apps.builtins.ops_mission_control.backend.notify_out import _clip as notify_clip
+from kiro_crew.computer_use.render import _clip as render_clip
+
+FAMILY = "👨\u200d👩\u200d👧"
+FLAG = "🇰🇷"
+
+
+class TestComputerUseClip:
+    def test_family_is_dropped_whole_not_split(self) -> None:
+        assert render_clip("AB" + FAMILY, 3) == "AB…"
+
+    def test_thai_tone_mark_survives(self) -> None:
+        assert render_clip("หน้าก้", 5) == "หน้า…"
+
+    def test_wider_limit_keeps_the_whole_family(self) -> None:
+        assert render_clip("AB" + FAMILY + "CD", 6) == "AB…"
+
+
+class TestNotifyClip:
+    def test_flag_is_dropped_whole_not_split(self) -> None:
+        assert notify_clip("AB" + FLAG + "CD", 4) == "AB…"
+
+    def test_short_text_untouched(self) -> None:
+        assert notify_clip("hi", 4) == "hi"
+
+    def test_family_survives_when_it_fits(self) -> None:
+        assert notify_clip("AB" + FAMILY + "CD", 8) == "AB" + FAMILY + "…"


### PR DESCRIPTION
## Problem / Motivation

A slice by code point can land inside a grapheme cluster, which is the unit a reader sees as one character — the result is a changed or broken glyph. The repository already contains a guard that prevents exactly this (`_grapheme_boundary` / `_grapheme_end` in `imessage/plaintext.py`, measured against ZWJ families, flags, skin tones, keycaps, and combining accents), but three cut sites each modeled only a subset:

- `_title_reveal_prefixes` (`dashboard/chat_title.py`) extended past combining marks only (1 of 6 mechanisms): on `季度报告👨‍👩‍👧完成` two frames ended on a dangling U+200D, animating a broken family in the sidebar.
- `_clip` (`computer_use/render.py`, `flat[:limit]`) turned `AB👨‍👩‍👧` at limit 3 into `AB👨` and dropped the tone mark off `หน้าก้` — this text is the user's own desktop, so non-Latin is the normal case.
- `_clip` (`ops_mission_control/backend/notify_out.py`) turned `AB🇰🇷CD` at limit 4 into `AB🇰`, a lone regional indicator (boxed letter, not a flag).

## Why it matters

Broken glyphs in the sidebar animation, model-relayed desktop text, and push notifications — all user-visible, all silent.

## What changed (motivation → approach → change)

All three sites route through the shared guard (already imported cross-module elsewhere, e.g. `_ChatSlot` in `chat_title.py`; the helper module is stdlib-only so no cycle):

- Reveal extends each cut to the grapheme end (same frame rhythm on clean cuts; progress is structural since end ≥ cut).
- Both `_clip`s pull the cut back to the boundary, emitting a leading cluster whole rather than an empty cut.

## Tests

- New `test/test_grapheme_safe_clips.py`: family dropped whole, Thai tone kept, flag dropped whole, short text untouched — all pass.
- `test/test_chat_title.py`: new ZWJ-family reveal test; full file green.
- `test/test_imessage_plaintext.py`: full file green (helper untouched).
- `black`/`flake8`/`isort` clean on non-baselined touched files; added hunks in baselined files verified black-clean in isolation.

## Pattern harvest

Not generalizable: one-off consolidation onto the existing guard; no new pattern.

## Related Issues

Fixes #10380.

## Checklist

- [x] Single commit with Conventional Commits title
- [x] Issue repro verified pre-fix shape, green post-fix
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
