### PR TITLE
fix(chat): run refusal recovery when the backend aborts the denied turn

### DIFF
--- a/.github/agent-sdk-boundary-baseline.txt
+++ b/.github/agent-sdk-boundary-baseline.txt
@@ -48,7 +48,6 @@
 1 src/kiro_crew/dashboard/handlers/usage.py
 1 src/kiro_crew/dashboard/session_memory.py
 1 src/kiro_crew/dashboard/stall_enrichment.py
-1 src/kiro_crew/dashboard/state.py
 1 src/kiro_crew/dashboard/steer_settle.py
 1 src/kiro_crew/dashboard/turn_dispatch.py
 1 src/kiro_crew/discord/renderer.py

--- a/src/kiro_crew/agent_sdk/backends.py
+++ b/src/kiro_crew/agent_sdk/backends.py
@@ -499,9 +499,23 @@ ACP_BACKENDS_SESSION_SHARING = frozenset({ACP_BACKEND_KIRO})
 # a member dispatch to ride on.
 ACP_BACKENDS_MEMBER_DISPATCH = frozenset({ACP_BACKEND_CLAUDE, ACP_BACKEND_KAS})
 
-# Backends implementing the ``_session/steer`` extension (mid-turn steer). Neither
-# claude-agent-acp nor codex-acp implements it, so a steer sent to either would be
-# answered with method-not-found rather than reaching the turn.
+# Backends implementing the ``_session/steer`` extension (mid-turn steer).
+# claude-agent-acp does not implement it, so a steer sent there is answered with
+# method-not-found rather than reaching the turn.
+# codex-acp (1.11.0) has a steering channel, but not this one and not usable for
+# what membership buys. Measured against a real adapter: it is a different method
+# (``_session/steering``, ``{sessionId, prompt: [ContentBlock]}``, answered with
+# ``{outcome: injected|startedNewTurn|failed}``, advertised as
+# ``initialize._meta.steering.supported``) with no ``steering_consumed`` echo --
+# and the one thing membership is for, handing a deny reason to the model INSIDE
+# the turn that was denied, cannot happen on codex at all: its command approval
+# advertises ``cancel`` as the ONLY reject option (no ``decline``), and answering
+# it aborts the turn with ``stopReason: "cancelled"`` before the model is called
+# again. A steer injected while the permission request is pending returns
+# ``injected`` and is then discarded with the turn. So codex stays a non-member
+# and takes the refusal-recovery continuation (see
+# ``dashboard.state.should_queue_refusal_recovery``), which is the only channel
+# that reaches its model.
 # opencode is not a member either: its ``initialize`` result advertises
 # ``sessionCapabilities`` of close, fork, list and resume, and nothing else.
 ACP_BACKENDS_STEER = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -6421,6 +6421,24 @@ async def _run_chat(
     # The monotonic generation preserves that user intent across the whole call.
     _stop_gen_at_entry = slot._stop_generation
 
+    def _stop_pressed() -> bool:
+        """The user's Stop signal for this turn, read LIVE at the call site.
+
+        True when a stop is in flight OR the monotonic stop generation moved since
+        entry -- a Stop that pressed and already resolved back to idle is invisible
+        to ``_stopping`` but not to the counter. The two end-of-turn continuation
+        gates (Stop-hook and refusal recovery) read THIS, never the backend's wire
+        stop reason: a backend that aborts a policy-denied turn (codex answers its
+        only reject option, ``cancel``, that way) reports ``cancelled`` with no
+        Stop pressed, and the continuation is owed there. A function rather than a
+        value so no gate can consume a snapshot taken before an await -- the Stop
+        hook and the credential-hint lookup both suspend between the turn's end
+        and the queue write.
+        """
+        return bool(getattr(slot, "_stopping", False)) or (
+            getattr(slot, "_stop_generation", _stop_gen_at_entry) != _stop_gen_at_entry
+        )
+
     session_key = effective_session_key(slot)
     sessions = getattr(state, "sessions", None)
 
@@ -12158,7 +12176,17 @@ async def _run_chat(
             # Resetting it on the recovery turn's completion would let a repeated
             # post-token 5xx during recovery re-queue forever.
 
-        if _stop_reason == STOP_REASON_CANCELLED:
+        if _stop_reason == STOP_REASON_CANCELLED and _refusal_reasons and not _stop_pressed():
+            # Not a user stop: the backend aborted the turn on the rejected tool
+            # (codex answers its only reject option, `cancel`, this way). Logged
+            # apart from the user case so an operator reading "cancelled by user"
+            # is not sent looking for a Stop press that never happened.
+            logger.info(
+                "Turn for slot %s aborted by the backend after a policy-blocked tool "
+                "call (stopReason=cancelled, no Stop pressed) -- refusal recovery follows",
+                slot.key,
+            )
+        elif _stop_reason == STOP_REASON_CANCELLED:
             logger.info("Turn cancelled by user for slot %s", slot.key)
         elif (
             not _retrying_empty
@@ -12239,14 +12267,12 @@ async def _run_chat(
         # override the Stop button. A configurable consecutive-turn backstop
         # bounds faulty always-block hooks; 0 explicitly disables that backstop.
         # The finally block's dequeue loop dispatches accepted continuations.
-        if should_queue_hook_continuation(slot._stopping, needs_session_reset, _stop_reason) and (
-            # Suppress if any user stop was initiated during this turn (streaming,
-            # completion persistence, or the hook _fire above): stop_turn()
-            # reporting "idle" resets _stop_state before this guard reads
-            # _stopping, but _stop_generation counts stop INITIATIONS and never
-            # rewinds, so an entry-vs-now delta is the durable signal.
-            slot._stop_generation
-            == _stop_gen_at_entry
+        # `user_stopped` is read live: a Stop initiated during this turn
+        # (streaming, completion persistence, or the hook _fire above) may have
+        # resolved already -- stop_turn() reporting "idle" resets _stop_state --
+        # and only the generation counter still says it happened.
+        if should_queue_hook_continuation(
+            slot._stopping, needs_session_reset, user_stopped=_stop_pressed()
         ):
             _hook_reasons = parse_hook_continuations(_stop_hook_out)
             # No block decision -> nothing to queue; skip the cap load and
@@ -12259,11 +12285,8 @@ async def _run_chat(
                 # Config loading yields to the event loop. Recheck the Stop
                 # boundary before mutating the queue so a Stop that lands during
                 # that await cannot be bypassed by the stale outer guard.
-                if (
-                    not should_queue_hook_continuation(
-                        slot._stopping, needs_session_reset, _stop_reason
-                    )
-                    or slot._stop_generation != _stop_gen_at_entry
+                if not should_queue_hook_continuation(
+                    slot._stopping, needs_session_reset, user_stopped=_stop_pressed()
                 ):
                     _hook_reasons = []
             else:
@@ -12346,11 +12369,17 @@ async def _run_chat(
         # third case, so the ordering answer-then-block gets the same awareness
         # body as block-then-answer instead of being told to continue and
         # re-deriving what is already on screen.
+        #
+        # The user-cancel input is the host's live Stop signal, not the wire
+        # stop reason: on codex the ONLY reject option a command approval
+        # advertises is `cancel`, which aborts the turn with stopReason
+        # "cancelled" -- the refusal's own consequence, not a Stop press, and
+        # this continuation is the only channel that still reaches its model.
         if should_queue_refusal_recovery(
             _refusal_reasons,
             slot._stopping,
             needs_session_reset,
-            _stop_reason,
+            user_stopped=_stop_pressed(),
             notices_sent=len(_refusal_notices) + _refusal_notices_settled,
             notices_pending=len(_refusal_notices),
         ):
@@ -12361,14 +12390,26 @@ async def _run_chat(
                 )
                 if _recovery_hint:
                     break
-            _recovery_body = build_refusal_recovery_prompt(
-                _refusal_reasons,
-                credential_tool_hint=_recovery_hint,
-                answered=(
-                    bool(_answer_text.strip())
-                    or _produced_visible_output
-                    or _turn_flushed_visible_text
-                ),
+            # The hint lookup above yields to the event loop. Re-read the Stop
+            # signal before the queue write, exactly as the hook-continuation
+            # gate does after its config load: a Stop that lands during that
+            # await must not be bypassed by the outer gate's earlier read.
+            _recovery_body = (
+                ""
+                if _stop_pressed()
+                else build_refusal_recovery_prompt(
+                    _refusal_reasons,
+                    credential_tool_hint=_recovery_hint,
+                    answered=(
+                        bool(_answer_text.strip())
+                        or _produced_visible_output
+                        or _turn_flushed_visible_text
+                    ),
+                    # The backend ended the blocked turn as cancelled: it will
+                    # tell the model the user interrupted, so the body must say
+                    # otherwise.
+                    turn_aborted=(_stop_reason == STOP_REASON_CANCELLED),
+                )
             )
             if _recovery_body:
                 _queue_recovery(

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, TypeVar
 
 from aiohttp import web
 
-from kiro_crew.acp.types import STOP_REASON_CANCELLED
 from kiro_crew.atomic_write import atomic_write, fsync_dir
 from kiro_crew.config.loader import (
     DASHBOARD_PORT,
@@ -2756,8 +2755,8 @@ def should_queue_refusal_recovery(
     refusal_reasons: list,
     stopping: bool,
     needs_reset: bool,
-    stop_reason: str,
     *,
+    user_stopped: bool,
     notices_sent: int = 0,
     notices_pending: int = 0,
 ) -> bool:
@@ -2767,41 +2766,61 @@ def should_queue_refusal_recovery(
     - No refusals occurred
     - A stop is still in progress
     - A session reset is already re-queuing
-    - The turn was cancelled by the user (not a policy block)
+    - The user pressed Stop during the turn (``user_stopped``)
     - Every refusal was already explained IN-BAND and the backend confirmed it
+
+    ``user_stopped`` is the host's own Stop signal, read LIVE at the call: a stop
+    in flight, or ``slot._stop_generation`` moved since the turn began. It is the
+    only user-cancel input this gate takes; the backend's wire ``stopReason`` is
+    deliberately not one. The two are not the same thing: codex-acp's command
+    approval advertises ``cancel`` as its ONLY reject option (measured on
+    codex-acp 1.11.0 / codex 0.153.4 -- there is no ``decline``), and codex
+    answers that reject by aborting the whole turn with ``stopReason:
+    "cancelled"`` before the model is called again. A gate that read that stop
+    reason as a Stop press skipped this continuation on every policy block, and
+    on codex this continuation is the only channel that reaches the model (the
+    turn itself is gone, so no in-band notice can). A backend abort with
+    refusals recorded and no Stop pressed is the refusal's own consequence, and
+    the continuation is exactly what is owed.
+
+    The parameter is keyword-only and REQUIRED so no caller can reintroduce a
+    stop-reason rule by omission. Callers must read it at the gate, not from a
+    snapshot taken before an await: a Stop that presses and resolves during an
+    awaited Stop hook leaves ``stopping`` False again, and only the generation
+    counter still says it happened.
 
     ``notices_sent`` is how many :func:`build_refusal_steer_notice` bodies were
     steered into the turn, and ``notices_pending`` how many of those the
     ``steering_consumed`` echo did NOT account for. The extra turn is skipped only
-    when every refusal got a notice AND none is still pending — an unconfirmed
+    when every refusal got a notice AND none is still pending -- an unconfirmed
     steer is treated as undelivered, so the fallback continuation still runs. The
     check is deliberately coarse (counts, not a per-refusal pairing): its two
     failure directions are not symmetric. Skipping wrongly leaves the model with
     kiro-cli's "User denied tool execution" and no correction, while queueing
-    wrongly costs one turn the model would otherwise have been told twice — which
-    is exactly what this path already cost before in-band delivery existed.
-
-    Both are keyword-only with defaults so a caller on a harness without mid-turn
-    steer keeps the original three-condition behaviour unchanged.
+    wrongly costs one turn the model would otherwise have been told twice --
+    which is exactly what this path already cost before in-band delivery
+    existed. Both keep defaults so a caller on a harness without mid-turn steer
+    behaves as if nothing was steered.
     """
     if refusal_reasons and notices_sent >= len(refusal_reasons) and notices_pending == 0:
         return False
-    return bool(
-        refusal_reasons
-        and not stopping
-        and not needs_reset
-        and stop_reason != STOP_REASON_CANCELLED
-    )
+    return bool(refusal_reasons and not stopping and not needs_reset and not user_stopped)
 
 
-def should_queue_hook_continuation(stopping: bool, needs_reset: bool, stop_reason: str) -> bool:
+def should_queue_hook_continuation(
+    stopping: bool, needs_reset: bool, *, user_stopped: bool
+) -> bool:
     """Decide whether a Stop hook's block decision may inject a continuation.
 
     Mirrors :func:`should_queue_refusal_recovery`'s suppression set so a hook can
     never override the Stop button: a stop in progress, a pending session reset,
-    or a user-cancelled turn all win over the hook.
+    or a Stop pressed during the turn all win over the hook. Like that gate it
+    takes the host's live Stop signal and not the backend's wire ``stopReason``:
+    a backend that aborts a policy-denied turn (codex) reports ``cancelled``
+    with no Stop pressed, and a hook continuation is owed there just as the
+    refusal continuation is.
     """
-    return bool(not stopping and not needs_reset and stop_reason != STOP_REASON_CANCELLED)
+    return bool(not stopping and not needs_reset and not user_stopped)
 
 
 def parse_hook_continuations(stdouts: list[str]) -> list[str]:
@@ -2832,7 +2851,11 @@ def parse_hook_continuations(stdouts: list[str]) -> list[str]:
 
 
 def build_refusal_recovery_prompt(
-    refusals: list[tuple[str, str]], *, credential_tool_hint: str = "", answered: bool = False
+    refusals: list[tuple[str, str]],
+    *,
+    credential_tool_hint: str = "",
+    answered: bool = False,
+    turn_aborted: bool = False,
 ) -> str:
     """Build the body of an automatic continuation after a recoverable tool refusal.
 
@@ -2876,6 +2899,15 @@ def build_refusal_recovery_prompt(
     model's last word on the subject is kiro-cli's "User denied tool execution",
     and it will keep attributing the block to the user in later turns.
 
+    ``turn_aborted`` says the backend ended the blocked turn as CANCELLED rather
+    than letting it run on -- codex, whose only reject option aborts the turn.
+    Codex then tells the model, in its own words, that the turn was interrupted
+    ("aborted by user" on the tool result, a ``<turn_aborted>`` note saying the
+    user interrupted on purpose). Those words are wrong here and they arrive
+    right next to this continuation, so the body has to name and overrule them
+    explicitly; the generic "not a user action" sentence alone loses to two
+    harness-authored messages saying the opposite.
+
     Lives here (a leaf module that owns the prefix) rather than in context.py so
     chat_runner can import it at module top without a circular import. There is
     deliberately no retry cap: the model decides when to stop, and the user's
@@ -2896,9 +2928,16 @@ def build_refusal_recovery_prompt(
             "user action — do not treat it as a cancellation or interruption by "
             "the user."
         ),
-        "",
-        "Blocked:",
     ]
+    if turn_aborted:
+        lines.append(
+            "The backend then reported that turn as aborted or interrupted (a tool "
+            "result reading 'aborted by user', or a note that the user interrupted "
+            "the previous turn on purpose). That abort was the consequence of the "
+            "blocked call, not an interruption by the user -- disregard those "
+            "messages."
+        )
+    lines += ["", "Blocked:"]
     for title, reason in refusals:
         lines.append(f"  - {title}: {reason}" if reason else f"  - {title}")
     lines += [

--- a/test/test_chat_slot_interrupt.py
+++ b/test/test_chat_slot_interrupt.py
@@ -200,26 +200,86 @@ class TestChatSlotInterrupt:
 
 
 class TestRefusalRecoverySkippedOnCancel:
-    """Recovery prompt should not fire when the turn was cancelled by the
-    user (stop_reason='cancelled')."""
+    """Recovery prompt should not fire when the user pressed Stop during the turn."""
 
-    def test_cancelled_turn_suppresses_recovery(self):
-        """The guard must return False when stop_reason is cancelled,
-        even with non-empty refusal_reasons."""
-        from kiro_crew.acp.types import STOP_REASON_CANCELLED
+    def test_stop_press_suppresses_recovery(self):
+        """The guard must return False when the user stopped, even with
+        non-empty refusal_reasons."""
         from kiro_crew.dashboard.state import should_queue_refusal_recovery
 
-        refusal_reasons = [("Creating /tmp/name.txt", "command '---' is not on the read-only allowlist")]
+        refusal_reasons = [
+            ("Creating /tmp/name.txt", "command '---' is not on the read-only allowlist")
+        ]
         assert not should_queue_refusal_recovery(
-            refusal_reasons, stopping=False, needs_reset=False, stop_reason=STOP_REASON_CANCELLED
+            refusal_reasons, stopping=False, needs_reset=False, user_stopped=True
         )
 
     def test_normal_refusal_still_triggers_recovery(self):
-        """When the turn ends normally (not cancelled) with refusal reasons,
-        recovery should still fire."""
+        """When the turn ends with refusal reasons and no Stop, recovery fires."""
         from kiro_crew.dashboard.state import should_queue_refusal_recovery
 
         refusal_reasons = [("write /tmp/x", "not on read-only allowlist")]
         assert should_queue_refusal_recovery(
-            refusal_reasons, stopping=False, needs_reset=False, stop_reason=""
+            refusal_reasons, stopping=False, needs_reset=False, user_stopped=False
+        )
+
+
+class TestRefusalRecoveryOnBackendAbort:
+    """A ``cancelled`` stop reason is not, by itself, a user cancel.
+
+    Measured on codex-acp 1.11.0 / codex 0.153.4: a command approval advertises
+    ``allow_once``, ``accept_execpolicy_amendment`` and ``cancel`` -- no
+    ``decline`` -- so the host's policy deny can only answer ``cancel``, and
+    codex aborts the turn with ``stopReason: "cancelled"`` before the model is
+    called again. A recovery gate keyed on the wire stop reason reads that as a
+    Stop press and skips, which makes every policy block on codex a silent stop.
+    The gate takes the host's own Stop signal instead, and only that.
+    """
+
+    REFUSALS = [("python3 -c ...", "Blocked by security policy: credential-exfil-kirocrew-token")]
+
+    def test_backend_abort_without_a_stop_press_queues_recovery(self):
+        # The wire said "cancelled"; the host's Stop signal says nobody pressed
+        # Stop. The gate only ever sees the latter, so recovery is owed.
+        from kiro_crew.dashboard.state import should_queue_refusal_recovery
+
+        assert should_queue_refusal_recovery(
+            self.REFUSALS, stopping=False, needs_reset=False, user_stopped=False
+        )
+
+    def test_a_real_stop_press_still_suppresses_recovery(self):
+        # The person pressed Stop during the turn (and it may already have
+        # resolved, so stopping is False again): the continuation must not
+        # jump ahead of whatever they type next.
+        from kiro_crew.dashboard.state import should_queue_refusal_recovery
+
+        assert not should_queue_refusal_recovery(
+            self.REFUSALS, stopping=False, needs_reset=False, user_stopped=True
+        )
+
+    def test_the_gate_has_no_stop_reason_input_at_all(self):
+        # Structural: a wire stop reason cannot be reintroduced as the user-cancel
+        # signal by omission, because there is no parameter to carry one, and the
+        # Stop signal is required rather than defaulted.
+        import inspect
+
+        from kiro_crew.dashboard.state import should_queue_refusal_recovery
+
+        params = inspect.signature(should_queue_refusal_recovery).parameters
+        assert "stop_reason" not in params
+        assert params["user_stopped"].default is inspect.Parameter.empty
+        assert params["user_stopped"].kind is inspect.Parameter.KEYWORD_ONLY
+
+    def test_in_band_delivery_still_short_circuits_on_an_abort(self):
+        # Not reachable on codex today (the abort discards a pending steer), but
+        # the precedence must hold: a confirmed in-band notice owes no extra turn.
+        from kiro_crew.dashboard.state import should_queue_refusal_recovery
+
+        assert not should_queue_refusal_recovery(
+            self.REFUSALS,
+            stopping=False,
+            needs_reset=False,
+            notices_sent=1,
+            notices_pending=0,
+            user_stopped=False,
         )

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -1644,6 +1644,42 @@ class TestBuildRefusalRecoveryPrompt:
         assert "continue the task where you left off" in out
         assert "this note is for awareness" not in out
 
+    def test_backend_abort_overrules_the_harness_interrupted_message(self):
+        """codex ends a denied turn as cancelled and then tells the model, twice,
+        that the USER interrupted ('aborted by user' on the tool result, a
+        <turn_aborted> note). The generic 'not a user action' line loses to two
+        harness-authored messages saying the opposite unless the body names them.
+        """
+        out = build_refusal_recovery_prompt([("bash", "reason")], turn_aborted=True)
+        assert "aborted by user" in out
+        assert "interrupted the previous turn on purpose" in out
+        assert "not an interruption by the user" in out
+        assert "disregard those messages" in out
+        # The reason and the remediation instruction are unchanged by the flag.
+        assert "bash" in out and "reason" in out
+        assert "continue the task where you left off" in out
+
+    def test_abort_clause_is_absent_when_the_turn_ran_on(self):
+        out = build_refusal_recovery_prompt([("bash", "reason")])
+        assert "aborted by user" not in out
+        assert "disregard those messages" not in out
+
+    def test_abort_clause_does_not_inflate_the_blocked_count(self):
+        # RecoveryCard counts bullet-shaped lines as blocked calls; the clause is
+        # prose and must not read as one more blocked tool.
+        plain = build_refusal_recovery_prompt([("bash", "reason")])
+        aborted = build_refusal_recovery_prompt([("bash", "reason")], turn_aborted=True)
+
+        def bullets(body: str) -> int:
+            return sum(1 for line in body.splitlines() if line.lstrip().startswith("- "))
+
+        assert bullets(aborted) == bullets(plain) == 1
+
+    def test_abort_clause_composes_with_the_awareness_body(self):
+        out = build_refusal_recovery_prompt([("bash", "reason")], answered=True, turn_aborted=True)
+        assert "this note is for awareness" in out
+        assert "disregard those messages" in out
+
     def test_answered_keeps_per_class_remediation(self):
         # The awareness variant drops the resume instruction, not the guidance:
         # "how to do this properly" is the awareness the user is owed.

--- a/test/test_refusal_inband_notice.py
+++ b/test/test_refusal_inband_notice.py
@@ -332,7 +332,7 @@ class TestRecoveryIsNowAFallback:
             self.REFUSALS,
             stopping=False,
             needs_reset=False,
-            stop_reason="end_turn",
+            user_stopped=False,
             notices_sent=1,
             notices_pending=0,
         )
@@ -344,7 +344,7 @@ class TestRecoveryIsNowAFallback:
             self.REFUSALS,
             stopping=False,
             needs_reset=False,
-            stop_reason="end_turn",
+            user_stopped=False,
             notices_sent=1,
             notices_pending=1,
         )
@@ -355,16 +355,16 @@ class TestRecoveryIsNowAFallback:
             [("bash", "denied"), ("fs_write", "blocked")],
             stopping=False,
             needs_reset=False,
-            stop_reason="end_turn",
+            user_stopped=False,
             notices_sent=1,
             notices_pending=0,
         )
 
     def test_defaults_preserve_pre_existing_behaviour(self):
-        # A caller that knows nothing about notices (harness without steer, and
-        # every existing call site) must behave exactly as before.
+        # A caller that knows nothing about notices (harness without steer)
+        # behaves as if nothing was steered: the extra turn is owed.
         assert should_queue_refusal_recovery(
-            self.REFUSALS, stopping=False, needs_reset=False, stop_reason="end_turn"
+            self.REFUSALS, stopping=False, needs_reset=False, user_stopped=False
         )
 
     def test_user_cancel_still_wins_over_in_band_accounting(self):
@@ -372,14 +372,14 @@ class TestRecoveryIsNowAFallback:
             self.REFUSALS,
             stopping=False,
             needs_reset=False,
-            stop_reason="cancelled",
+            user_stopped=True,
             notices_sent=0,
             notices_pending=0,
         )
 
     def test_no_refusals_never_queues_even_with_notices(self):
         assert not should_queue_refusal_recovery(
-            [], stopping=False, needs_reset=False, stop_reason="end_turn", notices_sent=3
+            [], stopping=False, needs_reset=False, user_stopped=False, notices_sent=3
         )
 
 
@@ -723,6 +723,40 @@ class TestEveryHostDenyCallSiteIsWired:
             "these host-deny call sites reach the model through no channel -- "
             f"pass refusal_notices= and refusal_reasons=: lines {missing}"
         )
+
+    def test_both_continuation_gates_read_the_live_stop_signal(self):
+        # Both end-of-turn continuation gates take the host's Stop signal, read
+        # LIVE at each call (`_stop_pressed()`), never a snapshot and never the
+        # backend's wire stop reason. A snapshot taken before the awaited Stop
+        # hook goes stale when a Stop presses and resolves during it; a wire
+        # stop reason reads codex's `cancel`-only reject (stopReason
+        # "cancelled", no Stop pressed) as a user cancel -- the silent-stop
+        # defect. Pinned at source level because both sites live inside the
+        # turn coroutine.
+        src = self._src()
+        assert src.count("def _stop_pressed() -> bool:") == 1, "the live Stop signal helper moved"
+        body = src.split("def _stop_pressed() -> bool:", 1)[1][:1400]
+        assert "_stop_generation" in body and "_stop_gen_at_entry" in body
+        # refusal recovery: the gate call, and the re-read after the awaited
+        # credential-hint lookup, before the queue write.
+        gate = "if should_queue_refusal_recovery("
+        assert (
+            src.count(gate) == 1
+        ), "the refusal-recovery gate moved or multiplied -- guard is stale"
+        window = src.split(gate, 1)[1][:2400]
+        assert "user_stopped=_stop_pressed()" in window[:600]
+        assert "_stop_reason" not in window[:400], "the gate must not take the wire stop reason"
+        after_await = window.split("await _credential_tool_hint_for(", 1)[1]
+        assert "if _stop_pressed()" in after_await.split("_queue_recovery(", 1)[0]
+        assert "turn_aborted=(_stop_reason == STOP_REASON_CANCELLED)" in window
+        # stop-hook continuation: outer gate and the recheck after the config load.
+        hook_calls = re.findall(
+            r"should_queue_hook_continuation\(\s*slot\._stopping, needs_session_reset, user_stopped=_stop_pressed\(\)\s*\)",
+            src,
+        )
+        assert (
+            len(hook_calls) == 2
+        ), f"expected the hook gate + its post-await recheck, saw {len(hook_calls)}"
 
     def test_interactive_approved_path_is_wired(self):
         # The sharpest case: the person clicked APPROVE and the host denied

--- a/test/test_stop_hook_continuation.py
+++ b/test/test_stop_hook_continuation.py
@@ -21,7 +21,6 @@ from kiro_crew.dashboard.chat_utils import SYNTHETIC_RECOVERY_KIND, is_synthetic
 from kiro_crew.dashboard.state import (
     HOOK_CONTINUATION_RECOVERY_PREFIX,
     HOOK_HALTED_RECOVERY_PREFIX,
-    STOP_REASON_CANCELLED,
     _ChatSlot,
     parse_hook_continuations,
     should_queue_hook_continuation,
@@ -82,17 +81,29 @@ class TestParseHookContinuations:
 
 class TestShouldQueueHookContinuation:
     def test_normal_turn_end_allows_a_continuation(self) -> None:
-        assert should_queue_hook_continuation(False, False, "end_turn") is True
+        assert should_queue_hook_continuation(False, False, user_stopped=False) is True
 
     def test_user_stop_suppresses_it(self) -> None:
         """A hook must never be able to override the Stop button."""
-        assert should_queue_hook_continuation(True, False, "end_turn") is False
+        assert should_queue_hook_continuation(True, False, user_stopped=False) is False
 
     def test_pending_session_reset_suppresses_it(self) -> None:
-        assert should_queue_hook_continuation(False, True, "end_turn") is False
+        assert should_queue_hook_continuation(False, True, user_stopped=False) is False
 
-    def test_cancelled_turn_suppresses_it(self) -> None:
-        assert should_queue_hook_continuation(False, False, STOP_REASON_CANCELLED) is False
+    def test_a_stop_pressed_during_the_turn_suppresses_it(self) -> None:
+        # The Stop may already have resolved (stopping=False again); the
+        # generation-derived signal is what still says it happened.
+        assert should_queue_hook_continuation(False, False, user_stopped=True) is False
+
+    def test_a_backend_abort_alone_does_not_suppress_it(self) -> None:
+        # No wire stop reason is consulted: a backend that aborts a policy-denied
+        # turn (codex) reports "cancelled" with no Stop pressed, and the hook's
+        # continuation is still owed. The gate has no parameter for the stop
+        # reason at all, so this cannot regress by omission.
+        import inspect
+
+        assert "stop_reason" not in inspect.signature(should_queue_hook_continuation).parameters
+        assert should_queue_hook_continuation(False, False, user_stopped=False) is True
 
 
 class TestQueuedContinuationProvenance:


### PR DESCRIPTION
## Problem / Motivation

With the codex ACP backend, a tool call blocked by a Kiro Crew safety policy ends the session silently. The dashboard shows the blocked tool card and nothing else: no assistant text, no `[Tool refusal — automatic recovery]` card, no adaptation. On kiro/KAS the same block is followed by the model picking an allowed alternative. A Stop hook's block decision is dropped on codex the same way.

## Why it matters

Every policy block on codex is a dead stop the user has to notice and manually resume, and the model is left believing the *user* cancelled — codex's own tool result says "aborted by user" — so it keeps attributing the block to the user in later turns.

## What changed (motivation → approach → change)

Symptom → cause, measured against a real adapter (codex-acp 1.11.0, bundled codex 0.153.4, driven with a fake Responses API so no login was needed):

- A command approval's `session/request_permission` advertises `allow_once`, `accept_execpolicy_amendment` and `cancel`. There is **no `decline`**. So `reject_tool`'s "first `reject_once`" is `cancel`.
- Answering `cancel` makes codex abort the whole turn: `session/prompt` returns `stopReason: "cancelled"` and the model is never called again in that turn.
- A `_session/steering` sent while the permission was pending returns `{outcome: "injected"}` and is then discarded with the aborted turn — codex has no usable in-band channel for the deny reason.
- Both end-of-turn continuation gates — `should_queue_refusal_recovery` and `should_queue_hook_continuation` — treated `stop_reason == "cancelled"` as "the user pressed Stop" and skipped. The refusal continuation was the only channel left, so the session went silent; a Stop hook's block decision was suppressed too.

Change: the gates take the host's own Stop signal and nothing else.

```mermaid
flowchart LR
  subgraph Before
    A1[policy deny] --> B1[codex answers cancel] --> C1[stopReason cancelled]
    C1 --> D1{"gate: stop_reason != cancelled?"}
    D1 -- no --> E1[skip continuation]
  end
  subgraph After
    A2[policy deny] --> B2[codex answers cancel] --> C2[stopReason cancelled]
    C2 --> D2{"gate: _stop_pressed()"}
    D2 -- no --> E2[queue continuation<br/>turn_aborted=True]
    D2 -- yes --> F2[skip: user stopped]
  end
  classDef added fill:#DCFCE7,stroke:#16A34A
  classDef changed fill:#FEF3C7,stroke:#D97706
  classDef removed fill:#FEE2E2,stroke:#DC2626,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7
  class A1,B1,C1,A2,B2,C2 ctx
  class D1,E1 removed
  class D2 changed
  class E2,F2 added
```
🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

The gate stops asking the wire what happened and asks the host whether the user pressed Stop; when nobody did, the model gets its continuation.

- `should_queue_refusal_recovery(refusal_reasons, stopping, needs_reset, *, user_stopped, notices_sent=0, notices_pending=0)` and `should_queue_hook_continuation(stopping, needs_reset, *, user_stopped)`: `user_stopped` is keyword-only and required, and there is no stop-reason parameter, so the rule cannot come back by omission.
- `chat_runner` reads that signal live through one helper, `_stop_pressed()` (a stop in flight, or `slot._stop_generation` moved since entry). Both gates call it, and each re-reads it after its own await — the credential-hint lookup, the config load — before writing to the queue. A Stop that presses and resolves during the awaited Stop hook leaves `_stopping` False again; only the counter still says it happened, and a value captured before that hook would miss it.
- `build_refusal_recovery_prompt` gains `turn_aborted`. When the blocked turn ended cancelled, the body names and overrules the harness-authored "aborted by user" / "interrupted the previous turn on purpose" messages that arrive next to it. The clause is prose, not a bullet, so the RecoveryCard's blocked count is unchanged.
- A backend abort after a policy block is logged apart from "Turn cancelled by user".
- `ACP_BACKENDS_STEER` comment replaced: codex-acp does have a steering channel, but a different method (`_session/steering`, `{sessionId, prompt: [ContentBlock]}`, no `steering_consumed` echo) and it cannot reach the denied turn, so codex stays a non-member and the recovery continuation is its channel.
- `.github/agent-sdk-boundary-baseline.txt`: `state.py` no longer imports the ACP layer, and the gate requires the graduated entry to be pruned.

No wire behaviour changes for kiro/KAS: their denies still steer in-band and skip the extra turn when the echo confirms delivery.

## Tests

- `test/test_chat_slot_interrupt.py::TestRefusalRecoveryOnBackendAbort` — with refusals and `user_stopped=False` recovery is queued; `user_stopped=True` suppresses it; the signature has no `stop_reason` and `user_stopped` is required keyword-only; a confirmed in-band notice still short-circuits.
- `test/test_stop_hook_continuation.py::TestShouldQueueHookContinuation` — same contract for the hook gate, including the no-stop-reason pin.
- `test/test_dashboard_approval.py::TestBuildRefusalRecoveryPrompt` — `turn_aborted=True` adds the overruling clause, absent otherwise, composes with `answered=True`, and does not change the bullet count.
- `test/test_refusal_inband_notice.py::TestEveryHostDenyCallSiteIsWired::test_both_continuation_gates_read_the_live_stop_signal` — source-level pin: one `_stop_pressed()` helper derived from `_stop_generation`; the refusal gate passes it and re-reads it after the credential-hint await before `_queue_recovery`; the hook gate and its post-config-load recheck both pass it; `turn_aborted` reaches the body builder.

Red-before: the new gate tests fail on `origin/main`; a mutant that restores a `stop_reason != "cancelled"` rule is caught.

## Manual verification

Reproduced the defect against the real adapter without a model login: codex-acp 1.11.0 + codex 0.153.4, `CODEX_HOME` pointing at a scratch config with a custom `wire_api = "responses"` provider served by a tiny local fake, session mode `read-only`, fake model requesting `exec_command` with `sandbox_permissions: require_escalated`. Observed the option set above, `stopReason: "cancelled"` after answering `cancel`, one model request only (no tool result reached the model), and on the next prompt codex's `aborted by user` tool output plus its `<turn_aborted>` note. The same harness with `_session/steering` before the answer returned `injected` and the model still saw nothing.

Local gates: isort, flake8, mypy, black gate, comment-history, harness-parity, feature-map, changelog, brand, sync-io, agent-sdk-boundary, focus-cue, docs lint all green. 20 affected test files (2132 tests) green apart from 3 known host-environmental `atomic no-replace rename is unavailable` failures that fail identically on main on this host. The full backend suite runs in CI.

## Related Issues

no linked issue: found while switching a dashboard session to the codex backend; not tracked as an issue.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a harness-reported stop reason ("cancelled") read as user intent — any gate keyed on a wire stop reason instead of the host's own Stop signal misreads a backend abort as a user action; and any Stop signal captured before an await and consumed after it can miss a Stop that resolved in between.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, the behaviour is internal; the design note lives on `ACP_BACKENDS_STEER`
- [x] No secrets, credentials, or internal references in the diff

