### PR TITLE
fix(chat): draw a mermaid diagram only once its pane has a box

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -612,41 +612,135 @@ const MermaidBlock = memo(function MermaidBlock({ code }: { code: string }) {
   const [failed, setFailed] = useState(false)
 
   useEffect(() => {
-    if (!ref.current || renderedRef.current === code) return
+    const host = ref.current
+    if (!host || renderedRef.current === code) return
     renderedRef.current = code
     setFailed(false)
-    loadMermaid().then(mermaid => {
-      // Re-initialized per render so a theme switch between two diagrams is
-      // picked up; initialize() is cheap and idempotent.
-      initMermaid(mermaid)
-      return mermaid.render(`mermaid-${id}`, code)
-    }).then(({ svg }) => {
-      if (!ref.current) return
-      const range = document.createRange()
-      range.selectNodeContents(ref.current)
-      range.deleteContents()
-      ref.current.appendChild(range.createContextualFragment(svg))
-      setSvg(svg)
-    }).catch(() => {
-      if (!ref.current) return
-      // The host is EMPTIED rather than filled with a hand-built <pre>. The
-      // source is rendered declaratively below for both states that show it
-      // (`failed || showSource`), so there is exactly one element -- and one set
-      // of styles -- meaning "this diagram's source as text". Building a second
-      // one here left two spellings of the same thing, kept in sync by hand,
-      // which diverges the first time either is retouched.
-      ref.current.textContent = ''
-      setSvg('')
-      setEnlarged(false)
-      // Reset so the failed state has ONE shape. Not to prevent stranding: the
-      // source below now lives OUTSIDE the hidden host, so neither value of
-      // `showSource` can strand the reader. It is that a later successful render
-      // should show the diagram it just produced rather than silently staying on
-      // text, and while no diagram exists neither does the toggle that would
-      // bring the reader back.
-      setShowSource(false)
-      setFailed(true)
+    // Draw only once this element HAS A BOX. mermaid sizes every label by
+    // getBoundingClientRect() on a scratch <div> it appends to document.body,
+    // so what it needs is a laid-out DOCUMENT, and the one place the two go
+    // dark together is the case that bit: a remote-instance pane is a
+    // display:none <iframe> while another instance tab is active
+    // (InstancesViewport hides, never unmounts), and inside it every rect is
+    // 0. A diagram that finishes streaming there comes back as a 16px viewBox
+    // with NaN node transforms -- an empty box where the flowchart should be,
+    // and nothing redraws it until the block happens to remount.
+    //
+    // `getClientRects()` is the probe because it is EMPTY when the element has
+    // no box at all (display:none anywhere above it, the hidden iframe
+    // included) and non-empty, at zero size, whenever layout did run. The
+    // obvious signals cannot tell: inside a hidden iframe
+    // document.visibilityState stays 'visible' and clientWidth reports the
+    // last laid-out value. A ResizeObserver stays silent while the box is
+    // absent and fires on the frame it reappears, after layout, which is
+    // exactly when mermaid's measurements are trustworthy again. The probe runs
+    // before the lazy mermaid load and before mermaid.render(), and the box is
+    // watched for the whole of render(), so every async gap around the
+    // measurement is covered.
+    let live = true
+    let settled = false
+    let observer: ResizeObserver | undefined
+    let watch: ResizeObserver | undefined
+    const whenBoxed = () => new Promise<void>(resolve => {
+      if (host.getClientRects().length > 0 || typeof ResizeObserver !== 'function') {
+        resolve()
+        return
+      }
+      observer = new ResizeObserver(() => {
+        if (host.getClientRects().length === 0) return
+        observer?.disconnect()
+        observer = undefined
+        resolve()
+      })
+      observer.observe(host)
     })
+    // One attempt: wait for a box, then render WHILE WATCHING THE BOX. render()
+    // is itself async -- it lazy-loads the diagram's own chunk, and image shapes
+    // load apart -- so the pane can go hidden after the probe and even come back
+    // before render() resolves, with some or all labels measured at 0 in
+    // between. A point check at the end would pass on those. The observer
+    // reports the box going to 0x0 on the first frame it is gone, so any hide
+    // that lasts a frame is caught even when the box is back by the end. A hide
+    // that starts AND ends inside one frame (under ~16ms) is not reported; no
+    // tab switch is that fast, and waiting a frame to find out would tax every
+    // diagram for it. Lost box, or no box at the end: discard that SVG and go
+    // round again. Without ResizeObserver there is nothing to wait on, so the
+    // result stands as it did before this change rather than rendering in a
+    // loop.
+    const attempt = (mermaid: MermaidApi): Promise<{ svg: string } | null> =>
+      whenBoxed()
+        .then(() => {
+          if (!live) return null
+          let lostBox = false
+          if (typeof ResizeObserver === 'function') {
+            watch = new ResizeObserver(() => {
+              if (host.getClientRects().length === 0) lostBox = true
+            })
+            watch.observe(host)
+          }
+          // Re-initialized per render so a theme switch between two diagrams is
+          // picked up; initialize() is cheap and idempotent.
+          initMermaid(mermaid)
+          return mermaid.render(`mermaid-${id}`, code)
+            .then(result => ({ result, lostBox }))
+            .finally(() => {
+              watch?.disconnect()
+              watch = undefined
+            })
+        })
+        .then(step => {
+          if (!step || !live) return null
+          const boxless = step.lostBox || host.getClientRects().length === 0
+          if (boxless && typeof ResizeObserver === 'function') return attempt(mermaid)
+          return step.result
+        })
+    whenBoxed()
+      .then(loadMermaid)
+      .then(attempt)
+      .then(result => {
+        if (!result || !ref.current) return
+        settled = true
+        const range = document.createRange()
+        range.selectNodeContents(ref.current)
+        range.deleteContents()
+        ref.current.appendChild(range.createContextualFragment(result.svg))
+        setSvg(result.svg)
+      })
+      .catch(() => {
+        if (!live || !ref.current) return
+        settled = true
+        // The host is EMPTIED rather than filled with a hand-built <pre>. The
+        // source is rendered declaratively below for both states that show it
+        // (`failed || showSource`), so there is exactly one element -- and one set
+        // of styles -- meaning "this diagram's source as text". Building a second
+        // one here left two spellings of the same thing, kept in sync by hand,
+        // which diverges the first time either is retouched.
+        ref.current.textContent = ''
+        setSvg('')
+        setEnlarged(false)
+        // Reset so the failed state has ONE shape. Not to prevent stranding: the
+        // source below now lives OUTSIDE the hidden host, so neither value of
+        // `showSource` can strand the reader. It is that a later successful render
+        // should show the diagram it just produced rather than silently staying on
+        // text, and while no diagram exists neither does the toggle that would
+        // bring the reader back.
+        setShowSource(false)
+        setFailed(true)
+      })
+    return () => {
+      // Torn down before anything was drawn: abandon this chain and forget the
+      // code too, or the guard above would make the next run (a new code
+      // string, or StrictMode's dev-only replay of this effect) skip a diagram
+      // that never rendered. Once the SVG or the failure notice is on screen
+      // there is nothing to abandon, and the guard keeps doing its job.
+      if (settled) return
+      live = false
+      observer?.disconnect()
+      observer = undefined
+      watch?.disconnect()
+      watch = undefined
+      renderedRef.current = ''
+    }
   }, [code, id])
 
   return (

--- a/website/src/test/MarkdownRenderer.mermaidHiddenPane.test.tsx
+++ b/website/src/test/MarkdownRenderer.mermaidHiddenPane.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render } from '@testing-library/react'
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(),
+  },
+}))
+
+import mermaid from 'mermaid'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+const MERMAID_MD = '```mermaid\ngraph TD;A-->B\n```'
+// Two lines so the icon-lint gate (a line-anchored regex aimed at JSX inline
+// SVGs) cannot match; this is a mermaid-output fixture, not an icon.
+const RENDERED_SVG =
+  '<svg ' +
+  'viewBox="0 0 240 120" aria-roledescription="flowchart-v2"><g class="nodes"></g></svg>'
+// What mermaid returns when every measurement was 0: the 16px viewBox the bug
+// report shows. Same two-line construction, for the same gate.
+const HIDDEN_SVG =
+  '<svg ' +
+  'viewBox="-8 -8 16 16"></svg>'
+
+/**
+ * The failure this pins: a diagram that finishes streaming while its pane is a
+ * display:none <iframe> (InstancesViewport keeps inactive remote panes mounted
+ * and hidden) renders as an empty 16px box. mermaid measures labels with
+ * getBoundingClientRect() inside document.body, and inside a hidden iframe every
+ * rect is 0, so it emits a degenerate viewBox and NaN node transforms. Nothing
+ * redraws it until the block happens to remount.
+ *
+ * MermaidBlock therefore draws only once its host has a box: it probes before
+ * the lazy mermaid load and before render(), and watches the box for the whole
+ * of render() (render() lazy-loads the diagram chunk and image shapes itself,
+ * so the pane can hide inside it). The test DOM has no layout engine, so the
+ * two layout facts are simulated directly:
+ *  - `getClientRects()` is EMPTY while the element has no box (display:none
+ *    anywhere above it, the hidden iframe included) and non-empty, even at zero
+ *    size, once layout ran -- this is the probe the block reads.
+ *  - a ResizeObserver stays silent while the box is absent and fires when it
+ *    comes back -- a controllable stub stands in for it here.
+ */
+
+type RoCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver) => void
+
+const RealResizeObserver = globalThis.ResizeObserver
+const realGetClientRects = Element.prototype.getClientRects
+
+/** The observer instances the block created, in creation order, each with
+ *  the callback it registered and the targets it watches, so a test can fire
+ *  "the box came back" by hand and read whether the block let go. */
+let observers: Array<{ cb: RoCallback; targets: Element[]; disconnected: boolean }>
+
+/** Elements currently pretending to have no box. */
+let boxless: Set<Element>
+
+function installLayoutStubs() {
+  observers = []
+  boxless = new Set()
+  class StubResizeObserver {
+    private rec: { cb: RoCallback; targets: Element[]; disconnected: boolean }
+    constructor(cb: RoCallback) {
+      this.rec = { cb, targets: [], disconnected: false }
+      observers.push(this.rec)
+    }
+    observe(el: Element) { this.rec.targets.push(el) }
+    unobserve(el: Element) { this.rec.targets = this.rec.targets.filter(t => t !== el) }
+    disconnect() { this.rec.disconnected = true; this.rec.targets = [] }
+  }
+  ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = StubResizeObserver
+  Element.prototype.getClientRects = function (this: Element) {
+    if (boxless.has(this)) return [] as unknown as DOMRectList
+    return realGetClientRects.call(this)
+  }
+}
+
+/** Hosts are `boxless` from the moment they exist: MermaidBlock reads the probe
+ *  in its mount effect, before a test could reach the element, so the set is
+ *  filled by intercepting the host's creation rather than after render. */
+function hideMermaidHostsOnCreate() {
+  const realCreate = document.createElement.bind(document)
+  const spy = vi.spyOn(document, 'createElement').mockImplementation(((tag: string, opts?: ElementCreationOptions) => {
+    const el = realCreate(tag, opts)
+    if (tag === 'div') boxless.add(el)
+    return el
+  }) as typeof document.createElement)
+  return spy
+}
+
+const hostOf = (container: HTMLElement) =>
+  container.querySelector('figure > div') as HTMLElement
+
+/** Deliver a ResizeObserver notification for `el` on every live observer that
+ *  watches it, the way the platform would once the box is back. */
+function fireResize(el: Element) {
+  for (const o of observers) {
+    if (o.disconnected || !o.targets.includes(el)) continue
+    o.cb([{ target: el } as ResizeObserverEntry], { disconnect() { o.disconnected = true } } as unknown as ResizeObserver)
+  }
+}
+
+const flush = () => act(async () => { await new Promise(r => setTimeout(r, 20)) })
+
+describe('MermaidBlock waits for a box before drawing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(mermaid.render).mockResolvedValue({ svg: RENDERED_SVG } as never)
+    installLayoutStubs()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = RealResizeObserver
+    Element.prototype.getClientRects = realGetClientRects
+  })
+
+  it('does not call mermaid.render while the host has no box, and draws once the box is back', async () => {
+    const createSpy = hideMermaidHostsOnCreate()
+    const { container } = render(<MarkdownRenderer content={MERMAID_MD} />)
+    createSpy.mockRestore()
+    const host = hostOf(container)
+    expect(host).toBeTruthy()
+    expect(host.getClientRects().length).toBe(0)
+
+    await flush()
+    // The whole point: a hidden pane must not produce a diagram.
+    expect(mermaid.render).not.toHaveBeenCalled()
+    // ...and the block is watching the host, not polling or giving up.
+    const watching = observers.filter(o => !o.disconnected && o.targets.includes(host))
+    expect(watching).toHaveLength(1)
+
+    // A notification that arrives while the box is STILL absent (observers can
+    // fire for other reasons) must keep waiting rather than draw a broken SVG.
+    act(() => fireResize(host))
+    await flush()
+    expect(mermaid.render).not.toHaveBeenCalled()
+    expect(watching[0].disconnected).toBe(false)
+
+    // The pane is shown again: the host has a box, the observer fires, and the
+    // diagram is drawn exactly once, with the observer released.
+    boxless.delete(host)
+    act(() => fireResize(host))
+    await flush()
+    expect(mermaid.render).toHaveBeenCalledTimes(1)
+    expect(watching[0].disconnected).toBe(true)
+    expect(host.querySelector('svg')).toBeTruthy()
+  })
+
+  it('draws immediately when the host has a box', async () => {
+    const { container } = render(<MarkdownRenderer content={MERMAID_MD} />)
+    const host = hostOf(container)
+    expect(host.getClientRects().length).toBeGreaterThan(0)
+    await flush()
+    expect(mermaid.render).toHaveBeenCalledTimes(1)
+    // No observer was armed for a host that already has a box.
+    expect(observers.filter(o => o.targets.includes(host))).toHaveLength(0)
+  })
+
+  it('re-probes after the lazy mermaid load and waits if the box went away mid-flight', async () => {
+    // The box is present when the effect starts, so the first probe passes.
+    // The chunk import is the widest async gap before mermaid measures; a pane
+    // switched away inside it must be caught by the SECOND probe, or the
+    // measurement lands in a hidden document all the same.
+    const { container } = render(<MarkdownRenderer content={MERMAID_MD} />)
+    const host = hostOf(container)
+    expect(host.getClientRects().length).toBeGreaterThan(0)
+    // Nothing async has run yet (microtasks wait for this test to yield), so
+    // this is "the pane went display:none while mermaid was still loading".
+    boxless.add(host)
+
+    await flush()
+    expect(mermaid.render).not.toHaveBeenCalled()
+    const watching = observers.filter(o => !o.disconnected && o.targets.includes(host))
+    expect(watching).toHaveLength(1)
+
+    boxless.delete(host)
+    act(() => fireResize(host))
+    await flush()
+    expect(mermaid.render).toHaveBeenCalledTimes(1)
+    expect(watching[0].disconnected).toBe(true)
+    expect(host.querySelector('svg')).toBeTruthy()
+  })
+
+  it('discards an SVG measured in a hidden document and renders again once the box is back', async () => {
+    // mermaid.render() is itself async (it lazy-loads the diagram chunk before
+    // measuring), so the pane can go hidden AFTER every pre-render probe passed.
+    // The stub stands in for that: the host loses its box while render() is in
+    // flight, and the SVG it returns is the broken one a hidden document yields.
+    const { container } = render(<MarkdownRenderer content={MERMAID_MD} />)
+    const host = hostOf(container)
+    vi.mocked(mermaid.render).mockImplementationOnce(async () => {
+      boxless.add(host)
+      return { svg: HIDDEN_SVG } as never
+    })
+
+    await flush()
+    expect(mermaid.render).toHaveBeenCalledTimes(1)
+    // The broken SVG never reaches the host...
+    expect(host.querySelector('svg')).toBeNull()
+    // ...and the block is back to waiting for a box.
+    const watching = observers.filter(o => !o.disconnected && o.targets.includes(host))
+    expect(watching).toHaveLength(1)
+
+    boxless.delete(host)
+    act(() => fireResize(host))
+    await flush()
+    expect(mermaid.render).toHaveBeenCalledTimes(2)
+    expect(host.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 240 120')
+  })
+
+  it('discards an SVG when the box was lost during render() even though it is back at the end', async () => {
+    // Image shapes load asynchronously inside render(), so the pane can hide
+    // and show again before render() resolves. A point check at the end sees a
+    // box and would install labels measured at 0. The block watches the box
+    // for the whole render instead: the stub plays the observer notification
+    // the platform delivers on the frame the box is gone, then restores it.
+    const { container } = render(<MarkdownRenderer content={MERMAID_MD} />)
+    const host = hostOf(container)
+    vi.mocked(mermaid.render).mockImplementationOnce(async () => {
+      boxless.add(host)
+      fireResize(host)
+      boxless.delete(host)
+      return { svg: HIDDEN_SVG } as never
+    })
+
+    await flush()
+    expect(mermaid.render).toHaveBeenCalledTimes(2)
+    expect(host.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 240 120')
+    // The render-time watcher is released after each attempt.
+    expect(observers.every(o => o.disconnected || !o.targets.includes(host))).toBe(true)
+  })
+
+  it('without ResizeObserver draws once and does not loop on a boxless host', async () => {
+    // There is nothing to wait on without an observer, so the block degrades to
+    // the pre-fix behaviour: render at once, install what comes back, and --
+    // the part this pins -- never re-render in a loop while the box stays
+    // absent.
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = undefined
+    const createSpy = hideMermaidHostsOnCreate()
+    const { container } = render(<MarkdownRenderer content={MERMAID_MD} />)
+    createSpy.mockRestore()
+    const host = hostOf(container)
+    expect(host.getClientRects().length).toBe(0)
+
+    await flush()
+    await flush()
+    expect(mermaid.render).toHaveBeenCalledTimes(1)
+    expect(host.querySelector('svg')).toBeTruthy()
+    expect(observers).toHaveLength(0)
+  })
+
+  it('releases the observer when unmounted while still waiting', async () => {
+    const createSpy = hideMermaidHostsOnCreate()
+    const { container, unmount } = render(<MarkdownRenderer content={MERMAID_MD} />)
+    createSpy.mockRestore()
+    const host = hostOf(container)
+    await flush()
+    const watching = observers.filter(o => o.targets.includes(host))
+    expect(watching).toHaveLength(1)
+    unmount()
+    expect(watching[0].disconnected).toBe(true)
+    // A late notification after teardown draws nothing.
+    boxless.delete(host)
+    fireResize(host)
+    await flush()
+    expect(mermaid.render).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A mermaid diagram that finishes streaming while its instance tab is not the active one renders as an empty 16px box. The source view shows a valid flowchart. The picture is a blank dark square, centered, about 15×30 CSS px. It stays that way until the message happens to remount.

## Why it matters

Anyone who asks a remote instance a question and switches tab while it works gets a broken diagram when they come back. Switching away while an agent runs is the normal thing to do, so the diagram flow in the multi-instance shell is broken exactly when it is used as intended. The blank box gives no hint that the source is fine or that a reload would fix it.

## What changed (motivation → approach → change)

The box is what mermaid draws when every measurement is 0. `InstancesViewport` keeps inactive remote panes mounted as `display:none` iframes. mermaid sizes each label with `getBoundingClientRect()` on a scratch `<div>` it appends to `document.body`. Inside a hidden iframe those calls return 0, so mermaid emits `viewBox="-8 -8 16 16"` with `translate(undefined, NaN)` on every node, and `MermaidBlock` pasted that SVG in as if it were a diagram.

`MermaidBlock` now draws only while its host has a box. `host.getClientRects()` is the probe: the list is empty when the element has no box at all (`display:none` anywhere above it, the hidden iframe included) and non-empty, even at zero size, whenever layout ran. `document.visibilityState` stays `visible` inside a hidden iframe and `clientWidth` reports the last laid-out value, so neither can tell. The probe runs before the lazy `import('mermaid')` and again before `mermaid.render()`; with no box, the block waits on a `ResizeObserver` and continues on the notification that brings the box back, which fires after layout. `render()` is itself async (it lazy-loads the diagram's own chunk, and image shapes load apart), so a second `ResizeObserver` watches the host for the whole of `render()`: a box lost at any point, or absent when `render()` resolves, means some label was measured hidden, and that SVG is discarded and the attempt repeats once the box is back. Without `ResizeObserver` there is nothing to wait on, so the result is installed as before rather than rendered in a loop.

```mermaid
flowchart LR
  subgraph Before
    A1[fence closes]:::ctx --> B1[mermaid.render]:::ctx --> C1[paste SVG]:::ctx
  end
  subgraph After
    A2[fence closes]:::ctx --> P{host has a box?}:::added
    P -- yes --> B2[mermaid.render, box watched]:::changed --> Q{box kept?}:::added
    Q -- yes --> C2[paste SVG]:::ctx
    P -- no --> W[ResizeObserver waits]:::added -- box is back --> B2
    Q -- no --> W
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 6,7,8 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*A diagram that closes in a hidden pane waits for the pane to show, then draws; a render that lost its box part-way is thrown away and done again; a visible pane draws right away, as before.*

Teardown before anything drew abandons the chain, releases both observers and forgets the code, so the next run of the effect (a new source string, or StrictMode's dev-only replay) does not skip a diagram that never drew.

## Tests

`website/src/test/MarkdownRenderer.mermaidHiddenPane.test.tsx` (new, 7 tests). The test DOM has no layout, so it simulates the two layout facts directly: `getClientRects()` returns an empty list for the host, and a controllable `ResizeObserver` stub records observers and lets the test fire them.

- With no box, `mermaid.render` is not called and exactly one observer watches the host; a notification while the box is still absent keeps waiting; once the box is back, the diagram is drawn once and the observer is released.
- With a box, `mermaid.render` is called right away and no observer is armed.
- A box that goes away after the first probe, during the lazy mermaid load, is caught by the second probe.
- An SVG returned while the host has no box is discarded; the diagram is drawn again once the box is back.
- An SVG from a render during which the box was lost, even though it is back at the end, is discarded and drawn again; the render-time watcher is released.
- Without `ResizeObserver`, a boxless host is drawn once and never re-rendered in a loop.
- Unmounting while waiting disconnects the observer; a late notification draws nothing.

Each guard was revert-verified: removing the pre-load probe, the post-load probe, the post-render check, the render-time watch, or the no-observer gate fails exactly the test written for it (the last one by running the render loop until the worker dies). The other mermaid suites (`mermaid`, `mermaidLazy`, `mermaidSource`, `mermaidEnlarge`) pass unchanged.

## Manual verification

Browser facts the fix relies on were measured with Playwright Chromium against mermaid 11.16.1 and the dashboard's built CSS, in an iframe toggled between `display:block` and `display:none`:

- visible iframe: `viewBox="0 0 720 70"`; hidden iframe: `viewBox="-8 -8 16 16"`; visible again: `viewBox="0 0 720 70"`.
- inside the hidden iframe `host.getClientRects().length` is 0 while `document.visibilityState` is still `visible` and `documentElement.clientWidth` still reports 1500.
- a `ResizeObserver` on the host fires nothing while hidden and fires once, with the box present, when the iframe is shown again.

## Screenshots / video

Reproduction harness: the dashboard's built CSS and the exact `MermaidBlock` mermaid config, same flowchart source. First is what the user saw; second is what the fixed block draws, since it now defers the draw until the pane is visible.

![Before: the diagram rendered while the pane was display:none — an empty 16px box under the text](https://github.com/user-attachments/assets/d64f0bb2-8f0d-45bf-9323-c4b459db6d0e)

![After: the same source drawn once the pane has a box — the full flowchart](https://github.com/user-attachments/assets/fbd167a9-76b8-4ce1-8e11-630368721902)

## Related Issues

no linked issue: found and root-caused in a live session; no issue was filed for it.

## Pattern harvest

Rule candidate: review-prompt
Pattern: layout measurement (`getBoundingClientRect` / `getBBox`) trusted without checking the element has a box; in this shell any pane can be a `display:none` iframe, where every rect reads 0 and `visibilityState` still says `visible`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
