### PR TITLE
ci: diff changed surface locally to avoid API rate limit (#10434)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,12 @@ jobs:
     name: Detect changed surface
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # dorny/paths-filter reads the PR's changed-file list from the GitHub REST
-    # API on pull_request events -> needs pull-requests:read. Job-level
-    # permissions REPLACE the top-level grant, so contents:read is restated.
+    # dorny/paths-filter runs with `token: ''` (below), so it detects changes
+    # with local git instead of the REST API and needs no pull-requests:read.
+    # Job-level permissions REPLACE the top-level grant, so contents:read is
+    # restated.
     permissions:
       contents: read
-      pull-requests: read
     outputs:
       only_backend: ${{ steps.decide.outputs.only_backend }}
       only_frontend: ${{ steps.decide.outputs.only_frontend }}
@@ -88,6 +88,27 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
+          # An empty token switches the action to LOCAL git change detection on
+          # pull_request events (documented on the `token` input; the default is
+          # the shared installation token). The pinned v4.0.3 build then runs
+          # getChanges(pull_request.base.sha, HEAD): a plain two-dot
+          # `git diff` -- the checkout above already has the base commit
+          # (fetch-depth: 0), so no fetch and no API call happen. This matters
+          # because the REST list-files call spends the per-hour installation
+          # quota shared by EVERY workflow in this repo, and at dozens of
+          # ci.yml runs per hour it exhausted the quota and failed this job
+          # repo-wide (#10434). With an empty token the `base` input stays
+          # empty on purpose: the action falls back to the PR base SHA from
+          # the event payload. Both diff endpoints are frozen when the run is
+          # created (base.sha from the payload, HEAD at the event's merge
+          # commit), so a base-branch move after that changes nothing. The
+          # result is the NET change the merge introduces relative to base.sha:
+          # a PR-listed file whose identical change already landed in base
+          # drops out, which is correct for surface detection -- that surface
+          # is unchanged relative to base -- and any wider change set still
+          # pushes toward the full matrix. push events never consult `token`,
+          # so main builds are unchanged.
+          token: ''
           # 'some-with-excludes': a file matches a filter when it matches at
           # least one pattern AND none of the negated ones. That lets `backend`
           # be a true CATCH-ALL ("every changed file that is not frontend, not


### PR DESCRIPTION
## Problem / Motivation

Since ~19:00 UTC on 2026-09-12, CI runs across many branches fail at the first
step of the `CI / Detect changed surface` job with `API rate limit exceeded for
installation`. Everything downstream of the `changes` job (Coverage Gate, the
build matrix, Internal Content Scan, Security Scope Review, the review lanes,
PR Readiness) then fails or is skipped, so healthy trees look red. The affected
PRs have no code problem: the identical tree passes when quota is available.

## Why it matters

Every open PR is blocked by a shared, time-of-day-dependent resource instead of
by its own content. At dozens of `ci.yml` runs per hour, most of each hour is a
dead window: contributors see repo-wide reds, retry manually, and each retry
spends more of the same quota.

## What changed (motivation -> approach -> change)

Symptom: `dorny/paths-filter@v4.0.3` fails calling the REST list-files API.
Root cause: on `pull_request` events the action defaults to listing the PR's
changed files through the REST API with the installation token that every
workflow in this repo shares, so the per-hour installation quota is the real
capacity limit -- and `ci.yml` volume exhausts it.
Change: set `token: ''` on the paths-filter step. That is the action's
documented fallback to LOCAL git change detection: the pinned v4.0.3 build then
runs `getChanges(pull_request.base.sha, HEAD)`, a plain two-dot `git diff`.
The job's checkout already uses `fetch-depth: 0` (the leaf-test selector needs
the base commit), so the base SHA is already local and the happy path makes no
API call at all. The now-unused `pull-requests: read` job permission is
dropped (strict privilege reduction; no other step in the job touches the API).

Event-type walkthrough:
- `pull_request`: filter output now comes from `git diff base.sha..HEAD`
  (HEAD = the event's merge commit). Both endpoints are frozen when the run is
  created, so a base-branch move mid-run changes nothing. The diff is the NET
  change the merge introduces relative to base: a PR-listed file whose
  identical change already landed in base drops out, which is correct for
  surface detection, and any wider change set pushes toward the full matrix.
- `push`: the action never consults `token` on push events (verified in the
  pinned source), so main builds are byte-identical in behavior.
- Outputs: `only_backend` / `only_frontend` come from the same three filter
  buckets, unchanged; `linux_packaging` moves with the same change set; the
  leaf-test outputs never came from the filter (they read the event payload
  directly) and are untouched.
- `predicate-quantifier: 'some-with-excludes'`, the filter definitions, and
  the v4.0.3 pin are unchanged.

paths-filter `token` input documentation (README): "If an empty string is
provided, the action falls back to detect changes using git commands. In that
case, on pull request events the 'base' input overrides the pull request
base". `base` is left empty on purpose so the action uses the PR base SHA from
the event payload. Verified against the pinned source at
`ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d` (`src/main.ts`: the empty-token
`pull_request` branch logs "changes will be detected using git diff" and calls
`git.getChanges(base || baseSha || defaultBranch, currentRef)`).

## Tests

N/A -- workflow-file-only change; there is no unit test harness for `ci.yml`.
Manual verification below stands in.

## Manual verification

- `yaml.safe_load` parses the edited workflow.
- Read the pinned v4.0.3 sources (`src/main.ts`, `src/git.ts`) and confirmed:
  empty token on `pull_request` takes the git-diff branch (no octokit call);
  `getChanges` two-dot-diffs the base SHA against HEAD and only fetches when a
  ref is missing locally (`fetch-depth: 0` makes that a no-op here); the
  `push` path never reads `token`.
- Walked both event types and all five consumed outputs (above).
- Diff-scoped local gates green (brand name, comment history, harness parity,
  feature map, changelog history, focus cue, loop-bound locks, memory-store
  seam, black, subprocess encoding).
- Two pre-push model-pinned reviews (GPT, Opus) on a frozen worktree: zero
  blocking findings; the one comment-accuracy advisory was fixed in the
  squashed commit.

## Related Issues

Closes #10434

Residual, deliberately out of scope here: `build.yml`'s `desktop-matrix` job
uses the same paths-filter API path with the shared token on `pull_request`
events and keeps spending the same quota; its checkout lacks `fetch-depth: 0`,
so its local-diff conversion is a separate two-line change worth its own PR.
Also accepted: if the PR base SHA were ever absent from the clone AND the
anonymous fallback fetch failed, the `changes` job fails red (fails closed --
skipped dependents, never a silently narrowed suite).

## Pattern harvest

Rule candidate: review-prompt
Pattern: a hot-path workflow step that consults the shared installation API for
data already present in the local clone (changed-file lists with fetch-depth: 0)
spends the repo-wide quota for nothing; prefer the action's local-git mode.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
