### PR TITLE
refactor(memory-edit): route the three edit labels through one helper

### DIFF
--- a/src/kiro_crew/memory_edit.py
+++ b/src/kiro_crew/memory_edit.py
@@ -425,6 +425,16 @@ def _preview_offset(value: Any) -> int:
     return value
 
 
+def _operation_label(after: dict | None) -> str:
+    """Name what one change does: drop the record, review its pending proposals
+    without touching the content, or replace the content."""
+    if after is None:
+        return "forget"
+    if after.get("_resolution"):
+        return "resolve"
+    return "correct"
+
+
 def _preview_response(
     token: str,
     expires: int,
@@ -446,11 +456,7 @@ def _preview_response(
                     if after is not None
                     else None
                 ),
-                "operation": (
-                    "forget"
-                    if after is None
-                    else "resolve" if after.get("_resolution") else "correct"
-                ),
+                "operation": _operation_label(after),
             }
             for before, after in changes[offset : offset + PREVIEW_ROWS]
         ],
@@ -575,11 +581,15 @@ def _write(store: Any, before: dict, after: dict | None, now: str) -> None:
             f"updated_at = ?, embedding = NULL{extra} WHERE key = ?{guard}",
             params + (record_id,),
         )
+    operation = _operation_label(after)
+    # The events log spells a dropped record "delete"; the revision history
+    # spells the same change "forget".
+    event_type = "delete" if after is None else operation
     store.db.execute(
         "INSERT INTO memory_events (event_type, memory_type, memory_key, old_value, new_value, source, created_at) "
         "VALUES (?, ?, ?, ?, ?, ?, ?)",
         (
-            "delete" if after is None else "resolve" if resolving else "correct",
+            event_type,
             "episodic" if episode else "semantic",
             record_id,
             before["text"],
@@ -601,7 +611,7 @@ def _write(store: Any, before: dict, after: dict | None, now: str) -> None:
         after=physical_after,
         source="user_explicit",
         now=now,
-        operation="forget" if after is None else "resolve" if resolving else "correct",
+        operation=operation,
         force_revision=resolving,
         limit_v1_history=store.algorithm_version == "v1",
     )

--- a/test/test_memory_edit.py
+++ b/test/test_memory_edit.py
@@ -355,6 +355,13 @@ def test_forget_episode_and_semantic_is_reversible_history(store):
         >= 2
     )
     assert store.db.execute("SELECT count(*) FROM memory_revisions").fetchone()[0] >= 2
+    # The events log spells the same drop "delete"; the revision history says "forget".
+    assert (
+        store.db.execute(
+            "SELECT count(*) FROM memory_revisions WHERE operation = 'forget'"
+        ).fetchone()[0]
+        >= 2
+    )
 
 
 def test_retry_of_acknowledgement_lost_apply_is_idempotent(store):
@@ -489,6 +496,10 @@ def test_keep_current_value_resolves_only_pending_proposals_without_mutating_con
     current = memory_edit.list_records(store, {"q": "email000"})["entries"][0]
     assert current["metadata"]["pending_conflicts"] == 0
     assert current["metadata"]["revision"] == record["metadata"]["revision"] + int(private_policy)
+    events = store.db.execute(
+        "SELECT count(*) FROM memory_events WHERE event_type = 'resolve'"
+    ).fetchone()[0]
+    assert events == int(private_policy)
     history = memory_edit.record_history(store, {"kind": "fact", "id": record["id"]})
     if private_policy:
         assert history["entries"][0]["operation"] == "resolve"


### PR DESCRIPTION
## Problem / Motivation

One memory edit carries a label — `forget`, `resolve` or `correct` — and three
places in `memory_edit.py` each worked it out for themselves. Every one was its
own chained ternary. Two of the three read a separate `resolving` local on the
way, so the only way to tell the three copies apart was to compare them
character by character. One of them says `delete` where the other two say
`forget`, and nothing in the file said why.

## Why it matters

Those labels are the memory audit trail, and the dashboard reads them.
`MemoryRecordsEditor` shows the resolve explainer when it sees `resolve` and
marks a removal when it sees `forget`; `VectorMemoryCard` filters on the raw
`event_type`. Three hand-copied ternaries are three chances for one to drift
out of step with the others, and a drifted label is silent: the row is still
written, the panel just tells the operator the wrong thing about their own
memory.

## What changed (motivation → approach → change)

`_operation_label(after)` now owns the mapping. It returns `forget` when the
record is dropped, `resolve` when the record's pending proposals are reviewed
without touching the content, and `correct` otherwise. The preview entry and
the revision history both call it.

`_write` keeps the one real asymmetry and puts it on a line of its own:
`event_type = "delete" if after is None else operation`. The events log spells
a dropped record `delete`; the revision history spells the same change
`forget`. A comment says exactly that, so the next reader does not have to
diff two ternaries to find it.

Every string this code emits is the string it emitted before.

| the edit | preview entry | `memory_events.event_type` | `memory_revisions.operation` |
|---|---|---|---|
| record dropped | 🟦 `forget` | 🟦 `delete` | 🟦 `forget` |
| pending proposals reviewed | 🟦 `resolve` | 🟦 `resolve` | 🟦 `resolve` |
| content replaced | 🟦 `correct` | 🟦 `correct` | 🟦 `correct` |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*All nine values are what they were. Only one of the three ternaries that
produced them survives, as a helper.*

## Tests

Two of the six labels this code emits were read by no test, and one of them was
the half of the `delete`/`forget` split the new comment documents. Both are
pinned now, each next to a sibling assertion that already used the same
`SELECT count(*)` idiom:

- `test_keep_current_value_resolves_only_pending_proposals_without_mutating_content`
  counts `memory_events` rows with `event_type = 'resolve'`.
- `test_forget_episode_and_semantic_is_reversible_history` counts
  `memory_revisions` rows with `operation = 'forget'`.

Both were mutation-checked, not just run. Making `_write` pass `event_type` in
place of `operation` to `sync_record` — so the history would spell a drop
`delete` — leaves the whole file green before this PR and reds both lineages
after it.

No test was relaxed, skipped, retried or given a longer sleep.

## Manual verification

N/A — unit coverage is sufficient: the change emits the same strings from the
same places, and all six labels are now read by tests.

Before this PR opened, five read-only review agents went over the diff on
separate lenses — AUTOSDE blocking rules, behaviour preservation, import
semantics and test-patch observability, the security keystone and boot path,
and comment accuracy — and two more tried to refute what they raised. Three
findings survived and are fixed here: the helper's docstring said "a pending
proposal" where a single resolve retires **all** proposals pending on that base
revision, and the two labels above had no test. One was dropped after an
adversarial second pass: that `operation` and
`force_revision` no longer read the `_resolution` sentinel through the same
local. They agree on every input of type `dict | None`, reachable or not. The
label is `"resolve"` only when the key is present and truthy, which makes
`after` a non-empty dict and therefore truthy, so an `and` short-circuit and an
`is not None` test can never differ — and the one shape that would separate
them, `after == {}`, cannot carry the key. Both offered repairs cost more than
they buy. `operation` is not an internal flag: `memoryEditing.ts` types it
`'resolve' | 'correct' | 'forget'` and `MemoryRecordsEditor` branches on
`operation === 'resolve'`, so `force_revision=(operation == "resolve")` would
make a revision-history write depend on a display enum. The other repair
reinstates the chained ternary this PR removes. Counting the other way, the
module keeps three independent reads of the sentinel and goes from three
label-emitting expressions to one.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — one Python module and its test; no
frontend path is touched and no rendered pixel changes.

## Related Issues

no linked issue: routine module simplification, no reported defect.

## Pattern harvest

Rule candidate: review-prompt
Pattern: one derived label computed independently at each of its sinks, so the
copies drift silently and only a character-by-character read tells them apart.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
